### PR TITLE
refactor: domain-contract engine — computes_in, merged dim resolution (#63)

### DIFF
--- a/docs/contributing/static_widgets.md
+++ b/docs/contributing/static_widgets.md
@@ -63,7 +63,8 @@ import numpy as np
 import traitlets
 import xarray as xr
 
-from xmris.core.utils import _check_dims, _resolve_spectral_dim, _spectral_axis_label
+from xmris.core.config import SPECTRAL_DIMS
+from xmris.core.utils import _check_dims, _resolve_dim, _spectral_axis_label
 
 from .._shared import load_css, load_esm
 
@@ -162,11 +163,11 @@ Use the shared resolver and validator, and take an explicit `dim` override:
 
 ```python
 if dim is None:
-    dim = _resolve_spectral_dim(da)   # canonical: frequency / chemical_shift
+    dim = _resolve_dim(da, SPECTRAL_DIMS)   # canonical: frequency / chemical_shift
 _check_dims(da, dim, "my_widget")
 ```
 
-`_resolve_spectral_dim` raises a helpful error for non-standard axis names, which
+`_resolve_dim` raises a helpful error for non-standard axis names, which
 is why the factory always exposes `dim: str | None = None` as an escape hatch.
 Derive axis labels from the coordinate's **lineage metadata**, not a hardcoded
 string:

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -94,6 +94,8 @@ project:
               title: FID Processing
             - file: api_reference/processing.phasing.md
               title: Phase Correction
+            - file: api_reference/processing.referencing.md
+              title: Axis Referencing (Hz ↔ ppm)
 
         # --- 2. Visualization Submenu ---
         - title: Visualization

--- a/docs/quartodoc.yml
+++ b/docs/quartodoc.yml
@@ -9,6 +9,7 @@ quartodoc:
         - processing.fourier
         - processing.fid
         - processing.phasing
+        - processing.referencing
 
     - title: Visualization
       desc: Publication-ready plotting and aesthetics.

--- a/src/xmris/__init__.py
+++ b/src/xmris/__init__.py
@@ -32,6 +32,7 @@ from .processing.baseline import baseline_als
 from .processing.fid import apodize_exp, apodize_lg, to_fid, to_spectrum, zero_fill
 from .processing.fourier import fft, fftc, fftshift, ifft, ifftc, ifftshift
 from .processing.phasing import autophase, phase
+from .processing.referencing import to_hz, to_ppm
 from .processing.utils import to_complex, to_real_imag
 
 # =============================================================================
@@ -76,6 +77,8 @@ __all__ = [
     "apodize_lg",
     "to_fid",
     "to_spectrum",
+    "to_ppm",
+    "to_hz",
     "zero_fill",
     "fft",
     "fftc",

--- a/src/xmris/core/accessor.py
+++ b/src/xmris/core/accessor.py
@@ -14,15 +14,15 @@ import numpy as np
 import xarray as xr
 
 # Import our core architecture
-from xmris.core.config import ATTRS, COORDS, DIMS
-from xmris.core.utils import _check_dims, as_variable
-from xmris.core.validation import requires_attrs
+from xmris.core.config import DIMS
+from xmris.core.utils import _check_dims, as_variable  # noqa: F401  (re-exported)
 from xmris.processing.baseline import baseline_als
 
 # Processing imports
 from xmris.processing.fid import apodize_exp, apodize_lg, to_fid, to_spectrum, zero_fill
 from xmris.processing.fourier import fft, fftc, fftshift, ifft, ifftc, ifftshift
 from xmris.processing.phasing import autophase, phase
+from xmris.processing.referencing import to_hz, to_ppm
 
 # =============================================================================
 # Sub-Accessors (Terminal / Visualization tools)
@@ -340,43 +340,13 @@ class XmrisWidgetAccessor:
 class XmrisSpectrumCoordsMixin:
     """Mixin providing operations to translate physical coordinate systems."""
 
-    @requires_attrs(ATTRS.reference_frequency, ATTRS.carrier_ppm)
     def to_ppm(self, dim: str = DIMS.frequency) -> xr.DataArray:
         """Convert relative frequency axis [Hz] to absolute chemical shift axis [ppm]."""
-        _check_dims(self._obj, dim, "to_ppm")
+        return to_ppm(self._obj, dim=dim)
 
-        mhz = self._obj.attrs[ATTRS.reference_frequency]
-        carrier_ppm = self._obj.attrs[ATTRS.carrier_ppm]
-        hz_coords = self._obj.coords[dim].values
-
-        # 1. Calculate the math
-        ppm_coords = carrier_ppm + (hz_coords / mhz)
-
-        # 2. Build the fully-formed xarray Variable (data + metadata). Use the
-        #    COORDS term (carries unit="ppm") so the coordinate's lineage is
-        #    complete — mirrors `to_hz` using COORDS.frequency (unit="Hz").
-        shift_var = as_variable(COORDS.chemical_shift, dim, ppm_coords)
-
-        # 3. Assign and swap in one clean sweep
-        obj = self._obj.assign_coords({DIMS.chemical_shift: shift_var})
-        return obj.swap_dims({dim: DIMS.chemical_shift})
-
-    @requires_attrs(ATTRS.reference_frequency, ATTRS.carrier_ppm)
     def to_hz(self, dim: str = DIMS.chemical_shift) -> xr.DataArray:
         """Convert absolute chemical shift axis [ppm] to relative frequency axis [Hz]."""
-        _check_dims(self._obj, dim, "to_hz")
-
-        mhz = self._obj.attrs[ATTRS.reference_frequency]
-        carrier_ppm = self._obj.attrs[ATTRS.carrier_ppm]
-        ppm_coords = self._obj.coords[dim].values
-
-        hz_coords = (ppm_coords - carrier_ppm) * mhz
-
-        # Pack the data and metadata together instantly
-        freq_var = as_variable(COORDS.frequency, dim, hz_coords)
-
-        obj = self._obj.assign_coords({COORDS.frequency: freq_var})
-        return obj.swap_dims({dim: DIMS.frequency})
+        return to_hz(self._obj, dim=dim)
 
 
 class XmrisFourierMixin:

--- a/src/xmris/core/config.py
+++ b/src/xmris/core/config.py
@@ -338,7 +338,7 @@ VARS = XmrisDataVars()
 # Domain Groupings
 # =============================================================================
 # Semantic groupings of *existing* dimension terms (not new vocabulary) used by
-# the ``ensures_domain`` and ``resolves_spectral_dim`` decorators in
+# the ``ensures_domain`` and ``computes_in`` domain decorators in
 # ``validation.py``. They bundle the already-defined ``DIMS`` into the two
 # physical domains xmris operates in: time-domain FIDs vs. frequency-domain
 # spectra, where the spectral axis may be labelled in Hz (``frequency``) or

--- a/src/xmris/core/utils.py
+++ b/src/xmris/core/utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 import xarray as xr
 
-from xmris.core.config import SPECTRAL_DIMS, XmrisTerm
+from xmris.core.config import SPECTRAL_DIMS, TIME_DIMS, XmrisTerm
 
 
 def _check_dims(da: xr.DataArray, dims: str | list[str], method_name: str) -> None:
@@ -21,43 +21,62 @@ def _check_dims(da: xr.DataArray, dims: str | list[str], method_name: str) -> No
         )
 
 
-def _resolve_spectral_dim(da: xr.DataArray) -> str:
-    """Identify the single spectral dimension present on ``da``.
+def _domain_label(candidates: frozenset[str]) -> str:
+    """Human-readable name of a domain dim-group, for error messages and docs."""
+    if candidates == SPECTRAL_DIMS:
+        return "spectral"
+    if candidates == TIME_DIMS:
+        return "time"
+    return "target"
 
-    Scans ``da.dims`` for a dimension belonging to the spectral domain
-    (``SPECTRAL_DIMS`` — ``frequency`` [Hz] or ``chemical_shift`` [ppm]). Used
-    by the ``@resolves_spectral_dim`` decorator to fill a ``dim=None`` argument.
+
+def _resolve_dim(da: xr.DataArray, candidates: frozenset[str]) -> str:
+    """Identify the single dimension of ``da`` belonging to ``candidates``.
+
+    Scans ``da.dims`` for a dimension in the given domain group (e.g.
+    ``SPECTRAL_DIMS`` — ``frequency`` [Hz] or ``chemical_shift`` [ppm]). Used
+    by the domain decorators in ``validation.py`` to fill a ``dim=None``
+    argument, and by the visualization widgets to auto-detect the display axis.
 
     Parameters
     ----------
     da : xr.DataArray
         The data to inspect.
+    candidates : frozenset of str
+        The candidate dimension names constituting the domain — use
+        ``SPECTRAL_DIMS`` or ``TIME_DIMS`` from :mod:`xmris.core.config`.
 
     Returns
     -------
     str
-        The name of the unique spectral dimension found.
+        The name of the unique matching dimension found.
 
     Raises
     ------
     ValueError
-        If no spectral dimension is present, or if more than one is present
+        If no candidate dimension is present, or if more than one is present
         (ambiguous — the caller must pass ``dim`` explicitly).
     """
-    found = [d for d in da.dims if d in SPECTRAL_DIMS]
+    label = _domain_label(candidates)
+    found = [d for d in da.dims if d in candidates]
 
     if not found:
+        if candidates == SPECTRAL_DIMS:
+            hint = (
+                "If this is time-domain data, transform it first:\n"
+                "    >>> obj = obj.xmr.to_spectrum()\n"
+                "Otherwise pass the dimension explicitly, e.g. `dim='frequency'`."
+            )
+        else:
+            hint = f"Pass the dimension explicitly, e.g. `dim={sorted(candidates)[0]!r}`."
         raise ValueError(
-            f"Could not resolve a spectral dimension: none of "
-            f"{sorted(SPECTRAL_DIMS)} are present in {list(da.dims)}.\n\n"
-            f"If this is time-domain data, transform it first:\n"
-            f"    >>> obj = obj.xmr.to_spectrum()\n"
-            f"Otherwise pass the dimension explicitly, e.g. `dim='frequency'`."
+            f"Could not resolve a {label} dimension: none of "
+            f"{sorted(candidates)} are present in {list(da.dims)}.\n\n{hint}"
         )
 
     if len(found) > 1:
         raise ValueError(
-            f"Ambiguous spectral dimension: multiple spectral dims {found} are "
+            f"Ambiguous {label} dimension: multiple {label} dims {found} are "
             f"present in {list(da.dims)}.\n\n"
             f"Pass the target dimension explicitly, e.g. `dim={found[0]!r}`."
         )

--- a/src/xmris/core/validation.py
+++ b/src/xmris/core/validation.py
@@ -1,14 +1,29 @@
-"""Decorator engine for runtime validation and dynamic docstring generation."""
+"""Decorator engine for runtime validation, domain contracts, and docstring generation.
+
+Two decorator tiers guard the processing functions:
+
+- ``@requires_attrs(...)`` — *gate*: raise if required ``.attrs`` are missing.
+- ``@ensures_domain(...)`` / ``@computes_in(...)`` — *domain*: establish the
+  function's working domain (time vs. spectral), transforming the input through
+  the standard converters when needed and resolving a ``dim=None`` argument.
+  ``ensures_domain`` implements the *funnel* contract (the result is left in
+  the working domain); ``computes_in`` implements the *domain-preserving*
+  contract (the result is transformed back to the input's representation).
+
+The two domain decorators share one private engine and differ only in whether
+the coercion is inverted after the wrapped function runs.
+"""
 
 import functools
 import inspect
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
+import numpy as np
 import xarray as xr
 
-from .config import ATTRS
-from .utils import _resolve_spectral_dim
+from .config import ATTRS, DIMS, SPECTRAL_DIMS, TIME_DIMS
+from .utils import _domain_label, _resolve_dim
 
 
 def _append_to_docstring(doc: str | None, title: str, keys: tuple[str, ...], vocab: Any) -> str:
@@ -25,43 +40,6 @@ def _append_to_docstring(doc: str | None, title: str, keys: tuple[str, ...], voc
     return base_doc + "\n".join(lines) + "\n"
 
 
-def requires_attrs(*keys: str) -> Callable:
-    """Decorator to enforce that specific attributes exist in `self._obj.attrs`.
-
-    If attributes are missing at runtime, it raises a clear ValueError with
-    instructions on how to fix it using standard xarray methods. At import time,
-    it dynamically appends the required attributes to the method's docstring.
-
-    Parameters
-    ----------
-    *keys : str
-        The attribute string keys required by the method (e.g., ATTRS.b0_field).
-    """  # noqa: D401
-
-    def decorator(func: Callable) -> Callable:
-        # 1. Modify the docstring at import time
-        func.__doc__ = _append_to_docstring(
-            doc=func.__doc__, title="Required Attributes", keys=keys, vocab=ATTRS
-        )
-
-        # 2. Wrap the runtime execution
-        @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
-            missing = [k for k in keys if k not in self._obj.attrs]
-            if missing:
-                raise ValueError(
-                    f"Method '{func.__name__}' requires the following missing attributes "
-                    f"in `obj.attrs`: {missing}.\n\n"
-                    f"To fix this, assign them using standard xarray methods:\n"
-                    f"    >>> obj = obj.assign_attrs({{{repr(missing[0])}: value}})"
-                )
-            return func(self, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
 def _append_note_to_docstring(doc: str | None, title: str, body: str) -> str:
     """Append a free-text NumPy-style section (e.g. ``Notes``) to a docstring."""
     base_doc = doc or ""
@@ -72,97 +50,263 @@ def _append_note_to_docstring(doc: str | None, title: str, body: str) -> str:
     return base_doc + "\n".join(lines) + "\n"
 
 
-def resolves_spectral_dim(func: Callable) -> Callable:
-    """Fill a missing ``dim`` argument with the data's spectral dimension.
+def requires_attrs(*keys: str) -> Callable:
+    """Decorator to enforce that specific attributes exist in the input's ``.attrs``.
 
-    The *resolve* tier of the validation taxonomy (``requires`` → ``resolves``
-    → ``ensures``). If the caller leaves ``dim`` as ``None`` (or omits it), the
-    DataArray (first positional argument) is introspected and the unique
-    spectral dimension is injected via :func:`_resolve_spectral_dim`. An
-    explicitly supplied ``dim`` is never overridden. Zero-cost — no data is
-    transformed.
-    """
-    func.__doc__ = _append_note_to_docstring(
-        func.__doc__,
-        "Notes",
-        "If ``dim`` is left as ``None`` it is resolved automatically to the "
-        "spectral dimension present (``frequency`` or ``chemical_shift``).",
-    )
-
-    sig = inspect.signature(func)
-    first_param = next(iter(sig.parameters))
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        bound = sig.bind(*args, **kwargs)
-        if bound.arguments.get("dim") is None:
-            bound.arguments["dim"] = _resolve_spectral_dim(bound.arguments[first_param])
-        return func(*bound.args, **bound.kwargs)
-
-    return wrapper
-
-
-def _coerce_to_domain(da: xr.DataArray, target_dims: frozenset[str]) -> xr.DataArray:
-    """Return ``da`` transformed into the physical domain named by ``target_dims``.
-
-    A no-op if ``da`` already carries a dimension in ``target_dims``; otherwise a
-    Fourier transform (time ↔ spectral) moves it into the target domain and the
-    result is left there. The conversion routines are imported lazily to keep
-    ``validation`` free of an import-time dependency on ``processing``.
-    """
-    if any(d in target_dims for d in da.dims):
-        return da
-
-    from xmris.core.config import SPECTRAL_DIMS, TIME_DIMS
-    from xmris.processing.fid import to_fid, to_spectrum
-
-    if target_dims == SPECTRAL_DIMS:
-        source = next((str(d) for d in da.dims if d in TIME_DIMS), None)
-        if source is not None:
-            return to_spectrum(da, dim=source)
-    elif target_dims == TIME_DIMS:
-        source = next((str(d) for d in da.dims if d in SPECTRAL_DIMS), None)
-        if source is not None:
-            return to_fid(da, dim=source)
-
-    raise ValueError(
-        f"Cannot ensure domain {sorted(target_dims)}: found no convertible "
-        f"time/spectral dimension in {list(da.dims)}."
-    )
-
-
-def ensures_domain(target_dims: frozenset[str]) -> Callable:
-    """Ensure the input is in a target physical domain, transforming if needed.
-
-    The *ensures* tier of the validation taxonomy (``requires`` → ``resolves``
-    → ``ensures``). Before the wrapped function runs, its DataArray (first
-    positional argument) is coerced into ``target_dims``: a no-op if it is
-    already there, otherwise an FFT/IFFT (O(N log N)) moves it into the domain
-    and the result is *left in that domain* (no round-trip restore).
+    The *gate* tier of the validation taxonomy. The wrapped callable's first
+    positional argument must be the ``xarray.DataArray`` (free-function
+    convention). If attributes are missing at runtime, it raises a clear
+    ValueError with instructions on how to fix it using standard xarray
+    methods. At import time, it dynamically appends the required attributes to
+    the function's docstring.
 
     Parameters
     ----------
-    target_dims : frozenset of str
-        The dimension names constituting the required domain — use
-        ``SPECTRAL_DIMS`` or ``TIME_DIMS`` from :mod:`xmris.core.config`.
-    """
+    *keys : str
+        The attribute string keys required by the function (e.g., ATTRS.b0_field).
+    """  # noqa: D401
 
     def decorator(func: Callable) -> Callable:
-        # NB: no docstring-note injection here. When stacked with
-        # @resolves_spectral_dim (which does inject a Notes section) a second
-        # injection would produce a duplicate "Notes" block; the auto-transform
-        # behaviour is instead documented in each function's own parameter docs.
+        # 1. Modify the docstring at import time
+        func.__doc__ = _append_to_docstring(
+            doc=func.__doc__, title="Required Attributes", keys=keys, vocab=ATTRS
+        )
+
         sig = inspect.signature(func)
         first_param = next(iter(sig.parameters))
 
+        # 2. Wrap the runtime execution
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             bound = sig.bind(*args, **kwargs)
-            bound.arguments[first_param] = _coerce_to_domain(
-                bound.arguments[first_param], target_dims
-            )
+            da = bound.arguments[first_param]
+            missing = [k for k in keys if k not in da.attrs]
+            if missing:
+                raise ValueError(
+                    f"'{func.__name__}' requires the following missing attributes "
+                    f"in `obj.attrs`: {missing}.\n\n"
+                    f"To fix this, assign them using standard xarray methods:\n"
+                    f"    >>> obj = obj.assign_attrs({{{repr(missing[0])}: value}})"
+                )
             return func(*bound.args, **bound.kwargs)
 
         return wrapper
 
     return decorator
+
+
+class _RestoreState(NamedTuple):
+    """What a ``computes_in`` round trip must hand back after the function runs."""
+
+    dim: str  # original domain dim name (e.g. "chemical_shift")
+    coord: xr.Variable | None  # original coordinate, restored verbatim when possible
+    size: int  # original length along `dim`
+
+
+def _domain_of(da: xr.DataArray, domain: frozenset[str]) -> str | None:
+    """Return the first dimension of ``da`` belonging to ``domain``, or ``None``."""
+    return next((str(d) for d in da.dims if d in domain), None)
+
+
+def _coerce_to_domain(
+    da: xr.DataArray, domain: frozenset[str]
+) -> tuple[xr.DataArray, _RestoreState]:
+    """Transform ``da`` into the physical domain ``domain`` via the standard converters.
+
+    Only called when ``da`` carries no dimension of ``domain``. Routes strictly
+    through the converter functions (`to_spectrum`/`to_fid`, with the ppm leg
+    handled by `to_hz`) so an auto-inserted transform is bit-identical to an
+    explicit one. Returns the converted array plus the :class:`_RestoreState`
+    describing the original representation. The converters are imported lazily
+    to keep ``validation`` free of an import-time dependency on ``processing``.
+    """
+    from xmris.processing.fid import to_fid, to_spectrum
+
+    if domain == SPECTRAL_DIMS:
+        source = _domain_of(da, TIME_DIMS)
+        if source is not None:
+            state = _RestoreState(
+                dim=source,
+                coord=da.coords[source].variable if source in da.coords else None,
+                size=da.sizes[source],
+            )
+            return to_spectrum(da, dim=source), state
+
+    elif domain == TIME_DIMS:
+        source = _domain_of(da, SPECTRAL_DIMS)
+        if source is not None:
+            if not np.iscomplexobj(da.values):
+                raise ValueError(
+                    f"Cannot transform real-valued spectral data (dim {source!r}) "
+                    f"into the time domain: the imaginary component is gone (e.g. "
+                    f"discarded by `baseline_als`), so no valid FID exists behind "
+                    f"this spectrum.\n\n"
+                    f"Apply time-domain operations before the step that discarded "
+                    f"the imaginary part, or pass an explicit existing dimension "
+                    f"to operate on."
+                )
+            state = _RestoreState(
+                dim=source,
+                coord=da.coords[source].variable if source in da.coords else None,
+                size=da.sizes[source],
+            )
+            if source == DIMS.chemical_shift:
+                # ppm leg: reference to Hz first so `to_fid` reconstructs a
+                # physical dwell time (its math assumes Hz coordinate spacing).
+                from xmris.processing.referencing import to_hz
+
+                da = to_hz(da, dim=source)
+                source = str(DIMS.frequency)
+            return to_fid(da, dim=source), state
+
+    raise ValueError(
+        f"Cannot ensure domain {sorted(domain)}: found no convertible "
+        f"time/spectral dimension in {list(da.dims)}."
+    )
+
+
+def _restore_domain(
+    result: xr.DataArray, domain: frozenset[str], state: _RestoreState
+) -> xr.DataArray:
+    """Invert a ``computes_in`` coercion, returning ``result`` in its original representation.
+
+    Routes back through the standard converters; when the wrapped function
+    preserved the length along the working dimension, the original coordinate
+    variable is reassigned verbatim (protecting e.g. a dead-time offset that
+    `to_fid`'s synthesized ``[0, T)`` axis would drop). Length-changing
+    operations keep the converter-recomputed coordinates instead.
+    """
+    from xmris.processing.fid import to_fid, to_spectrum
+
+    working = _domain_of(result, domain)
+    if working is None:
+        raise ValueError(
+            f"Cannot restore the input representation: the wrapped function "
+            f"returned no {_domain_label(domain)} dimension "
+            f"(got {list(result.dims)}). Functions under `computes_in` must "
+            f"keep their working dimension."
+        )
+
+    if domain == TIME_DIMS:
+        out = to_spectrum(result, dim=working)
+        if state.dim == DIMS.chemical_shift:
+            # The inbound ppm leg went through `to_hz`, so the attrs needed by
+            # `to_ppm` are guaranteed present on the result.
+            from xmris.processing.referencing import to_ppm
+
+            out = to_ppm(out)
+    else:
+        out = to_fid(result, dim=working)
+
+    if state.coord is not None and out.sizes.get(state.dim) == state.size:
+        out = out.assign_coords({state.dim: state.coord})
+    return out
+
+
+def _domain_decorator(domain: frozenset[str], *, restore: bool) -> Callable:
+    """Shared engine behind ``ensures_domain`` (funnel) and ``computes_in`` (restore)."""
+    label = _domain_label(domain)
+    if restore:
+        note = (
+            f"The computation runs in the {label} domain: input in another "
+            f"domain is transformed in via the standard converters and the "
+            f"result is transformed back, preserving the input's representation "
+            f"and (where the length is unchanged) its exact coordinates. An "
+            f"explicitly requested ``dim`` outside the {label} domain passes "
+            f"through untouched."
+        )
+    else:
+        note = (
+            f"If the input is not already in the {label} domain it is "
+            f"transformed into it via the standard converters and the result "
+            f"is left there (funnel contract). A ``dim`` left as ``None`` is "
+            f"resolved to the unique {label} dimension present."
+        )
+
+    def decorator(func: Callable) -> Callable:
+        func.__doc__ = _append_note_to_docstring(func.__doc__, "Notes", note)
+
+        sig = inspect.signature(func)
+        first_param = next(iter(sig.parameters))
+        has_dim = "dim" in sig.parameters
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            da = bound.arguments[first_param]
+            requested = bound.arguments.get("dim") if has_dim else None
+
+            state = None
+            if _domain_of(da, domain) is None:
+                # Domain-preserving ops honor an explicit request for a foreign
+                # axis (e.g. zero_fill(dim="kx")) by not converting at all.
+                foreign_request = restore and requested is not None and requested not in domain
+                if not foreign_request:
+                    da, state = _coerce_to_domain(da, domain)
+                    bound.arguments[first_param] = da
+
+            if has_dim and bound.arguments.get("dim") is None:
+                bound.arguments["dim"] = _resolve_dim(da, domain)
+
+            result = func(*bound.args, **bound.kwargs)
+
+            if restore and state is not None:
+                result = _restore_domain(result, domain, state)
+            return result
+
+        wrapper.__xmris_domain__ = (domain, restore)  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator
+
+
+def ensures_domain(domain: frozenset[str]) -> Callable:
+    """Funnel contract: ensure the input is in a physical domain, leaving the result there.
+
+    The *domain* tier of the validation taxonomy, for operations that are only
+    meaningful in one domain and whose result is consumed there (e.g.
+    ``autophase``, ``baseline_als``). Before the wrapped function runs, its
+    DataArray (first positional argument) is transformed into ``domain`` via
+    the standard converters — a no-op if it is already there — and the result
+    is *left in that domain* (no round-trip restore). A ``dim`` argument left
+    as ``None`` is resolved to the unique domain dimension present; an
+    explicitly supplied ``dim`` is never overridden.
+
+    Parameters
+    ----------
+    domain : frozenset of str
+        The dimension names constituting the required domain — use
+        ``SPECTRAL_DIMS`` or ``TIME_DIMS`` from :mod:`xmris.core.config`.
+
+    See Also
+    --------
+    computes_in : The domain-preserving contract (round trip, representation restored).
+    """
+    return _domain_decorator(domain, restore=False)
+
+
+def computes_in(domain: frozenset[str]) -> Callable:
+    """Domain-preserving contract: compute in a physical domain, restore the representation.
+
+    The *domain* tier of the validation taxonomy, for operations whose physics
+    is identical seen from either domain (e.g. ``apodize_exp``, ``zero_fill``).
+    Input already in ``domain`` is processed directly. Input in the sibling
+    domain takes a round trip: it is transformed in via the standard
+    converters, processed, and transformed back — so the output keeps the
+    input's representation, with the original coordinates reassigned verbatim
+    whenever the operation preserved the length. Real-valued spectral input is
+    rejected (its inverse transform is undefined), and an explicitly requested
+    ``dim`` outside ``domain`` passes through untouched.
+
+    Parameters
+    ----------
+    domain : frozenset of str
+        The dimension names constituting the working domain — use
+        ``SPECTRAL_DIMS`` or ``TIME_DIMS`` from :mod:`xmris.core.config`.
+
+    See Also
+    --------
+    ensures_domain : The funnel contract (result is left in the working domain).
+    """
+    return _domain_decorator(domain, restore=True)

--- a/src/xmris/processing/phasing.py
+++ b/src/xmris/processing/phasing.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 from xmris.core.config import ATTRS, DIMS, SPECTRAL_DIMS
 from xmris.core.utils import _check_dims
-from xmris.core.validation import ensures_domain, resolves_spectral_dim
+from xmris.core.validation import ensures_domain
 from xmris.processing.fid import apodize_exp, to_fid, to_spectrum
 
 
@@ -160,7 +160,6 @@ def _roi_positivity_score(ph, da, dim, pivot, target_idx, index_width):
 
 # --- Public API ---
 @ensures_domain(SPECTRAL_DIMS)
-@resolves_spectral_dim
 def autophase(
     da: xr.DataArray,
     dim: str | None = None,
@@ -219,8 +218,8 @@ def autophase(
     xr.DataArray
         The phased spectrum.
     """
-    # `dim` is guaranteed non-None here by @resolves_spectral_dim; validate that
-    # an explicitly-passed dim actually exists (the resolver only fills None).
+    # `dim` is guaranteed non-None here by @ensures_domain's merged resolution;
+    # validate that an explicitly-passed dim actually exists (only None is filled).
     assert dim is not None
     _check_dims(da, dim, "autophase")
     kwargs.setdefault("disp", False)
@@ -257,9 +256,18 @@ def autophase(
 
     # 4. Optional preprocessing (applied ONLY to the 1D optimization slice)
     if lb > 0:
-        temp_fid = to_fid(opt_da, dim=dim, out_dim=temp_time_dim)
+        opt_src, work_dim = opt_da, dim
+        if dim == DIMS.chemical_shift:
+            # ppm axis: reference to Hz first so `to_fid` reconstructs a physical
+            # dwell time — `lb` is in Hz and needs a correct time axis.
+            from xmris.processing.referencing import to_hz, to_ppm
+
+            opt_src, work_dim = to_hz(opt_da, dim=dim), str(DIMS.frequency)
+        temp_fid = to_fid(opt_src, dim=work_dim, out_dim=temp_time_dim)
         temp_apodized_fid = apodize_exp(temp_fid, dim=temp_time_dim, lb=lb)
-        work_da = to_spectrum(temp_apodized_fid, dim=temp_time_dim, out_dim=dim)
+        work_da = to_spectrum(temp_apodized_fid, dim=temp_time_dim, out_dim=work_dim)
+        if dim == DIMS.chemical_shift:
+            work_da = to_ppm(work_da, dim=work_dim)
     else:
         work_da = opt_da
 

--- a/src/xmris/processing/referencing.py
+++ b/src/xmris/processing/referencing.py
@@ -1,0 +1,92 @@
+"""Spectral-axis referencing: conversion between relative [Hz] and absolute [ppm] axes.
+
+These converters are pure coordinate swaps (no Fourier transform): they build the
+sibling spectral coordinate from the ``reference_frequency`` / ``carrier_ppm``
+metadata and swap the indexing dimension. Together with ``to_spectrum`` /
+``to_fid`` they are the only functions in xmris that change a DataArray's
+representation on purpose — the domain decorators route every automatic
+conversion through them.
+"""
+
+import xarray as xr
+
+from xmris.core.config import ATTRS, COORDS, DIMS
+from xmris.core.utils import _check_dims, as_variable
+from xmris.core.validation import requires_attrs
+
+
+@requires_attrs(ATTRS.reference_frequency, ATTRS.carrier_ppm)
+def to_ppm(da: xr.DataArray, dim: str = DIMS.frequency) -> xr.DataArray:
+    """
+    Convert a relative frequency axis [Hz] to an absolute chemical shift axis [ppm].
+
+    Computes ``carrier_ppm + hz / reference_frequency`` for every point of the
+    frequency coordinate, assigns the result as a new ``chemical_shift``
+    coordinate, and swaps the indexing dimension to it. The original Hz
+    coordinate is kept alongside, so both views remain available.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input frequency-domain data with a coordinate on ``dim``.
+    dim : str, optional
+        The relative frequency dimension to convert, by default `DIMS.frequency`.
+
+    Returns
+    -------
+    xr.DataArray
+        The same data indexed by an absolute ``chemical_shift`` [ppm] dimension.
+    """
+    _check_dims(da, dim, "to_ppm")
+
+    mhz = da.attrs[ATTRS.reference_frequency]
+    carrier_ppm = da.attrs[ATTRS.carrier_ppm]
+    hz_coords = da.coords[dim].values
+
+    # 1. Calculate the math
+    ppm_coords = carrier_ppm + (hz_coords / mhz)
+
+    # 2. Build the fully-formed xarray Variable (data + metadata). Use the
+    #    COORDS term (carries unit="ppm") so the coordinate's lineage is
+    #    complete — mirrors `to_hz` using COORDS.frequency (unit="Hz").
+    shift_var = as_variable(COORDS.chemical_shift, dim, ppm_coords)
+
+    # 3. Assign and swap in one clean sweep
+    obj = da.assign_coords({DIMS.chemical_shift: shift_var})
+    return obj.swap_dims({dim: DIMS.chemical_shift})
+
+
+@requires_attrs(ATTRS.reference_frequency, ATTRS.carrier_ppm)
+def to_hz(da: xr.DataArray, dim: str = DIMS.chemical_shift) -> xr.DataArray:
+    """
+    Convert an absolute chemical shift axis [ppm] to a relative frequency axis [Hz].
+
+    Computes ``(ppm - carrier_ppm) * reference_frequency`` for every point of
+    the chemical shift coordinate, assigns the result as a new ``frequency``
+    coordinate, and swaps the indexing dimension to it.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        The input chemical-shift-domain data with a coordinate on ``dim``.
+    dim : str, optional
+        The chemical shift dimension to convert, by default `DIMS.chemical_shift`.
+
+    Returns
+    -------
+    xr.DataArray
+        The same data indexed by a relative ``frequency`` [Hz] dimension.
+    """
+    _check_dims(da, dim, "to_hz")
+
+    mhz = da.attrs[ATTRS.reference_frequency]
+    carrier_ppm = da.attrs[ATTRS.carrier_ppm]
+    ppm_coords = da.coords[dim].values
+
+    hz_coords = (ppm_coords - carrier_ppm) * mhz
+
+    # Pack the data and metadata together instantly
+    freq_var = as_variable(COORDS.frequency, dim, hz_coords)
+
+    obj = da.assign_coords({COORDS.frequency: freq_var})
+    return obj.swap_dims({dim: DIMS.frequency})

--- a/src/xmris/visualization/widget/phase/phase.py
+++ b/src/xmris/visualization/widget/phase/phase.py
@@ -5,7 +5,8 @@ import numpy as np
 import traitlets
 import xarray as xr
 
-from xmris.core.utils import _check_dims, _resolve_spectral_dim, _spectral_axis_label
+from xmris.core.config import SPECTRAL_DIMS
+from xmris.core.utils import _check_dims, _resolve_dim, _spectral_axis_label
 
 from .._shared import load_css, load_esm
 
@@ -121,7 +122,7 @@ def phase_spectrum(
     # Resolve the spectral axis: an explicit `dim` wins; otherwise auto-detect the
     # canonical spectral dimension (frequency / chemical_shift) via the shared resolver.
     if dim is None:
-        dim = _resolve_spectral_dim(da)
+        dim = _resolve_dim(da, SPECTRAL_DIMS)
     _check_dims(da, dim, "phase_spectrum")
 
     # Build the display axis from the coordinate and its lineage metadata (no name sniffing).

--- a/src/xmris/visualization/widget/scroller/scroller.py
+++ b/src/xmris/visualization/widget/scroller/scroller.py
@@ -5,7 +5,8 @@ import numpy as np
 import traitlets
 import xarray as xr
 
-from xmris.core.utils import _check_dims, _resolve_spectral_dim, _spectral_axis_label
+from xmris.core.config import SPECTRAL_DIMS
+from xmris.core.utils import _check_dims, _resolve_dim, _spectral_axis_label
 
 from .._shared import load_css, load_esm
 
@@ -123,7 +124,7 @@ def scroll_spectra(
     # 1. Resolve the spectral (display) axis from the vocabulary — an explicit
     #    `dim` wins; otherwise auto-detect the canonical spectral dimension.
     if dim is None:
-        spec_dim = _resolve_spectral_dim(da)
+        spec_dim = _resolve_dim(da, SPECTRAL_DIMS)
     else:
         spec_dim = dim
     _check_dims(da, spec_dim, "scroll_spectra")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,8 +33,9 @@ or user pipelines depend on.
      your new method does not accidentally strip xarray `.attrs`.
 
 * **Modifying or adding a decorator in `validation.py`:**
-  Update the `MockAccessor` class and add specific behavior checks to
-  `TestRequiresAttrsRuntime` or `TestRequiresAttrsDocstring`.
+  Update the module-level probe functions and add specific behavior checks to
+  the decorator sections (`TestRequiresAttrs*`, `TestEnsuresDomain`,
+  `TestComputesIn`, `TestDomainDimRule`).
 
 * **Changing core mathematical logic:**
   Do not test complex scientific logic here. This file is for architecture.
@@ -55,7 +56,9 @@ from xmris.core.config import (
     TIME_DIMS,
     VARS,
 )
-from xmris.core.validation import ensures_domain, requires_attrs, resolves_spectral_dim
+from xmris.core.utils import _resolve_dim
+from xmris.core.validation import computes_in, ensures_domain, requires_attrs
+from xmris.processing.fid import to_fid, to_spectrum
 
 # =============================================================================
 # Fixtures
@@ -276,36 +279,28 @@ class TestConfigMetadata:
 # =============================================================================
 
 
-class MockAccessor:
-    """Minimal mock of the xmris accessor pattern for testing ``@requires_attrs``.
+@requires_attrs(ATTRS.b0_field, ATTRS.reference_frequency)
+def _needs_both(da: xr.DataArray):
+    """Original docstring."""
+    return da.attrs[ATTRS.b0_field]
 
-    Replicates the real accessor's ``self._obj`` convention so the decorator
-    can inspect ``.attrs`` without depending on the full ``XmrisAccessor`` class.
-    """
 
-    def __init__(self, obj: xr.DataArray):
-        """Store the DataArray, matching the real accessor's ``__init__`` signature."""
-        self._obj = obj
+@requires_attrs(ATTRS.b0_field)
+def _needs_one(da: xr.DataArray):
+    """Function requiring only a single attribute."""  # noqa: D401
+    return da.attrs[ATTRS.b0_field]
 
-    @requires_attrs(ATTRS.b0_field, ATTRS.reference_frequency)
-    def needs_both(self):
-        """Original docstring."""
-        return self._obj.attrs[ATTRS.b0_field]
 
-    @requires_attrs(ATTRS.b0_field)
-    def needs_one(self):
-        """Method requiring only a single attribute."""  # noqa: D401
-        return self._obj.attrs[ATTRS.b0_field]
-
-    @requires_attrs(ATTRS.b0_field)
-    def no_docstring(self):  # noqa: D102
-        pass
+@requires_attrs(ATTRS.b0_field)
+def _no_docstring(da: xr.DataArray):  # noqa: D103
+    pass
 
 
 class TestRequiresAttrsRuntime:
     """Verify that ``@requires_attrs`` correctly validates at call time.
 
-    The decorator must:
+    The decorator wraps free functions whose first positional argument is the
+    DataArray. It must:
     - Raise ``ValueError`` if any required attr is missing.
     - Include the missing key names and fix instructions in the error message.
     - Pass through to the wrapped function if all attrs are present.
@@ -314,9 +309,8 @@ class TestRequiresAttrsRuntime:
 
     def test_all_missing(self, empty_da):
         """All required attrs absent — must raise with a descriptive message."""
-        accessor = MockAccessor(empty_da)
         with pytest.raises(ValueError, match="missing attributes"):
-            accessor.needs_both()
+            _needs_both(empty_da)
 
     def test_partial_missing(self, empty_da):
         """One attr present, one missing — must still raise.
@@ -325,32 +319,31 @@ class TestRequiresAttrsRuntime:
         after finding the first present attr instead of checking all of them.
         """
         da = empty_da.assign_attrs({ATTRS.b0_field: 3.0})
-        accessor = MockAccessor(da)
         with pytest.raises(ValueError, match="missing attributes"):
-            accessor.needs_both()
+            _needs_both(da)
 
     def test_all_present(self, valid_spectrum_da):
         """All required attrs present — must execute the function body normally."""
-        accessor = MockAccessor(valid_spectrum_da)
-        result = accessor.needs_both()
+        result = _needs_both(valid_spectrum_da)
         assert result == 3.0
 
     def test_error_message_lists_missing_keys(self, empty_da):
         """The error message must name the specific missing attr keys."""
-        accessor = MockAccessor(empty_da)
         with pytest.raises(ValueError, match=ATTRS.b0_field):
-            accessor.needs_both()
+            _needs_both(empty_da)
 
     def test_error_message_includes_fix(self, empty_da):
         """The error message must include copy-pasteable ``assign_attrs`` fix code."""
-        accessor = MockAccessor(empty_da)
         with pytest.raises(ValueError, match="assign_attrs"):
-            accessor.needs_both()
+            _needs_both(empty_da)
 
     def test_returns_original_value(self, valid_spectrum_da):
         """The decorator must be transparent — return value is unchanged."""
-        accessor = MockAccessor(valid_spectrum_da)
-        assert accessor.needs_one() == valid_spectrum_da.attrs[ATTRS.b0_field]
+        assert _needs_one(valid_spectrum_da) == valid_spectrum_da.attrs[ATTRS.b0_field]
+
+    def test_works_as_keyword_argument(self, valid_spectrum_da):
+        """The DataArray must also be accepted as a keyword argument."""
+        assert _needs_one(da=valid_spectrum_da) == valid_spectrum_da.attrs[ATTRS.b0_field]
 
 
 class TestRequiresAttrsDocstring:
@@ -363,17 +356,17 @@ class TestRequiresAttrsDocstring:
 
     def test_injects_section_header(self):
         """The auto-generated docstring must contain a 'Required Attributes' header."""
-        assert "Required Attributes" in MockAccessor.needs_both.__doc__
+        assert "Required Attributes" in _needs_both.__doc__
 
     def test_injects_key_names(self):
         """Every required attr key must appear in the generated docstring."""
-        doc = MockAccessor.needs_both.__doc__
+        doc = _needs_both.__doc__
         assert ATTRS.b0_field in doc
         assert ATTRS.reference_frequency in doc
 
     def test_preserves_original_docstring(self):
         """The original docstring text must not be overwritten by the injection."""
-        assert "Original docstring." in MockAccessor.needs_both.__doc__
+        assert "Original docstring." in _needs_both.__doc__
 
     def test_handles_no_docstring(self):
         """Decorating a function with ``None`` docstring must not crash.
@@ -381,13 +374,13 @@ class TestRequiresAttrsDocstring:
         The decorator should gracefully create a new docstring containing
         only the 'Required Attributes' section.
         """
-        doc = MockAccessor.no_docstring.__doc__
+        doc = _no_docstring.__doc__
         assert doc is not None
         assert "Required Attributes" in doc
 
     def test_preserves_function_name(self):
         """``functools.wraps`` must preserve ``__name__`` for introspection and debugging."""  # noqa: E501
-        assert MockAccessor.needs_both.__name__ == "needs_both"
+        assert _needs_both.__name__ == "_needs_both"
 
 
 # =============================================================================
@@ -550,11 +543,13 @@ class TestAccessorDefaults:
         )
 
     def test_autophase_dim_is_none_by_design(self):
-        """`autophase` intentionally defaults `dim=None` for the resolver.
+        """`autophase` mirrors the domain-decorator rule: `dim` defaults to None.
 
-        It is resolver-managed: ``@resolves_spectral_dim`` fills ``dim`` at call
-        time by detecting ``frequency`` vs ``chemical_shift``, so it deliberately
-        diverges from the config-constant-default convention above.
+        The free function carries ``@ensures_domain(SPECTRAL_DIMS)`` — a
+        multi-label domain — whose merged resolution fills ``dim`` at call time
+        by detecting ``frequency`` vs ``chemical_shift``. The accessor forwarder
+        mirrors that signature. See ``TestDomainDimRule`` for the package-wide
+        biconditional this instance follows.
         """  # noqa: D205
         import inspect
 
@@ -562,6 +557,73 @@ class TestAccessorDefaults:
 
         sig = inspect.signature(XmrisAccessor.autophase)
         assert sig.parameters["dim"].default is None
+
+
+class TestDomainDimRule:
+    """Enforce the package-wide `dim`-default rule (the "biconditional").
+
+    ``dim`` defaults to ``None`` **iff** the function is domain-decorated with
+    a *multi-label* domain (the decorator's merged resolution fills it at call
+    time); every other ``dim`` defaults to a config constant. This replaces
+    per-function carve-outs with one mechanically-enforced rule.
+    """
+
+    @staticmethod
+    def _public_dim_functions():
+        """Yield (qualname, function, dim_default) for the public processing API."""
+        import inspect
+
+        import xmris.fitting.amares
+        import xmris.processing.baseline
+        import xmris.processing.fid
+        import xmris.processing.fourier
+        import xmris.processing.phasing
+        import xmris.processing.referencing
+        import xmris.processing.utils
+        import xmris.vendor.bruker
+
+        modules = [
+            xmris.processing.baseline,
+            xmris.processing.fid,
+            xmris.processing.fourier,
+            xmris.processing.phasing,
+            xmris.processing.referencing,
+            xmris.processing.utils,
+            xmris.fitting.amares,
+            xmris.vendor.bruker,
+        ]
+        for mod in modules:
+            for name, obj in inspect.getmembers(mod, inspect.isfunction):
+                # Only functions *defined* in the module (functools.wraps keeps
+                # __module__ pointing at the definition site), skip privates.
+                if name.startswith("_") or obj.__module__ != mod.__name__:
+                    continue
+                sig = inspect.signature(obj)
+                if "dim" not in sig.parameters:
+                    continue
+                yield f"{mod.__name__}.{name}", obj, sig.parameters["dim"].default
+
+    def test_dim_defaults_follow_biconditional(self):
+        """``dim=None`` ⟺ domain-decorated with a multi-label domain."""
+        checked = 0
+        for qualname, func, default in self._public_dim_functions():
+            domain_info = getattr(func, "__xmris_domain__", None)
+            multi_label = domain_info is not None and len(domain_info[0]) > 1
+            if multi_label:
+                assert default is None, (
+                    f"{qualname} is domain-decorated with a multi-label domain "
+                    f"but defaults dim={default!r}. Multi-label domain functions "
+                    f"must default dim=None (the decorator resolves it)."
+                )
+            else:
+                assert default is not None, (
+                    f"{qualname} defaults dim=None but is not domain-decorated "
+                    f"with a multi-label domain. Use the config constant "
+                    f"(e.g., DIMS.time) as the default."
+                )
+            checked += 1
+        # Sanity: the introspection must actually cover the processing API.
+        assert checked >= 10, f"only {checked} functions found — introspection broke?"
 
 
 # =============================================================================
@@ -725,41 +787,36 @@ class TestToPpm:
 
 
 # =============================================================================
-# 10. Domain Decorators: @resolves_spectral_dim
+# 10. Domain Resolution: _resolve_dim
 # =============================================================================
 
 
-@resolves_spectral_dim
-def _resolver_probe(da, dim=None):
-    """Test probe for ``@resolves_spectral_dim``: return the dim it settled on."""
-    return dim
+class TestResolveDim:
+    """Verify ``_resolve_dim`` identifies the unique dimension of a domain group.
 
-
-class TestResolvesSpectralDim:
-    """Verify ``@resolves_spectral_dim`` fills ``dim=None`` by introspection.
-
-    The *resolve* tier must inject the unique spectral dimension when the caller
-    omits ``dim``, never override an explicit ``dim``, and raise actionable
-    errors when resolution is impossible or ambiguous.
+    The shared resolution helper behind the domain decorators' merged
+    ``dim=None`` handling (and the visualization widgets' axis auto-detection):
+    it must find the unique candidate dimension and raise actionable errors
+    when resolution is impossible or ambiguous.
     """
 
-    def test_fills_none_with_frequency(self, valid_spectrum_da):
+    def test_finds_frequency(self, valid_spectrum_da):
         """A spectrum in Hz must resolve to ``DIMS.frequency``."""
-        assert _resolver_probe(valid_spectrum_da) == DIMS.frequency
+        assert _resolve_dim(valid_spectrum_da, SPECTRAL_DIMS) == DIMS.frequency
 
-    def test_fills_none_with_chemical_shift(self, valid_spectrum_da):
+    def test_finds_chemical_shift(self, valid_spectrum_da):
         """A spectrum in ppm must resolve to ``DIMS.chemical_shift``."""
         ppm = valid_spectrum_da.xmr.to_ppm()
-        assert _resolver_probe(ppm) == DIMS.chemical_shift
+        assert _resolve_dim(ppm, SPECTRAL_DIMS) == DIMS.chemical_shift
 
-    def test_respects_explicit_dim(self, valid_spectrum_da):
-        """An explicitly-passed ``dim`` must never be overridden."""
-        assert _resolver_probe(valid_spectrum_da, dim="custom") == "custom"
+    def test_finds_time(self, valid_fid_da):
+        """A FID must resolve ``TIME_DIMS`` to ``DIMS.time``."""
+        assert _resolve_dim(valid_fid_da, TIME_DIMS) == DIMS.time
 
-    def test_raises_when_no_spectral_dim(self, valid_fid_da):
+    def test_raises_when_no_candidate(self, valid_fid_da):
         """Time-domain input (no spectral dim) must raise with guidance."""
         with pytest.raises(ValueError, match="spectral dimension"):
-            _resolver_probe(valid_fid_da)
+            _resolve_dim(valid_fid_da, SPECTRAL_DIMS)
 
     def test_raises_when_ambiguous(self):
         """Multiple spectral dims present must raise and ask for an explicit dim."""
@@ -769,11 +826,11 @@ class TestResolvesSpectralDim:
             coords={DIMS.frequency: np.arange(4), DIMS.chemical_shift: np.arange(4)},
         )
         with pytest.raises(ValueError, match="[Aa]mbiguous"):
-            _resolver_probe(da)
+            _resolve_dim(da, SPECTRAL_DIMS)
 
 
 # =============================================================================
-# 11. Domain Decorators: @ensures_domain
+# 11. Domain Decorators: @ensures_domain (funnel contract)
 # =============================================================================
 
 
@@ -789,13 +846,20 @@ def _ensure_time_probe(da):
     return da
 
 
-class TestEnsuresDomain:
-    """Verify ``@ensures_domain`` auto-transforms input into the target domain.
+@ensures_domain(SPECTRAL_DIMS)
+def _funnel_dim_probe(da, dim=None):
+    """Funnel probe with a ``dim`` argument: return the dim the decorator settled on."""
+    return dim
 
-    The *ensures* tier must pass already-in-domain data through untouched
-    (identity, no FFT), Fourier-transform mismatched data into the target
-    domain, leave the result in that domain (no restore), and preserve
-    ``.attrs`` across the transform (the issue #21 coupling).
+
+class TestEnsuresDomain:
+    """Verify ``@ensures_domain`` implements the funnel contract.
+
+    The funnel flavor must pass already-in-domain data through untouched
+    (identity, no FFT), transform mismatched data into the target domain via
+    the standard converters, leave the result there (no restore), resolve a
+    ``dim=None`` argument after coercion, and preserve ``.attrs`` across the
+    transform (the issue #21 coupling).
     """
 
     def test_noop_when_already_spectral(self, valid_spectrum_da):
@@ -832,14 +896,209 @@ class TestEnsuresDomain:
         assert DIMS.time in result.dims
         assert DIMS.frequency not in result.dims
 
+    # --- merged dim resolution -------------------------------------------------
+
+    def test_resolves_dim_on_spectrum(self, valid_spectrum_da):
+        """``dim=None`` on an in-domain spectrum resolves to ``frequency``."""
+        assert _funnel_dim_probe(valid_spectrum_da) == DIMS.frequency
+
+    def test_resolves_dim_on_ppm(self, valid_spectrum_da):
+        """``dim=None`` on a ppm spectrum resolves to ``chemical_shift``."""
+        ppm = valid_spectrum_da.xmr.to_ppm()
+        assert _funnel_dim_probe(ppm) == DIMS.chemical_shift
+
+    def test_resolves_dim_after_coercion(self, valid_fid_da):
+        """A FID is coerced first, then ``dim=None`` resolves on the *coerced* array.
+
+        This is the ordering the old two-decorator stack made load-bearing;
+        merged into one decorator it can no longer be applied wrongly.
+        """
+        assert _funnel_dim_probe(valid_fid_da) == DIMS.frequency
+
+    def test_respects_explicit_dim(self, valid_spectrum_da):
+        """An explicitly-passed ``dim`` must never be overridden."""
+        assert _funnel_dim_probe(valid_spectrum_da, dim="custom") == "custom"
+
+    # --- ppm leg & complexity gate --------------------------------------------
+
+    def test_ppm_to_time_reconstructs_physical_dwell(self, valid_spectrum_da):
+        """Coercing a ppm spectrum to time routes ppm→Hz→FID with a physical dwell time.
+
+        Regression test for the latent dwell-time bug: computing the time axis
+        from *ppm* coordinate spacing would be off by the reference frequency
+        (a factor of ~1e8). The engine must reference back to Hz first.
+        """
+        ppm = valid_spectrum_da.xmr.to_ppm()
+        result = _ensure_time_probe(ppm)
+
+        assert DIMS.time in result.dims
+        hz = valid_spectrum_da.coords[DIMS.frequency].values
+        df = abs(hz[1] - hz[0])
+        expected_dt = 1.0 / (len(hz) * df)
+        actual_dt = float(result.coords[DIMS.time][1] - result.coords[DIMS.time][0])
+        np.testing.assert_allclose(actual_dt, expected_dt, rtol=1e-9)
+
+    def test_ppm_to_time_without_attrs_raises(self):
+        """The ppm leg needs referencing attrs — missing ones raise the standard fix."""
+        rng = np.random.default_rng()
+        bare_ppm = xr.DataArray(
+            rng.standard_normal(64) + 1j * rng.standard_normal(64),
+            dims=[DIMS.chemical_shift],
+            coords={DIMS.chemical_shift: np.linspace(0, 10, 64)},
+        )
+        with pytest.raises(ValueError, match="missing attributes"):
+            _ensure_time_probe(bare_ppm)
+
+    def test_real_spectrum_to_time_raises(self, valid_spectrum_da):
+        """Real-valued spectral data cannot be transformed to time — loud error."""
+        real_spec = valid_spectrum_da.copy(data=valid_spectrum_da.values.real)
+        with pytest.raises(ValueError, match="real-valued"):
+            _ensure_time_probe(real_spec)
+
 
 # =============================================================================
-# 12. Integration: autophase domain-agnostic pilot
+# 12. Domain Decorators: @computes_in (domain-preserving contract)
+# =============================================================================
+
+
+@computes_in(TIME_DIMS)
+def _time_scale_probe(da, dim=DIMS.time, factor=2.0):
+    """Length-preserving time-domain probe: scale values, preserve metadata."""
+    return da.copy(data=da.values * factor)
+
+
+@computes_in(TIME_DIMS)
+def _time_pad_probe(da, dim=DIMS.time):
+    """Length-changing time-domain probe: zero-fill to double length."""
+    from xmris.processing.fid import zero_fill
+
+    return zero_fill(da, dim=dim, target_points=2 * da.sizes[dim])
+
+
+class TestComputesIn:
+    """Verify ``@computes_in`` implements the domain-preserving contract.
+
+    The restore flavor must process in-domain input directly (no transform),
+    round-trip out-of-domain input through the standard converters and hand it
+    back in the input's representation with the original coordinates reassigned
+    verbatim (length-preserving ops), recompute coordinates for length-changing
+    ops, reject real-valued spectral input, and pass an explicitly-requested
+    foreign dim through untouched.
+    """
+
+    def test_in_domain_input_is_not_transformed(self, valid_fid_da):
+        """A FID handed to a time-domain op stays a FID — no round trip."""
+        result = _time_scale_probe(valid_fid_da)
+        assert list(result.dims) == list(valid_fid_da.dims)
+        np.testing.assert_allclose(result.values, valid_fid_da.values * 2.0)
+        np.testing.assert_array_equal(
+            result.coords[DIMS.time].values, valid_fid_da.coords[DIMS.time].values
+        )
+
+    def test_spectrum_round_trips_to_spectrum(self, valid_spectrum_da):
+        """A Hz spectrum comes back as a Hz spectrum (scaling commutes with the FFT)."""
+        result = _time_scale_probe(valid_spectrum_da)
+        assert DIMS.frequency in result.dims
+        assert DIMS.time not in result.dims
+        np.testing.assert_allclose(
+            result.values, valid_spectrum_da.values * 2.0, rtol=1e-12, atol=1e-12
+        )
+
+    def test_round_trip_restores_coords_verbatim(self, valid_spectrum_da):
+        """Length-preserving ops reassign the original coordinate exactly."""
+        result = _time_scale_probe(valid_spectrum_da)
+        np.testing.assert_array_equal(
+            result.coords[DIMS.frequency].values,
+            valid_spectrum_da.coords[DIMS.frequency].values,
+        )
+
+    def test_ppm_round_trips_to_ppm(self, valid_spectrum_da):
+        """A ppm spectrum comes back as a ppm spectrum with its exact coordinates."""
+        ppm = valid_spectrum_da.xmr.to_ppm()
+        result = _time_scale_probe(ppm)
+        assert DIMS.chemical_shift in result.dims
+        assert DIMS.time not in result.dims
+        np.testing.assert_array_equal(
+            result.coords[DIMS.chemical_shift].values,
+            ppm.coords[DIMS.chemical_shift].values,
+        )
+        np.testing.assert_allclose(result.values, ppm.values * 2.0, rtol=1e-12, atol=1e-12)
+
+    def test_round_trip_preserves_attrs(self, valid_spectrum_da):
+        """The full round trip must not drop ``.attrs`` (issue #21 guarantee)."""
+        result = _time_scale_probe(valid_spectrum_da)
+        for key, value in valid_spectrum_da.attrs.items():
+            assert result.attrs.get(key) == value
+
+    def test_length_change_recomputes_coords(self, valid_spectrum_da):
+        """Length-changing ops keep converter-recomputed coordinates (finer grid)."""
+        n = valid_spectrum_da.sizes[DIMS.frequency]
+        result = _time_pad_probe(valid_spectrum_da)
+        assert DIMS.frequency in result.dims
+        assert result.sizes[DIMS.frequency] == 2 * n
+        freqs = result.coords[DIMS.frequency].values
+        assert np.all(np.diff(freqs) > 0)  # monotonic physical axis
+
+    def test_real_spectrum_raises(self, valid_spectrum_da):
+        """Real-valued spectral input has no valid FID behind it — loud error."""
+        real_spec = valid_spectrum_da.copy(data=valid_spectrum_da.values.real)
+        with pytest.raises(ValueError, match="real-valued"):
+            _time_scale_probe(real_spec)
+
+    def test_explicit_foreign_dim_passes_through(self):
+        """An explicitly-requested non-domain dim disables coercion entirely."""
+        rng = np.random.default_rng()
+        kspace = xr.DataArray(
+            rng.standard_normal(32) + 1j * rng.standard_normal(32),
+            dims=["kx"],
+            coords={"kx": np.arange(32)},
+        )
+        result = _time_scale_probe(kspace, dim="kx")
+        assert list(result.dims) == ["kx"]
+        np.testing.assert_allclose(result.values, kspace.values * 2.0)
+
+    def test_decorator_stamps_introspection_metadata(self):
+        """The wrapper must expose ``__xmris_domain__`` for the architecture tests."""
+        assert _time_scale_probe.__xmris_domain__ == (TIME_DIMS, True)
+        assert _ensure_spectral_probe.__xmris_domain__ == (SPECTRAL_DIMS, False)
+
+
+# =============================================================================
+# 13. Converter Round Trip (the guarantee the domain engine relies on)
+# =============================================================================
+
+
+class TestConverterRoundTrip:
+    """``to_fid(to_spectrum(fid)) ≈ fid`` — unitary transforms, physical coords.
+
+    The ``computes_in`` contract is only sound because the converter pair is
+    numerically unitary (``norm="ortho"``) and reconstructs the physical time
+    axis. Pin that guarantee down to tight tolerances.
+    """
+
+    def test_values_round_trip(self, valid_fid_da):
+        """Data values must survive the round trip to ~1e-12."""
+        rt = to_fid(to_spectrum(valid_fid_da))
+        np.testing.assert_allclose(rt.values, valid_fid_da.values, rtol=0, atol=1e-12)
+
+    def test_time_coords_round_trip(self, valid_fid_da):
+        """The reconstructed time axis must match the original dwell spacing."""
+        rt = to_fid(to_spectrum(valid_fid_da))
+        np.testing.assert_allclose(
+            rt.coords[DIMS.time].values,
+            valid_fid_da.coords[DIMS.time].values,
+            rtol=0,
+            atol=1e-12,
+        )
+
+
+# =============================================================================
+# 14. Integration: autophase domain-agnostic pilot
 # =============================================================================
 
 
 class TestAutophasePilot:
-    """End-to-end: ``autophase`` wired to ``@ensures_domain`` + ``@resolves_spectral_dim``.
+    """End-to-end: ``autophase`` wired to ``@ensures_domain`` (funnel + merged resolution).
 
     Proves the taxonomy works through the real accessor: a FID is auto-FFT'd,
     phased, and returned as a spectrum with metadata intact; a spectrum is
@@ -864,6 +1123,13 @@ class TestAutophasePilot:
         assert DIMS.frequency in result.dims
 
     def test_autophase_respects_explicit_dim(self, valid_spectrum_da):
-        """An explicit ``dim`` is honored (resolver does not override it)."""
+        """An explicit ``dim`` is honored (resolution never overrides it)."""
         result = valid_spectrum_da.xmr.autophase(dim=DIMS.frequency)
         assert DIMS.frequency in result.dims
+
+    def test_autophase_on_ppm_stays_ppm(self, valid_spectrum_da):
+        """A ppm spectrum resolves to ``chemical_shift`` and stays in ppm."""
+        ppm = valid_spectrum_da.xmr.to_ppm()
+        result = ppm.xmr.autophase()
+        assert DIMS.chemical_shift in result.dims
+        assert DIMS.time not in result.dims


### PR DESCRIPTION
First implementation PR for the #63 resolution (see the design article in #76). Engine only — the rollout to `apodize_*`/`zero_fill`/`baseline_als` follows in the next PR.

## What changed

**The domain tier is now two named decorators over one private engine** (`core/validation.py`):

- `@ensures_domain(X)` — *funnel*: coerce into the domain via the standard converters, leave the result there (pilot `autophase` behavior, unchanged).
- `@computes_in(X)` — *domain-preserving*: round trip through the domain and hand the result back in the input's representation, reassigning the original coordinates **verbatim** when the op preserved the length (protects dead-time offsets); length-changing ops keep converter-recomputed coords.

**Dim resolution is merged into the domain decorators.** `@resolves_spectral_dim` is deleted: its candidate set was always identical to the domain decorator's argument, and the coerce-before-resolve stacking order was load-bearing but unasserted. Merged, the ordering hazard is structurally gone. The helper generalizes to `_resolve_dim(da, candidates)` (widgets updated).

**Latent dwell-time bug fixed.** Coercing a ppm spectrum toward the time domain previously computed the dwell time from *ppm* spacing (`to_fid` assumes Hz) — off by ~the reference frequency. The engine now routes `chemical_shift → to_hz → to_fid`, and restores `→ to_spectrum → to_ppm`. The same fix is applied to `autophase`'s internal `lb>0` smoothing leg, which had the identical bug. Regression-tested.

**Guardrails:** real-valued spectral input is rejected on any spectral→time coercion (complexity gate — no valid FID exists behind e.g. `baseline_als` output); the ppm leg inherits `@requires_attrs` with its copy-pasteable fix; an explicitly-requested foreign dim (e.g. `zero_fill(dim="kx")`) passes through untouched under `computes_in`.

**Layering:** `requires_attrs` ported to first-arg-DataArray style so all tiers stack on free functions; `to_ppm`/`to_hz` moved to `processing/referencing.py` free functions (accessor delegates thinly; exported as `xmris.to_ppm`/`xmris.to_hz`).

**Architecture tests:** `TestComputesIn` (round trip, verbatim coords, gate, passthrough), `TestConverterRoundTrip` (`to_fid(to_spectrum(fid)) ≈ fid` @ 1e-12), funnel ppm-leg + dwell-time regression, and `TestDomainDimRule` — the package-wide biconditional *`dim=None` ⟺ multi-label-domain-decorated*, replacing the autophase carve-out.

## Verification

- `uv run test`: **164 passed** (architecture + all notebooks)
- `uv run ruff check .`: 4 pre-existing errors only (tracked in #71), none in touched files
- `uv run mypy src/xmris`: 62 errors vs **70 on main** (net −8; no new errors)
- REPL smoke: funnel FID→spectrum, ppm→ppm, `computes_in` ppm round trip with verbatim coords, both gates, docstring injection — all as specified

Refs #63, #42. Merge before #76 (article) and the rollout PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)