### PR TITLE
feat: add new-doc-notebook skill; fix notebook kernelspecs and doc links

### DIFF
--- a/.claude/skills/new-doc-notebook/SKILL.md
+++ b/.claude/skills/new-doc-notebook/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: new-doc-notebook
+description: Create or edit an xmris documentation notebook (MyST .md under docs/notebooks/) following the project's notebook conventions. Use when adding a tutorial/doc page, writing notebook tests for a function, documenting a new .xmr method, or restructuring existing doc notebooks.
+---
+
+# Write an xmris doc notebook
+
+Doc notebooks are **simultaneously the documentation and the test suite**. Every `.md` under `docs/notebooks/` is executed twice in CI:
+
+1. `uv run test` — jupytext converts it to `tests/autogen_notebooks/*.ipynb`, then pytest runs it via nbmake (parallel, with coverage).
+2. `myst build --html --execute` — the docs deploy re-executes it and publishes the output.
+
+So every cell must run headless, deterministically, and reasonably fast. A notebook that only renders but doesn't prove anything is half done; a notebook that asserts but reads like a test file is also half done.
+
+## 1. Placement & naming
+
+- Category dirs: `basics/`, `pipeline/`, `fitting/`, `vendor/`, `visualization/plot/`, `visualization/widget/`.
+- Lowercase snake_case filenames. Numeric `NN_` prefixes **only** inside the two `visualization/` dirs (elsewhere the TOC controls order).
+- `testonly_` prefix = executed by the test suite but never added to the TOC, never rendered. Use for internal validation against ground-truth data.
+
+## 2. Tone & writing style
+
+Conversational, sharp, concise. No filler — get to the point. But never assume too much prior knowledge: background and theory that experts would skip goes into a `:::{dropdown}` block (the "Under the Hood: No Magic Strings" / "Imports & a small plotting helper" pattern). Every page should be educational, precise, easy to read, and look modern and inviting.
+
+Use the full mystmd palette *where it earns its place*: LaTeX for the math actually being demonstrated, comparison tables, admonitions (`{note}`, `{warning}`, `seealso`), mermaid diagrams, sparing emoji as visual anchors (✅ ❌ 📦 ⚡ 🚧). Style exemplars: `docs/index.md`, `docs/notebooks/basics/architecture.md`, `docs/notebooks/pipeline/domain_agnostic_autophase.md`.
+
+## 3. The canonical skeleton
+
+````markdown
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (xmris)
+  language: python
+  name: python3
+---
+
+(my-topic)=
+# Descriptive Title
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+import matplotlib.pyplot as plt
+import matplotlib_inline.backend_inline
+
+# Crisp retina output + sane default DPI for the rendered docs
+matplotlib_inline.backend_inline.set_matplotlib_formats("retina")
+plt.rcParams["figure.dpi"] = 150
+```
+
+One-paragraph hook: the problem this page solves, in plain language.
+Physics/math motivation next — LaTeX, a table, or a mermaid diagram if it
+genuinely clarifies.
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+
+import xmris  # registers the .xmr accessor
+from xmris.fitting.simulation import simulate_fid
+```
+
+(my-topic-generate-data)=
+## 1. Generate a synthetic FID
+
+```{code-cell} ipython3
+fid = simulate_fid(...)
+```
+
+(my-topic-apply)=
+## 2. Apply the transform
+
+```{code-cell} ipython3
+result = fid.xmr.some_method()
+```
+
+... plot the result with xarray's native plotting ...
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# STRICT TESTS: some_method
+from xmris.core.config import ATTRS, DIMS
+
+np.testing.assert_allclose(..., err_msg="...")
+```
+````
+
+Hard rules baked into that skeleton:
+
+- **Frontmatter is exactly this.** `display_name: Python 3 (xmris)` is the frozen project label — if your local Jupyter rewrites it (to `.venv`, `Python 3 (ipykernel)`, …), fix it back before committing. Execution is unaffected either way; `name: python3` resolves to the uv venv.
+- **Nothing before `(target)=` + `# H1`.** mystmd lifts the first H1 as the page title *only* when it is the first content node. Any cell before it — even a hidden `remove-cell` one — breaks the lift and the built page renders the title **twice**. The setup cell always comes *after* the H1. Exactly one H1 per file; never restate the title as another header.
+- **Explicit MyST target above every header** (H1 and all `##`/`###`), kebab-case, prefixed with the notebook topic. Never rely on auto-generated slugs.
+- **Reader-facing cells use plain strings** (`"time"`, `"frequency"`) — the low entrance barrier is deliberate. `ATTRS`/`DIMS`/`COORDS` from `xmris.core.config` may appear **only inside hidden test cells**.
+- Imports in a plain visible cell; wrap them in a `:::{dropdown}` only when bundled with a longer plotting-helper function.
+- `+++` splits adjacent markdown into separate cells — use it when prose after a `:::` block would otherwise be swallowed into it.
+
+## 4. Hidden assert cells
+
+Recommended for any cell that demonstrates a computation (use judgment — pure-concept or plotting-gallery pages can skip them). Pattern:
+
+- Tagged `:tags: [remove-cell]`, placed **immediately after** the demonstration it verifies. nbmake still executes it; the site hides it.
+- Opens with a `# STRICT TESTS: <what>` comment. Underscore-prefix throwaway variables (`_target_points`).
+- `np.testing.assert_allclose` / `assert_array_equal` with an `err_msg=`, plus plain `assert`s for metadata.
+- Prove three things: (a) the **math** is right, (b) **coordinates** were built/extrapolated correctly, (c) original **attrs survived** and the new lineage attrs were stamped (quantitative parameters only, e.g. `phase_p0` — never boolean flags).
+
+## 5. Data
+
+- Prefer `xmris.fitting.simulation.simulate_fid` for MRS-like signals; hand-rolled numpy is fine when the notebook is *teaching* raw construction.
+- Seed randomness (`np.random.default_rng(42)` / `target_snr=...` with fixed seed context) whenever asserts depend on noisy data — unseeded noise means flaky CI.
+- Real data only from `tests/data/` (relative path `../../../tests/data/` from a notebook). The gitignore blocks all data extensions; new files need explicit whitelist entries in `.gitignore` and must stay small (<10 MB).
+
+## 6. Mermaid diagrams
+
+Escaping is where these usually break — the existing diagrams were expensive to develop, so follow the house rules:
+
+- Always double-quote node and edge labels: `A["label"]`, `B{"decision?"}`, `-->|"edge label"|`.
+- Line breaks inside labels: `<br>`, never `\n`.
+- Code inside labels: `<span style='font-family:monospace;'>fid.xmr.to_spectrum()</span>` — markdown backticks do **not** render inside mermaid labels.
+- Single quotes for HTML attributes and for literal quotes inside labels (`dims='time'`); never nest unescaped double quotes.
+- Prefer the ```` ```{mermaid} ```` directive in notebooks (bare ```` ```mermaid ```` fences also render).
+- For sophisticated styling (`classDef`, `subgraph`, styled spans) copy the reference diagram in `docs/index.md`; for simple decision flowcharts copy `basics/architecture.md`.
+
+## 7. Cell tag reference
+
+| Tag | Rendered site | Tests (nbmake) | Use for |
+|---|---|---|---|
+| `remove-cell` | cell gone entirely | executed | matplotlib setup, STRICT TESTS |
+| `remove-input` | output only | executed | `export_widget_static(...)` call |
+| `remove-output` | input only | executed | live widget call the reader should type |
+| `hide-input` | input collapsed | executed | data-generation boilerplate |
+| `hide-output` | output collapsed | executed | verbose prints / long assertion logs |
+
+## 8. Widget notebooks only
+
+Static docs have no kernel, so live widgets need the export pattern from `docs/contributing/static_widgets.md`:
+
+1. Show the reader the live call in a cell tagged `remove-output`.
+2. Follow it with a hidden cell tagged `remove-input` that calls `export_widget_static(widget_factory, *args, **kwargs)` — that renders the interactive canvas on the site.
+
+Mind the ~2.5 MB iframe payload limit (`debug=True` to inspect) and the `xmris-close-btn` CSS-class rule for kernel-dependent buttons. Screenshots live in `assets/notebook-assets/`.
+
+## 9. Register, link, commit
+
+- **TOC entry is mandatory** (except `testonly_`): add the file under the right group in `docs/myst.yml` with a `title:`. The sidebar shows the TOC title — keep it consistent with the H1. A notebook missing from the TOC still passes tests but silently never renders.
+- **Cross-links**: `[text](#explicit-target)` or relative `.md` paths only. Never link `.ipynb` — those are excluded from the build, so the link dies.
+- **Commit only the `.md`.** `docs/**/*.ipynb` is gitignored; edits made in an `.ipynb` twin are invisible to both tests and docs until synced back (`uv run jupytext --sync <file>`).
+
+## 10. Verify before finishing
+
+```bash
+uv run test-gen
+uv run pytest "tests/autogen_notebooks/<category>/<name>.ipynb" -n0 --no-cov
+```
+
+(`--nbmake` is already in pytest addopts.) Optionally preview the rendered page: `cd docs && uv run myst start --execute`.
+
+Final checklist:
+
+- [ ] Frontmatter exact; `display_name: Python 3 (xmris)`
+- [ ] H1 is the very first content; target above it and above every header; single H1
+- [ ] Setup cell after the H1, tagged `remove-cell`, dpi 150
+- [ ] Reader-facing cells use plain dim strings; config singletons only in hidden cells
+- [ ] Assert cells hidden with `remove-cell` and placed right after what they prove
+- [ ] TOC entry in `docs/myst.yml` (unless `testonly_`)
+- [ ] No `.ipynb` links; no unquoted mermaid labels
+- [ ] Single-notebook nbmake run is green
+- [ ] Only the `.md` staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Ruff: line length 100, NumPy docstring convention. Public functions need fully-t
 ## Gotchas
 
 - `pyamares` comes from a git fork (`[tool.uv.sources]`, branch `xmris-compatible`), not PyPI. For local pyAMARES dev, swap the `git` line for the commented `path` line. Publish builds use `uv build --no-sources`.
