### PR TITLE
feat: roll out domain contracts — apodize/zero_fill preserve, baseline funnels (#63)

### DIFF
--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -44,6 +44,8 @@ project:
           title: 3c. Domain-Agnostic Autophase
         - file: notebooks/pipeline/baseline.md
           title: 4. Baseline Correction
+        - file: notebooks/pipeline/domain_contracts.md
+          title: 5. Domain Contracts
 
     # 3. GROUP: Advanced Quantification
     - title: Spectral Fitting & Simulation

--- a/docs/notebooks/pipeline/domain_agnostic_autophase.md
+++ b/docs/notebooks/pipeline/domain_agnostic_autophase.md
@@ -9,6 +9,9 @@ kernelspec:
   name: python3
 ---
 
+(domain-agnostic-autophase)=
+# Domain-Agnostic Autophase
+
 ```{code-cell} ipython3
 :tags: [remove-cell]
 
@@ -19,9 +22,6 @@ import matplotlib_inline.backend_inline
 matplotlib_inline.backend_inline.set_matplotlib_formats("retina")
 plt.rcParams["figure.dpi"] = 100
 ```
-
-(domain-agnostic-autophase)=
-# Domain-Agnostic Autophase
 
 Phase correction is a *frequency-domain* operation, but the data you have in hand
 is often a *time-domain* FID. Classically that forces you to remember the ritual:
@@ -37,28 +37,32 @@ into the frequency domain for you, then phases:
 spectrum = fid.xmr.autophase()   # auto-FFT happens under the hood
 ```
 
-This is powered by the **`requires` → `resolves` → `ensures`** decorator taxonomy,
-a ladder of increasing *agency* that each processing function stacks to declare —
-and satisfy — its preconditions.
+This is powered by the **domain-contract taxonomy**: a gate decorator plus two
+domain decorators sharing one engine, each declaring a function's contract at
+the definition site.
 
-| Tier | Decorator | What it does | Cost |
-|------|-----------|--------------|------|
+| Tier | Decorator | Contract | Cost |
+|------|-----------|----------|------|
 | gate | `@requires_attrs(...)` | raises if metadata is missing | $O(1)$ |
-| infer | `@resolves_spectral_dim` | fills a missing `dim` by introspection | $O(1)$ |
-| transform | `@ensures_domain(...)` | auto-FFTs into the required domain | $O(N \log N)$ |
+| domain — funnel | `@ensures_domain(...)` | transforms into the home domain, result **stays** there | $O(N \log N)$ |
+| domain — preserving | `@computes_in(...)` | round-trips through the home domain, representation **restored** | $O(N \log N)$ |
 
-`autophase` wears the two upper tiers:
+Both domain decorators also *resolve* the working axis: a `dim=None` argument is
+filled with the spectral dimension actually present (`frequency` [Hz] or
+`chemical_shift` [ppm]) — an explicit `dim` is never overridden.
+
+`autophase` is a **funnel** operation — you phase in order to inspect the
+spectrum, so the result lands there:
 
 ```mermaid
 flowchart TD
     A["fid.xmr.autophase()"] --> B{"@ensures_domain(SPECTRAL_DIMS)"}
     B -- "time-domain FID" --> C["auto-FFT → spectrum"]
     B -- "already spectral" --> D["pass through (no FFT)"]
-    C --> E{"@resolves_spectral_dim"}
+    C --> E["resolve dim: frequency / chemical_shift"]
     D --> E
-    E -- "dim is None" --> F["detect frequency / chemical_shift"]
-    F --> G["phase correction"]
-    G --> H["phased spectrum"]
+    E --> F["phase correction"]
+    F --> G["phased spectrum"]
 ```
 
 A FID $s(t)$ and its spectrum $S(\nu)$ are a Fourier pair, $S(\nu) = \mathcal{F}\{s(t)\}$,
@@ -71,10 +75,15 @@ $$
 `@ensures_domain` supplies the $\mathcal{F}$ so you can start from either side.
 
 ::: {note}
-The result is **left in the operating domain**: a FID in gives a *spectrum* out.
-The conversion is honest and self-documenting — it shows up in `.dims` — and no
-redundant round-trip FFTs are inserted. If you want the FID back, call
-`.xmr.to_fid()` explicitly.
+The result is **left in the operating domain**: a FID in gives a *spectrum* out —
+that is the funnel contract. The conversion is honest and self-documenting — it
+shows up in `.dims` — and no redundant round-trip FFTs are inserted. If you want
+the FID back, call `.xmr.to_fid()` explicitly.
+
+Domain-preserving operations (`apodize_exp`, `zero_fill`, …) make the opposite
+promise: your representation comes back. See
+[The Two Domains](../../explanation/domains.md) for the design rationale and
+[Domain Contracts in Action](#domain-contracts) for the executable proof.
 :::
 
 ::: {dropdown} Imports & a small plotting helper

--- a/docs/notebooks/pipeline/domain_contracts.md
+++ b/docs/notebooks/pipeline/domain_contracts.md
@@ -1,0 +1,266 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (xmris)
+  language: python
+  name: python3
+---
+
+(domain-contracts)=
+# Domain Contracts in Action
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+import matplotlib.pyplot as plt
+import matplotlib_inline.backend_inline
+
+# Crisp retina output + sane default DPI for the rendered docs
+matplotlib_inline.backend_inline.set_matplotlib_formats("retina")
+plt.rcParams["figure.dpi"] = 150
+```
+
+Every xmris operation makes a **contract about what you get back**: the output
+domain is a pure function of the operation and the input domain — never a
+surprise. This page *proves* the two contracts executable-style; the design
+story lives in [The Two Domains](../../explanation/domains.md).
+
+| You call | on a FID (`time`) | on a spectrum (`frequency`/`chemical_shift`) |
+|---|---|---|
+| `apodize_exp()`, `zero_fill()` | FID ✅ | spectrum ✅ (round trip inside) |
+| `autophase()`, `baseline_als()` | spectrum (funnel ⤵) | spectrum |
+| `to_spectrum()`, `to_fid()` | explicit conversion | explicit conversion |
+
+- **Domain-preserving ops** compute in the time domain but *hand back what you
+  gave them* — same physics either side.
+- **Funnel ops** are only meaningful on a spectrum, so their result *lands*
+  there, whatever you feed them.
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import xarray as xr
+
+import xmris  # noqa: F401  (registers the .xmr accessor)
+from xmris.fitting.simulation import simulate_fid
+```
+
+(domain-contracts-data)=
+## 1. A distorted, time-domain FID
+
+```{code-cell} ipython3
+fid = simulate_fid(
+    amplitudes=[100, 70, 45],
+    chemical_shifts=[2.0, 3.5, 5.0],
+    reference_frequency=123.2,
+    carrier_ppm=3.0,
+    dampings=[25, 25, 30],
+    phases=np.deg2rad(65),   # zero-order phase error, baked into the FID
+    target_snr=250,
+    n_points=2048,
+)
+fid.dims   # -> ('time',)
+```
+
+(domain-contracts-preserving)=
+## 2. Domain-preserving: same physics, either side
+
+Multiplying an FID by $e^{-\pi\,\mathrm{lb}\,t}$ *is* convolving its spectrum
+with a Lorentzian of width $\mathrm{lb}$ Hz — one operation, two views. So
+`apodize_exp` never changes your representation:
+
+```{code-cell} ipython3
+spectrum = fid.xmr.to_spectrum()
+
+fid_smooth = fid.xmr.apodize_exp(lb=3)         # FID in      -> FID out
+spec_smooth = spectrum.xmr.apodize_exp(lb=3)   # spectrum in -> spectrum out
+
+print("FID path      :", fid.dims, "->", fid_smooth.dims)
+print("spectrum path :", spectrum.dims, "->", spec_smooth.dims)
+```
+
+And the two paths are *numerically the same operation* — transforming the
+apodized FID reproduces the apodized spectrum to machine precision:
+
+```{code-cell} ipython3
+fig, ax = plt.subplots(figsize=(7, 3))
+ax.plot(spec_smooth["frequency"], np.real(spec_smooth), lw=2.5, label="spectrum path")
+ax.plot(
+    spec_smooth["frequency"],
+    np.real(fid_smooth.xmr.to_spectrum()),
+    lw=1.0,
+    ls="--",
+    label="FID path → to_spectrum()",
+)
+ax.set_xlabel("Frequency (Hz)")
+ax.set_ylabel("Re{S}")
+ax.legend()
+ax.grid(True, alpha=0.3)
+ax.set_title("Two entry domains, one operation")
+plt.tight_layout()
+plt.show()
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# STRICT TESTS: apodize_exp domain-preserving contract
+from xmris.core.config import ATTRS, DIMS
+
+# (a) Representation preserved on both paths.
+assert list(fid_smooth.dims) == [DIMS.time]
+assert list(spec_smooth.dims) == [DIMS.frequency]
+
+# (b) The two paths are the same operation (unitary round trip, ~1e-12).
+np.testing.assert_allclose(
+    spec_smooth.values,
+    fid_smooth.xmr.to_spectrum().values,
+    rtol=1e-10,
+    atol=1e-10 * float(np.abs(spec_smooth).max()),
+    err_msg="spectrum-path and FID-path apodization must be numerically identical",
+)
+
+# (c) Coordinates restored verbatim on the round-tripped path.
+np.testing.assert_array_equal(
+    spec_smooth.coords[DIMS.frequency].values,
+    spectrum.coords[DIMS.frequency].values,
+    err_msg="round trip must reassign the original frequency coordinates verbatim",
+)
+
+# (d) Attrs survived and the lineage parameter was stamped on both paths.
+assert spec_smooth.attrs[ATTRS.apodization_lb] == 3
+assert fid_smooth.attrs[ATTRS.apodization_lb] == 3
+assert spec_smooth.attrs[ATTRS.reference_frequency] == 123.2
+```
+
++++
+
+The same contract holds for `zero_fill`: zero-padding the FID *is* interpolating
+the spectrum onto a finer grid — so calling it **on a spectrum** hands back a
+spectrum with more points, not a FID:
+
+```{code-cell} ipython3
+spec_fine = spectrum.xmr.zero_fill(target_points=4096)
+print(spectrum.sizes, "->", spec_fine.sizes)
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# STRICT TESTS: zero_fill on a spectrum (length-changing round trip)
+assert list(spec_fine.dims) == [DIMS.frequency]
+assert spec_fine.sizes[DIMS.frequency] == 4096
+_freqs = spec_fine.coords[DIMS.frequency].values
+assert np.all(np.diff(_freqs) > 0), "recomputed frequency axis must be monotonic"
+assert spec_fine.attrs[ATTRS.reference_frequency] == 123.2
+```
+
+(domain-contracts-funnel)=
+## 3. Funnel: the canonical pipeline, one FFT
+
+Phasing and baseline correction exist *for* the spectrum — their results land
+there. That makes the classic monotonic pipeline read naturally, with exactly
+**one** Fourier transform executing at the funnel boundary:
+
+```{code-cell} ipython3
+result = (
+    fid.xmr.zero_fill(target_points=4096)   # time-domain home: no transform
+       .xmr.apodize_exp(lb=3)               # time-domain home: no transform
+       .xmr.autophase()                     # funnel: FID -> spectrum, stays
+       .xmr.baseline_als()                  # already spectral: no transform
+)
+print("pipeline result:", result.dims, "| real-valued:", not np.iscomplexobj(result.values))
+```
+
+```{code-cell} ipython3
+ppm = result.xmr.to_ppm()
+fig, ax = plt.subplots(figsize=(7, 3))
+ax.plot(ppm["chemical_shift"], ppm.values, lw=1.5)
+ax.axhline(0, color="red", ls="--", alpha=0.4)
+ax.set_xlabel("Chemical shift (ppm)")
+ax.set_ylabel("Re{S}")
+ax.invert_xaxis()
+ax.grid(True, alpha=0.3)
+ax.set_title("zero_fill → apodize → autophase → baseline, straight from the FID")
+plt.tight_layout()
+plt.show()
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# STRICT TESTS: the canonical pipeline
+# (a) Landed in the spectral domain (funnel), real-valued after baseline.
+assert DIMS.frequency in result.dims
+assert DIMS.time not in result.dims
+assert not np.iscomplexobj(result.values)
+assert result.sizes[DIMS.frequency] == 4096
+
+# (b) The full lineage of quantitative parameters was recorded.
+assert result.attrs[ATTRS.apodization_lb] == 3
+assert ATTRS.phase_p0 in result.attrs
+assert ATTRS.phase_p1 in result.attrs
+
+# (c) Physics metadata survived the whole chain (issue #21 guarantee).
+assert result.attrs[ATTRS.reference_frequency] == 123.2
+assert result.attrs[ATTRS.carrier_ppm] == 3.0
+```
+
+(domain-contracts-guardrails)=
+## 4. Guardrails
+
+**One-way data fails loudly.** `baseline_als` discards the imaginary component,
+so no valid FID exists behind its output — a time-domain op on it refuses
+rather than inventing one:
+
+```{code-cell} ipython3
+try:
+    result.xmr.apodize_exp(lb=2)
+except ValueError as err:
+    print(err)
+```
+
+**Explicit dims pass through.** Automatic conversion only triggers when your
+call targets an operation's home domain — naming another axis (k-space, say)
+leaves the data untouched:
+
+```{code-cell} ipython3
+rng = np.random.default_rng(42)
+kspace = xr.DataArray(
+    rng.standard_normal((8, 8)),
+    dims=["kx", "ky"],
+    coords={"kx": np.arange(8), "ky": np.arange(8)},
+)
+kfilled = kspace.xmr.zero_fill(dim="kx", target_points=16, position="symmetric")
+print(dict(kspace.sizes), "->", dict(kfilled.sizes))
+```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# STRICT TESTS: guardrails
+# (a) Complexity gate: real-valued spectral data cannot go to the time domain.
+_raised = False
+try:
+    result.xmr.apodize_exp(lb=2)
+except ValueError as _err:
+    _raised = True
+    assert "real-valued" in str(_err)
+assert _raised, "the complexity gate must reject real-valued spectral input"
+
+# (b) Passthrough: explicit foreign dim disables coercion entirely.
+assert list(kfilled.dims) == ["kx", "ky"]
+assert kfilled.sizes["kx"] == 16 and kfilled.sizes["ky"] == 8
+```
+
++++
+
+::: {seealso}
+[The Two Domains](../../explanation/domains.md) — the design rationale, the full
+contract table, and the contributor decision tree.
+[Domain-Agnostic Autophase](#domain-agnostic-autophase) — the funnel contract in
+detail.
+:::

--- a/src/xmris/core/accessor.py
+++ b/src/xmris/core/accessor.py
@@ -534,7 +534,7 @@ class XmrisProcessingMixin:
 
     def baseline_als(
         self,
-        dim: str = DIMS.frequency,
+        dim: str | None = None,
         lam: float = 1e5,
         p: float = 0.001,
         n_iter: int = 10,
@@ -554,9 +554,10 @@ class XmrisProcessingMixin:
 
         Parameters
         ----------
-        dim : str, optional
-            The coordinate dimension along which to apply correction.
-            Defaults to `DIMS.frequency`.
+        dim : str or None, optional
+            The spectral dimension along which to apply correction. If ``None``
+            (default) it is resolved automatically to the spectral dim present
+            (Hz or ppm); time-domain input is transformed to a spectrum first.
         lam : float, optional
             The smoothness penalty ($\lambda$). Higher values result in a stiffer,
             flatter baseline. Typical NMR ranges are 10,000 to 10,000,000.

--- a/src/xmris/processing/baseline.py
+++ b/src/xmris/processing/baseline.py
@@ -3,8 +3,9 @@ import xarray as xr
 from scipy import sparse
 from scipy.sparse.linalg import spsolve
 
-from xmris.core.config import ATTRS, DIMS
+from xmris.core.config import ATTRS, SPECTRAL_DIMS
 from xmris.core.utils import _check_dims
+from xmris.core.validation import ensures_domain
 
 
 def _als_core(y: np.ndarray, lam: float, p: float, n_iter: int) -> np.ndarray:
@@ -40,9 +41,10 @@ def _als_core(y: np.ndarray, lam: float, p: float, n_iter: int) -> np.ndarray:
     return z
 
 
+@ensures_domain(SPECTRAL_DIMS)
 def baseline_als(
     da: xr.DataArray,
-    dim: str = DIMS.frequency,
+    dim: str | None = None,
     lam: float = 1e5,
     p: float = 0.001,
     n_iter: int = 10,
@@ -66,9 +68,11 @@ def baseline_als(
     da : xr.DataArray
         The input spectrum. Can be complex-valued and N-dimensional. If complex,
         the real component is extracted automatically.
-    dim : str, optional
-        The coordinate dimension along which to apply correction.
-        Defaults to `DIMS.frequency`.
+    dim : str or None, optional
+        The spectral dimension along which to apply correction. If ``None``
+        (default) it is resolved automatically to the spectral dim present
+        (``frequency`` [Hz] or ``chemical_shift`` [ppm]); time-domain input
+        is transformed to a spectrum first.
     lam : float, optional
         The smoothness penalty ($\lambda$). Higher values result in a stiffer,
         flatter baseline. Typical NMR ranges are 10,000 to 10,000,000.
@@ -87,6 +91,9 @@ def baseline_als(
         parameters ($\lambda$, $p$, iterations) are appended to the dataset
         attributes to preserve data lineage.
     """
+    # `dim` is guaranteed non-None here by @ensures_domain's merged resolution;
+    # validate that an explicitly-passed dim actually exists (only None is filled).
+    assert dim is not None
     _check_dims(da, dim, "baseline_als")
 
     # 1. Enforce real-valued math and intentionally discard the imaginary part

--- a/src/xmris/processing/fid.py
+++ b/src/xmris/processing/fid.py
@@ -1,8 +1,9 @@
 import numpy as np
 import xarray as xr
 
-from xmris.core.config import ATTRS, COORDS, DIMS
+from xmris.core.config import ATTRS, COORDS, DIMS, TIME_DIMS
 from xmris.core.utils import _check_dims, as_variable
+from xmris.core.validation import computes_in
 from xmris.processing.fourier import fft, fftshift, ifft, ifftshift
 
 
@@ -42,9 +43,7 @@ def to_spectrum(
     return da_spectrum
 
 
-def to_fid(
-    da: xr.DataArray, dim: str = DIMS.frequency, out_dim: str = DIMS.time
-) -> xr.DataArray:
+def to_fid(da: xr.DataArray, dim: str = DIMS.frequency, out_dim: str = DIMS.time) -> xr.DataArray:
     """
     Convert a frequency-domain spectrum back to a time-domain FID.
 
@@ -102,6 +101,7 @@ def to_fid(
     return da_fid
 
 
+@computes_in(TIME_DIMS)
 def apodize_exp(da: xr.DataArray, dim: str = DIMS.time, lb: float = 1.0) -> xr.DataArray:
     """
     Apply an exponential weighting filter function for line broadening.
@@ -144,6 +144,7 @@ def apodize_exp(da: xr.DataArray, dim: str = DIMS.time, lb: float = 1.0) -> xr.D
     return da_apodized
 
 
+@computes_in(TIME_DIMS)
 def apodize_lg(
     da: xr.DataArray, dim: str = DIMS.time, lb: float = 1.0, gb: float = 1.0
 ) -> xr.DataArray:
@@ -198,6 +199,7 @@ def apodize_lg(
     return da_apodized
 
 
+@computes_in(TIME_DIMS)
 def zero_fill(
     da: xr.DataArray,
     dim: str = DIMS.time,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1133,3 +1133,102 @@ class TestAutophasePilot:
         result = ppm.xmr.autophase()
         assert DIMS.chemical_shift in result.dims
         assert DIMS.time not in result.dims
+
+
+# =============================================================================
+# 15. Domain Contract Rollout (which ops carry which contract)
+# =============================================================================
+
+
+class TestDomainRollout:
+    """Pin every operation's domain contract (or deliberate absence of one).
+
+    The op-class table from the domain-contracts design: funnel ops land in
+    their home domain, domain-preserving physics ops restore the input
+    representation, and converters/primitives/fitting stay undecorated with
+    explicit domain handling.
+    """
+
+    def test_funnel_ops(self):
+        """``autophase`` and ``baseline_als`` carry the funnel contract."""
+        from xmris.processing.baseline import baseline_als
+        from xmris.processing.phasing import autophase
+
+        for func in (autophase, baseline_als):
+            assert getattr(func, "__xmris_domain__", None) == (SPECTRAL_DIMS, False), func.__name__
+
+    def test_domain_preserving_ops(self):
+        """The apodizers and ``zero_fill`` carry the domain-preserving contract."""
+        from xmris.processing.fid import apodize_exp, apodize_lg, zero_fill
+
+        for func in (apodize_exp, apodize_lg, zero_fill):
+            assert getattr(func, "__xmris_domain__", None) == (TIME_DIMS, True), func.__name__
+
+    def test_undecorated_by_design(self):
+        """Converters, primitives, and fitting must NOT auto-convert."""
+        from xmris.fitting.amares import fit_amares
+        from xmris.processing.fourier import fft, ifft
+        from xmris.processing.phasing import phase
+        from xmris.processing.referencing import to_hz, to_ppm
+        from xmris.vendor.bruker import remove_digital_filter
+
+        undecorated = (
+            to_spectrum,
+            to_fid,
+            to_ppm,
+            to_hz,
+            fft,
+            ifft,
+            phase,
+            fit_amares,
+            remove_digital_filter,
+        )
+        for func in undecorated:
+            assert not hasattr(func, "__xmris_domain__"), func.__name__
+
+    def test_baseline_accessor_mirrors_dim_none(self):
+        """The accessor forwarder mirrors ``baseline_als``'s ``dim=None`` signature."""
+        import inspect
+
+        from xmris.core.accessor import XmrisAccessor
+
+        sig = inspect.signature(XmrisAccessor.baseline_als)
+        assert sig.parameters["dim"].default is None
+
+    # --- behavior smoke through the real accessor ------------------------------
+
+    def test_spectrum_apodize_stays_spectrum(self, valid_spectrum_da):
+        """Line-broadening a spectrum hands back a spectrum (round trip inside)."""
+        result = valid_spectrum_da.xmr.apodize_exp(lb=5.0)
+        assert DIMS.frequency in result.dims
+        assert DIMS.time not in result.dims
+
+    def test_fid_baseline_returns_real_spectrum(self, valid_fid_da):
+        """Baseline on a FID funnels: lands as a real-valued spectrum."""
+        result = valid_fid_da.xmr.baseline_als()
+        assert DIMS.frequency in result.dims
+        assert not np.iscomplexobj(result.values)
+
+    def test_ppm_baseline_stays_ppm(self, valid_spectrum_da):
+        """Baseline on a ppm spectrum resolves ``chemical_shift`` and stays ppm."""
+        ppm = valid_spectrum_da.xmr.to_ppm()
+        result = ppm.xmr.baseline_als()
+        assert DIMS.chemical_shift in result.dims
+
+    def test_baseline_then_apodize_raises(self, valid_spectrum_da):
+        """One-way data downstream of baseline is caught by the complexity gate."""
+        corrected = valid_spectrum_da.xmr.baseline_als()
+        with pytest.raises(ValueError, match="real-valued"):
+            corrected.xmr.apodize_exp(lb=2.0)
+
+    def test_kspace_zero_fill_passes_through(self):
+        """An explicit non-domain dim disables coercion — k-space stays k-space."""
+        rng = np.random.default_rng()
+        kspace = xr.DataArray(
+            rng.standard_normal((8, 8)),
+            dims=["kx", "ky"],
+            coords={"kx": np.arange(8), "ky": np.arange(8)},
+        )
+        result = kspace.xmr.zero_fill(dim="kx", target_points=16, position="symmetric")
+        assert result.sizes["kx"] == 16
+        assert list(result.dims) == ["kx", "ky"]


### PR DESCRIPTION
Second implementation PR for the #63 resolution — applies the engine from #77 to the operation classes. **Stacked on #77** (base branch: `refactor/63-domain-engine`); retarget to `main` after #77 merges.

## The contract table, now live

| Op | Decorator | FID in | Spectrum in |
|---|---|---|---|
| `apodize_exp` / `apodize_lg` / `zero_fill` | `@computes_in(TIME_DIMS)` | FID | **spectrum** (round trip inside, coords verbatim) |
| `autophase` / `baseline_als` | `@ensures_domain(SPECTRAL_DIMS)` | spectrum (funnel) | spectrum |
| converters, `phase`, `fft` family, `fit_amares`, `remove_digital_filter` | *(none — deliberate)* | explicit | explicit |

- `baseline_als` gains `dim=None` + merged resolution — ppm spectra now work by default (previously required `dim="chemical_shift"` explicitly); the accessor forwarder mirrors it.
- `zero_fill(dim="kx", position="symmetric")` on k-space passes through untouched (explicit-foreign-dim rule).
- `baseline_als(...)` → `apodize_exp(...)` chains are caught by the complexity gate with an explanatory error.

## Tests & docs

- `TestDomainRollout`: pins every op's contract stamp (`__xmris_domain__`) and the deliberate-undecorated list, plus accessor behavior smoke (spectrum-apodize stays spectrum, FID-baseline lands real spectral, ppm-baseline stays ppm, gate chain, k-space passthrough).
- New notebook `docs/notebooks/pipeline/domain_contracts.md` (TOC: "5. Domain Contracts"): executable proof — FID-path ≡ spectrum-path apodization at 1e-10, verbatim coordinate restore, finer-grid zero-fill, the canonical one-FFT pipeline (`zero_fill → apodize_exp → autophase → baseline_als` straight from a FID), and both guardrails.
- `domain_agnostic_autophase.md` prose updated to the two-decorator taxonomy (merged resolution in the diagram) and cross-linked to the design article.

## Verification

- `uv run test`: **174 passed** (164 on the engine branch + 10)
- `uv run mypy src/xmris`: 62 errors — unchanged vs engine branch, still −8 vs main
- ruff: only the 4 pre-existing errors (#71)

Note: the cross-links to `explanation/domains.md` resolve once #76 (the design article) lands — suggested merge order **#77 → #76 → this**.

Refs #63, #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)