-- Jupytext syncs `.md` ↔ `.ipynb`; edit either, but commit ONLY `.md` — `docs/**/*.ipynb` are gitignored. Bulk-fix kernels: `uv run jupytext --sync --set-kernel python3 --display-name "Python 3 (xmris)" ./docs/notebooks/**/*.md`.
+- Jupytext syncs `.md` ↔ `.ipynb`; edit either, but commit ONLY `.md` — `docs/**/*.ipynb` are gitignored. The frozen kernel label is `display_name: Python 3 (xmris)` (jupytext has no `--display-name` flag). To bulk-fix drifted kernels, register the venv kernelspec once with `uv run python -m ipykernel install --sys-prefix --name python3 --display-name "Python 3 (xmris)"`, then `uv run jupytext --set-kernel python3 ./docs/notebooks/**/*.md`.
 - Python is capped at ≤3.13 (pyamares constraint). The pins `xarray<2025.11.0`, `griffe<0.40.0`, `pytest-cov<7.0` are deliberate — don't unpin without a reason.
 
 ## Commits & releases

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -49,9 +49,7 @@ project:
         - file: notebooks/fitting/simufid.md
           title: FID Simulation
         - file: notebooks/fitting/pyamares.md
-          title: pyAMARES - Part I
-        - file: notebooks/fitting/pyamares_advanced.md
-          title: pyAMARES - Part II
+          title: pyAMARES
 
     # 4. GROUP: Visualization / plotting
     - title: Visualization
@@ -64,14 +62,14 @@ project:
               title: 2. [1D + Time] Waterfall Plot
             - file: notebooks/visualization/plot/03_plot_carpet.md
               title: 3. [1D + Time] Carpet Plot
-            - file: notebooks/visualization/plot/03_plotting_fit_1d.md
+            - file: notebooks/visualization/plot/03_plotting_1dfid.md
               title: 4. [1D + Time] pyAMARES Plot
         - title: Widgets
           children:
             - file: notebooks/visualization/widget/01_widget_phase.md
               title: 1. Spectrum phasing
             - file: notebooks/visualization/widget/02_widget_scroller.md
-              title: 2. Srcolling through spectra
+              title: 2. Scrolling through spectra
             - file: notebooks/visualization/widget/03_apodization.md
               title: 3. Apodization
     # 5. GROUP: Vendor Specific

--- a/docs/notebooks/basics/architecture.md
+++ b/docs/notebooks/basics/architecture.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/basics/complex_numbers.md
+++ b/docs/notebooks/basics/complex_numbers.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/basics/fft.md
+++ b/docs/notebooks/basics/fft.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/basics/fft.md
+++ b/docs/notebooks/basics/fft.md
@@ -56,7 +56,7 @@ As a user, you can pass simple strings like `"time"` and `"frequency"` to `xmris
 
 This architecture allows `xmris` to intercept your request and automatically inject physical metadata (like setting the new coordinate units to `Hz` or `s`) without you ever having to ask for it!
 
-For more info see [xmris Architecture: Why We Built It This Way](./architecture.ipynb)
+For more info see [xmris Architecture: Why We Built It This Way](./architecture.md)
 :::
 
 ```{code-cell} ipython3

--- a/docs/notebooks/basics/fid_transformations.md
+++ b/docs/notebooks/basics/fid_transformations.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/basics/fid_transformations.md
+++ b/docs/notebooks/basics/fid_transformations.md
@@ -102,7 +102,7 @@ When `.xmr.to_spectrum()` built the new frequency axis, it intercepted your `"fr
 
 **Bonus:** Because `"time"` and `"frequency"` are declared default dimensions in `xmris`, we could actually drop the arguments completely and just call `da_fid.xmr.to_spectrum()` for the exact same result!
 
-For more info on this design, see [xmris Architecture: Why We Built It This Way](./architecture.ipynb)
+For more info on this design, see [xmris Architecture: Why We Built It This Way](./architecture.md)
 :::
 
 ```{code-cell} ipython3

--- a/docs/notebooks/basics/hz_and_ppm.md
+++ b/docs/notebooks/basics/hz_and_ppm.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/fitting/pyamares.md
+++ b/docs/notebooks/fitting/pyamares.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/fitting/simufid.md
+++ b/docs/notebooks/fitting/simufid.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/apodization.md
+++ b/docs/notebooks/pipeline/apodization.md
@@ -130,7 +130,7 @@ As a user, you can pass simple strings like `"time"` and `"frequency"` to `xmris
 
 This architecture allows `xmris` to intercept your request and automatically inject physical metadata (like setting the new coordinate units to `Hz` or `s`) without you ever having to ask for it!
 
-For more info see [xmris Architecture: Why We Built It This Way](https://www.google.com/search?q=./architecture.ipynb)
+For more info see [xmris Architecture: Why We Built It This Way](../basics/architecture.md)
 :::
 
 Here is the resulting, smoothed spectrum:

--- a/docs/notebooks/pipeline/apodization.md
+++ b/docs/notebooks/pipeline/apodization.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/autophasing.md
+++ b/docs/notebooks/pipeline/autophasing.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/baseline.md
+++ b/docs/notebooks/pipeline/baseline.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/domain_agnostic_autophase.md
+++ b/docs/notebooks/pipeline/domain_agnostic_autophase.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/phase.md
+++ b/docs/notebooks/pipeline/phase.md
@@ -93,7 +93,7 @@ plt.show()
 ## 2. Manual Phase Correction
 
 :::{tip} Interactive manual phase correction
-Use the [Interactive Phasing Widget](../visualization/widget/01_widget_phase.ipynb) to interactivley adjust $p_0$ and $p_1$.
+Use the [Interactive Phasing Widget](../visualization/widget/01_widget_phase.md) to interactively adjust $p_0$ and $p_1$.
 :::
 
 We can manually apply zero- and first-order phase correction (in degrees) using the `.xmr.phase()` method.
@@ -169,5 +169,5 @@ Finding the perfect phase angles manually is tedious. We can use algorithms such
 algorithm (ACME) to find the global phase minimum automatically.
 
 :::{tip} Automated phase correction
-The dedicated documentation is here: [Automated Phase Correction](./autophasing.ipynb).
+The dedicated documentation is here: [Automated Phase Correction](./autophasing.md).
 :::

--- a/docs/notebooks/pipeline/phase.md
+++ b/docs/notebooks/pipeline/phase.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/pipeline/zero_fill.md
+++ b/docs/notebooks/pipeline/zero_fill.md
@@ -120,7 +120,7 @@ As a user, you can pass simple strings like `"time"` and `"frequency"` to `xmris
 
 This architecture allows `xmris` to intercept your request and automatically inject physical metadata (like setting the new coordinate units to `Hz` or `s`) or properly extrapolate coordinate values when extending an array with zeros.
 
-For more info see [xmris Architecture: Why We Built It This Way](https://www.google.com/search?q=./architecture.ipynb)
+For more info see [xmris Architecture: Why We Built It This Way](../basics/architecture.md)
 :::
 
 ### Interpolating the Truth (Frequency Domain)

--- a/docs/notebooks/pipeline/zero_fill.md
+++ b/docs/notebooks/pipeline/zero_fill.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/vendor/bruker_fid_loader.md
+++ b/docs/notebooks/vendor/bruker_fid_loader.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/vendor/bruker_filter_removal.md
+++ b/docs/notebooks/vendor/bruker_filter_removal.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
+++ b/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
@@ -6,7 +6,7 @@ jupytext:
 kernelspec:
   name: python3
   language: python
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
 ---
 
 # Internal Test: Bruker 13C Slab Reshaping and Validation

--- a/docs/notebooks/visualization/plot/01_plot_basics.md
+++ b/docs/notebooks/visualization/plot/01_plot_basics.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/plot/02_plot_waterfall.md
+++ b/docs/notebooks/visualization/plot/02_plot_waterfall.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Carpet Plots
 
-As a quantitative alternative to the 2D waterfall plot (see [2. Waterfall Plots](./02_waterfall_plots.md)), carpet plots provide a top-down, 2D image representation of stacked spectra . They are 2D rasterized visualizations of 1D time-series data, effectively "rolling out" the time-domain flat on the floor. This approach eliminates visual occlusion, allowing for direct observation of signal intensities and frequency shifts across the stacking dimension (e.g., time or repetitions).
+As a quantitative alternative to the 2D waterfall plot (see [2. Waterfall Plots](./02_plot_waterfall.md)), carpet plots provide a top-down, 2D image representation of stacked spectra . They are 2D rasterized visualizations of 1D time-series data, effectively "rolling out" the time-domain flat on the floor. This approach eliminates visual occlusion, allowing for direct observation of signal intensities and frequency shifts across the stacking dimension (e.g., time or repetitions).
 
 In `xmris`, this visualization is built around the `CarpetConfig` object, which includes specialized logic for truncating colormaps so your data never gets lost in absolute white or absolute black on printed paper.
 

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/plot/03_plotting_1dfid.md
+++ b/docs/notebooks/visualization/plot/03_plotting_1dfid.md
@@ -24,7 +24,7 @@ matplotlib_inline.backend_inline.set_matplotlib_formats("retina")
 plt.rcParams["figure.dpi"] = 150
 ```
 
-Following the quantification of spectra using time-domain fitting (as covered in the [Time-Domain Fitting with AMARES](./amares_fitting.md) tutorial), the next critical step is interpreting the results.
+Following the quantification of spectra using time-domain fitting (as covered in the [Time-Domain Fitting with AMARES](../../fitting/pyamares.md) tutorial), the next critical step is interpreting the results.
 
 When analyzing a 1D array of spectra—such as a dynamic time-series (fMRS), an echo-time series (relaxation mapping), or a 1D spatial CSI slice—researchers generally need to quickly answer two questions:
 1. **The Kinetics:** How do the metabolite concentrations change across the dimension?

--- a/docs/notebooks/visualization/plot/03_plotting_1dfid.md
+++ b/docs/notebooks/visualization/plot/03_plotting_1dfid.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: Python 3 (ipykernel)
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/widget/01_widget_phase.md
+++ b/docs/notebooks/visualization/widget/01_widget_phase.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/widget/02_widget_scroller.md
+++ b/docs/notebooks/visualization/widget/02_widget_scroller.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/widget/03_apodization.md
+++ b/docs/notebooks/visualization/widget/03_apodization.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
 kernelspec:
-  display_name: .venv
+  display_name: Python 3 (xmris)
   language: python
   name: python3
 ---

--- a/docs/notebooks/visualization/widget/03_apodization.md
+++ b/docs/notebooks/visualization/widget/03_apodization.md
@@ -89,7 +89,7 @@ export_widget_static(
 
 | Control | Description |
 |---|---|
-| **Method** | Switch between **Exponential** (SNR enhancement) and **Lorentz-Gauss** (resolution enhancement). See the [Apodization](../../processing/apodization.md) guide for details on each filter. |
+| **Method** | Switch between **Exponential** (SNR enhancement) and **Lorentz-Gauss** (resolution enhancement). See the [Apodization](../../pipeline/apodization.md) guide for details on each filter. |
 | **Display Mode** | Show the **Real**, **Imaginary**, or **Magnitude** spectrum. |
 | **Show Original** | Overlay the un-apodized data as a gray trace for comparison. |
 | **LB / GB Sliders** | Adjust apodization parameters. The orange dashed line on the FID canvas shows the weighting envelope being applied. |


### PR DESCRIPTION
## Summary

- Adds the `.claude/skills/new-doc-notebook` skill: a guided workflow for authoring new MyST doc notebooks that follow the project's Jupytext/nbmake testing strategy.
- Freezes the notebook kernelspec `display_name` to `"Python 3 (xmris)"` across all doc notebooks (was leaking local `.venv` names).
- Fixes broken TOC entries and cross-links in `docs/myst.yml` and the doc notebooks.

Stacked on the decorator-taxonomy pilot (#73), rebased onto `main` after its squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)