### PR TITLE
feat: set_options strict mode + contributor-docs alignment (#63)

### DIFF
--- a/.claude/skills/new-processing-method/SKILL.md
+++ b/.claude/skills/new-processing-method/SKILL.md
@@ -18,8 +18,9 @@ Add the pure math to the right domain module under `src/xmris/` — `processing/
 Rules that are easy to get wrong here:
 - **Functional purity** — never mutate in place; always return a new `xr.DataArray`/`xr.Dataset`.
 - **No magic strings** — import `ATTRS`/`DIMS`/`COORDS`/`VARS` from `xmris.core.config`; never hardcode `"time"`, `"reference_frequency"`, etc. inside the package.
-- **Config-constant defaults** — a `dim` argument defaults to the config constant (`dim: str = DIMS.time`), never `None`.
-- **Validation** — guard required attrs with `@requires_attrs(...)`; validate dims with `_check_dims(self._obj, dim, "func_name")`.
+- **Domain contract** — decide it up front (see `docs/explanation/domains.md`): only meaningful in one domain and consumed there (e.g. phasing, baseline) → `@ensures_domain(DOMAIN)` (funnel: result stays there); same physics in both domains and length-preserving math meaningful from either side (e.g. apodization, zero-fill) → `@computes_in(DOMAIN)` (representation restored); converter/primitive/fitting → no domain decorator, transforms stay explicit. Route any conversion through `to_spectrum`/`to_fid`/`to_ppm`/`to_hz` — never inline `fft`/`ifft`.
+- **Dim defaults (the biconditional)** — a `dim` argument defaults to the config constant (`dim: str = DIMS.time`), EXCEPT it defaults to `None` iff the function is domain-decorated with a multi-label domain (`SPECTRAL_DIMS`) — the decorator resolves Hz vs ppm. Enforced by `TestDomainDimRule`.
+- **Validation** — guard required attrs with `@requires_attrs(...)` (free-function style: first arg is the DataArray); validate dims with `_check_dims(da, dim, "func_name")`.
 - **Coordinates** — build new coords with `as_variable(TERM, dim, data)` + `.assign_coords(...)`, don't hand-mutate `.attrs`.
 - **Lineage** — append only quantitative parameters to `.attrs` (e.g. `phase_p0=15.0`); no boolean/string flags.
 - **Docstring** — NumPy convention, fully-typed signature (feeds the quartodoc API docs).

--- a/.claude/skills/new-widget/SKILL.md
+++ b/.claude/skills/new-widget/SKILL.md
@@ -42,8 +42,8 @@ Rules that are easy to get wrong here:
   button must emit a reproducible `.xmr.<method>(...)` snippet. If that method
   doesn't exist yet, add it first (use the `new-processing-method` skill).
 - **No name sniffing / no magic strings** — resolve the axis with
-  `if dim is None: dim = _resolve_spectral_dim(da)` then `_check_dims(da, dim, "<factory>")`;
-  import `DIMS`/`ATTRS`/`COORDS` from `xmris.core.config` when you need vocabulary.
+  `if dim is None: dim = _resolve_dim(da, SPECTRAL_DIMS)` then `_check_dims(da, dim, "<factory>")`;
+  import `DIMS`/`ATTRS`/`COORDS`/`SPECTRAL_DIMS` from `xmris.core.config` when you need vocabulary.
 - **Labels from lineage** — build axis labels from `da.coords[dim].attrs`
   (`long_name`/`units`), never a hardcoded string.
 - **Functional purity** — never mutate the input; read from it only.

--- a/docs/contributing/ai_context.md
+++ b/docs/contributing/ai_context.md
@@ -23,7 +23,8 @@ Functions are strictly segregated into domain-specific nested modules under the 
 
 * **Internal Modules (`src/xmris/core/` and beyond):**
     * `config.py`: Contains the global singletons (`ATTRS`, `DIMS`, `COORDS`, `VARS`) which serve as the single source of truth for xarray string keys and metadata.
-    * `validation.py`: Contains the `@requires_attrs` decorator.
+    * `validation.py`: Contains the validation decorators — `@requires_attrs` (gate) and the domain decorators `@ensures_domain` (funnel) / `@computes_in` (domain-preserving). See `docs/explanation/domains.md` for the contract design.
+    * `options.py`: Contains `set_options` (e.g. `auto_convert` strict mode).
     * `processing/`: Core mathematical transforms (e.g., `fourier.py`, `fid.py`, `phase.py`).
     * `vendor/`: Hardware-specific sanitization (e.g., `bruker.py`).
     * `fitting/`: Mathematical modeling (e.g., `amares.py`).
@@ -39,9 +40,11 @@ Whenever you generate a new function for `xmris`, you MUST follow these rules:
 3. **Data Lineage:** You MUST preserve coordinates and attributes. Append new processing parameters to `da.attrs` so the user has a permanent record of what was done to the data. Keep `.attrs` strictly to quantifiable mathematical parameters applied (e.g., `phase_p0=15.0`); do NOT use boolean flags or descriptive string flags (e.g., `phase_applied=True`) to avoid metadata bloat.
 4. **No Magic Strings (The Config):** NEVER hardcode raw strings for dimensions (like `"time"`) or attributes (like `"reference_frequency"`). Import the singletons `ATTRS`, `DIMS`, `COORDS`, and `VARS` from `xmris.core.config`. These contain `XmrisTerm` objects that evaluate as strings but carry `.unit` and `.long_name` metadata. Note that this only applies for INSIDE the xmris package and must not affect user code and examples. The user is free to use 'time' etc. to keep the entrance barrier low.
     * **CRITICAL:** If a new function requires a dimension, coordinate, or lineage attribute that is not already in the vocabulary, **you must propose adding it to `config.py`**. Furthermore, you must **explicitly highlight and mention** to the user in your response any new `ATTRS`, `DIMS`, or `COORDS` you are introducing so they can be tracked.
-5. **Accessor Defaults:** Method signatures that take a dimension must use the config constant directly as the default (e.g., `def func(self, dim: str = DIMS.time):`). Do NOT default to `None`.
-6. **Strict Validation:** * Validate hidden state (attributes) using the `@requires_attrs(...)` decorator.
-    * Validate dimensions explicitly inside the function using `_check_dims(self._obj, dim, "func_name")`.
+5. **Dimension Defaults (the biconditional):** A `dim` argument defaults to the config constant (e.g., `def func(da, dim: str = DIMS.time):`) — EXCEPT it must default to `None` **iff** the function is domain-decorated with a *multi-label* domain (`@ensures_domain(SPECTRAL_DIMS)` / `@computes_in(SPECTRAL_DIMS)`), whose merged resolution fills it at call time (`frequency` [Hz] vs `chemical_shift` [ppm]). This rule is mechanically enforced by `TestDomainDimRule` in `tests/test_core.py`.
+6. **Strict Validation & Domain Contracts:**
+    * Validate hidden state (attributes) using the `@requires_attrs(...)` decorator (free-function style: the first argument is the DataArray).
+    * Declare a domain-sensitive function's working domain with `@ensures_domain(DOMAIN)` (*funnel*: only meaningful in that domain, result stays there — e.g. `autophase`, `baseline_als`) or `@computes_in(DOMAIN)` (*domain-preserving*: same physics either side, representation restored — e.g. `apodize_exp`, `zero_fill`). Converters (`to_spectrum`/`to_fid`/`to_ppm`/`to_hz`), low-level primitives (`phase`, `fft` family), and fitting stay undecorated: their transforms are explicit by design. Never inline `fft`/`ifft` for domain handling — route through the converters. See `docs/explanation/domains.md` for the decision tree.
+    * Validate dimensions explicitly inside the function using `_check_dims(da, dim, "func_name")`.
 7. **Coordinate Building:** When creating new coordinates, do not manually mutate `.attrs`. Instead, use the internal `as_variable(TERM, dim, data)` helper to bundle data and metadata into a fully formed `xr.Variable` before assigning it via `.assign_coords()`.
 8. **MyST Markdown Links:** When writing documentation, never rely on auto-generated header slugs for internal links. Always define explicit MyST targets (e.g., `(my-target)=`) immediately above the header, and link to it via `[text](#my-target)`.
 
@@ -97,49 +100,55 @@ def as_variable(term: XmrisTerm, dims: str | tuple, data: np.ndarray) -> xr.Vari
     return xr.Variable(dims, data, attrs=attrs)
 ```
 
-(example accessor)
+(example processing function — decorators live on the free function; the accessor method is a thin `return example_func(self._obj, ...)` delegator)
 ```python
 import xarray as xr
 import numpy as np
 
-from xmris.core.config import ATTRS, DIMS, COORDS
-from xmris.core.validation import requires_attrs
-from xmris.core.accessor import _check_dims, as_variable
+from xmris.core.config import ATTRS, COORDS, DIMS, TIME_DIMS
+from xmris.core.utils import _check_dims, as_variable
+from xmris.core.validation import computes_in, requires_attrs
 
-# 1. Validate hidden state (attributes) at the door
+# 1. Validate hidden state (attributes) at the door, and declare the domain
+#    contract: computes_in = domain-preserving (representation restored);
+#    use ensures_domain for funnel ops. Omit for converters/primitives/fitting.
 @requires_attrs(ATTRS.reference_frequency)
-def example_func(self, dim: str = DIMS.time, scale: float = 1.0) -> xr.DataArray:
+@computes_in(TIME_DIMS)
+def example_func(da: xr.DataArray, dim: str = DIMS.time, scale: float = 1.0) -> xr.DataArray:
     """
     NumPy docstring here.
 
     Parameters
     ----------
+    da : xr.DataArray
+        The input time-domain data.
     dim : str, optional
         Dimension to process. Defaults to DIMS.time.
+        (Spectral ops decorated with a multi-label domain default to None instead
+        — the domain decorator resolves it. See Commandment 5.)
     scale : float, optional
         Scaling factor applied, by default 1.0.
     """
     # 2. Validate the action space (dimensions)
-    _check_dims(self._obj, dim, "example_func")
-    
+    _check_dims(da, dim, "example_func")
+
     # 3. Extract physics constants safely (decorator guarantees they exist)
-    mhz = self._obj.attrs[ATTRS.reference_frequency]
-    
+    mhz = da.attrs[ATTRS.reference_frequency]
+
     # 4. Perform pure mathematics
-    raw_data = self._obj.data
-    new_vals = (raw_data * scale) / mhz
-    
+    new_vals = (da.data * scale) / mhz
+
     # 5. Build new coordinates safely using XmrisTerm metadata
-    new_time_coords = self._obj.coords[dim].values * 2.0
+    new_time_coords = da.coords[dim].values * 2.0
     time_var = as_variable(COORDS.time, dim, new_time_coords)
-    
+
     # 6. Rebuild DataArray and assign variables
-    da_new = self._obj.copy(data=new_vals)
+    da_new = da.copy(data=new_vals)
     da_new = da_new.assign_coords({COORDS.time: time_var})
-    
+
     # 7. Preserve lineage by appending new processing parameters
     da_new.attrs[ATTRS.example_scale_applied] = scale
-    
+
     return da_new
 ```
 

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -139,6 +139,8 @@ project:
               title: Xarray Accessors
             - file: api_reference/core.config.md
               title: Global Config
+            - file: api_reference/core.options.md
+              title: Runtime Options
             - file: api_reference/core.utils.md
               title: Utilities
             - file: api_reference/core.validation.md

--- a/docs/notebooks/pipeline/baseline.md
+++ b/docs/notebooks/pipeline/baseline.md
@@ -81,7 +81,8 @@ fid_macro = simulate_fid(
     reference_frequency=REF_FREQ,
     spectral_width=SW,
     n_points=N,
-    target_snr=40 # Realistic noise
+    target_snr=40, # Realistic noise
+    seed=42,       # Reproducible noise: the strict asserts below depend on it
 )
 
 # Combine for final simulated signal

--- a/docs/quartodoc.yml
+++ b/docs/quartodoc.yml
@@ -35,5 +35,6 @@ quartodoc:
       contents:
         - core.accessor
         - core.config
+        - core.options
         - core.utils
         - core.validation

--- a/src/xmris/__init__.py
+++ b/src/xmris/__init__.py
@@ -18,6 +18,7 @@ from .core import (
 # 2. Xarray Accessors (Importing these automatically registers the .xmr namespace)
 # =============================================================================
 from .core.accessor import XmrisAccessor, XmrisDatasetAccessor
+from .core.options import set_options
 
 # =============================================================================
 # 4. Modeling & Fitting
@@ -70,6 +71,7 @@ __all__ = [
     # --- 2. Accessors ---
     "XmrisAccessor",
     "XmrisDatasetAccessor",
+    "set_options",
     # --- 3. Core Processing & Utilities ---
     "to_complex",
     "to_real_imag",

--- a/src/xmris/core/options.py
+++ b/src/xmris/core/options.py
@@ -1,0 +1,52 @@
+"""Global runtime options for xmris, mirroring :func:`xarray.set_options`."""
+
+from typing import Any
+
+OPTIONS: dict[str, bool] = {
+    "auto_convert": True,
+}
+
+
+class set_options:
+    """Set global xmris options, either permanently or within a context.
+
+    Parameters
+    ----------
+    auto_convert : bool, optional
+        When ``True`` (the default), domain-decorated operations transform
+        their input into the required physical domain automatically — the
+        funnel (``@ensures_domain``) and domain-preserving (``@computes_in``)
+        contracts. When ``False``, xmris runs *strict*: a domain mismatch
+        raises an actionable error instead of converting, so every Fourier
+        transform in a pipeline is written explicitly. Recommended for
+        quantitative work.
+
+    Examples
+    --------
+    Temporarily, as a context manager::
+
+        with xmris.set_options(auto_convert=False):
+            fid.xmr.autophase()   # raises: convert with .xmr.to_spectrum() first
+
+    Or globally::
+
+        xmris.set_options(auto_convert=False)
+    """
+
+    def __init__(self, **kwargs: bool):
+        self.old: dict[str, bool] = {}
+        for key, value in kwargs.items():
+            if key not in OPTIONS:
+                raise ValueError(
+                    f"Unknown xmris option {key!r}. Available options: {sorted(OPTIONS)}"
+                )
+            self.old[key] = OPTIONS[key]
+            OPTIONS[key] = value
+
+    def __enter__(self) -> "set_options":
+        """Enter the context; options were already applied in ``__init__``."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Restore the option values that were active before this context."""
+        OPTIONS.update(self.old)

--- a/src/xmris/core/validation.py
+++ b/src/xmris/core/validation.py
@@ -23,6 +23,7 @@ import numpy as np
 import xarray as xr
 
 from .config import ATTRS, DIMS, SPECTRAL_DIMS, TIME_DIMS
+from .options import OPTIONS
 from .utils import _domain_label, _resolve_dim
 
 
@@ -243,6 +244,16 @@ def _domain_decorator(domain: frozenset[str], *, restore: bool) -> Callable:
                 # axis (e.g. zero_fill(dim="kx")) by not converting at all.
                 foreign_request = restore and requested is not None and requested not in domain
                 if not foreign_request:
+                    if not OPTIONS["auto_convert"]:
+                        converter = "to_spectrum" if domain == SPECTRAL_DIMS else "to_fid"
+                        raise ValueError(
+                            f"'{func.__name__}' requires a {label} dimension, but "
+                            f"none of {sorted(domain)} are present in "
+                            f"{list(da.dims)}, and automatic conversion is "
+                            f"disabled (xmris.set_options(auto_convert=False)).\n\n"
+                            f"Convert explicitly first:\n"
+                            f"    >>> obj = obj.xmr.{converter}()"
+                        )
                     da, state = _coerce_to_domain(da, domain)
                     bound.arguments[first_param] = da
 

--- a/src/xmris/fitting/simulation.py
+++ b/src/xmris/fitting/simulation.py
@@ -110,6 +110,7 @@ def simulate_fid(
     lineshape_g: float | ArrayLike = 0.0,
     dead_time: float = 0.0,
     target_snr: float | None = None,
+    seed: int | None = None,
 ) -> xr.DataArray:
     """Simulate a complex Free Induction Decay (FID) signal.
 
@@ -154,6 +155,10 @@ def simulate_fid(
         The target Signal-to-Noise Ratio. If provided, complex Gaussian white
         noise is added to the FID. Signal power is calculated from the first
         10 points of the FID. Default is None (returns ideal, noiseless FID).
+    seed : int | None, optional
+        Seed for the noise generator. Pass an integer for reproducible noise —
+        required whenever downstream assertions depend on the noisy data (e.g.
+        the notebook test suite). Default is None (fresh entropy every call).
 
     Returns
     -------
@@ -189,7 +194,7 @@ def simulate_fid(
         # Split variance for complex noise: scale std by 1/sqrt(2)
         noise_std_channel = noise_std_total / np.sqrt(2)
         # use the new Generator API instead of legacy np.random functions
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(seed)
         noise_real = rng.normal(0, noise_std_channel, fid_data.shape)
         noise_imag = rng.normal(0, noise_std_channel, fid_data.shape)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1232,3 +1232,86 @@ class TestDomainRollout:
         result = kspace.xmr.zero_fill(dim="kx", target_points=16, position="symmetric")
         assert result.sizes["kx"] == 16
         assert list(result.dims) == ["kx", "ky"]
+
+
+# =============================================================================
+# 16. Runtime Options: strict mode (auto_convert=False)
+# =============================================================================
+
+
+class TestSetOptions:
+    """Verify ``xmris.set_options(auto_convert=False)`` turns coercion into errors.
+
+    Strict mode never changes numbers — it only converts the automatic domain
+    transforms into loud, actionable errors, so every Fourier transform in a
+    quantitative pipeline is written explicitly. In-domain calls and explicit
+    foreign-dim passthrough are unaffected.
+    """
+
+    def test_default_is_auto_convert(self):
+        """Automatic conversion is on by default."""
+        from xmris.core.options import OPTIONS
+
+        assert OPTIONS["auto_convert"] is True
+
+    def test_strict_funnel_raises_actionable(self, valid_fid_da):
+        """A funnel coercion under strict mode raises with the explicit fix."""
+        import xmris
+
+        with xmris.set_options(auto_convert=False):
+            with pytest.raises(ValueError, match="to_spectrum"):
+                _ensure_spectral_probe(valid_fid_da)
+
+    def test_strict_restore_raises_actionable(self, valid_spectrum_da):
+        """A domain-preserving coercion under strict mode raises with the fix."""
+        import xmris
+
+        with xmris.set_options(auto_convert=False):
+            with pytest.raises(ValueError, match="to_fid"):
+                _time_scale_probe(valid_spectrum_da)
+
+    def test_strict_error_names_the_switch(self, valid_fid_da):
+        """The error must name ``auto_convert`` so users can find the switch."""
+        import xmris
+
+        with xmris.set_options(auto_convert=False):
+            with pytest.raises(ValueError, match="auto_convert"):
+                _ensure_spectral_probe(valid_fid_da)
+
+    def test_strict_in_domain_unaffected(self, valid_spectrum_da):
+        """In-domain calls need no conversion and work identically under strict."""
+        import xmris
+
+        with xmris.set_options(auto_convert=False):
+            result = _ensure_spectral_probe(valid_spectrum_da)
+        assert result is valid_spectrum_da
+
+    def test_strict_foreign_dim_passthrough_unaffected(self):
+        """Explicit foreign-dim passthrough involves no conversion — still works."""
+        import xmris
+
+        rng = np.random.default_rng()
+        kspace = xr.DataArray(
+            rng.standard_normal(16) + 1j * rng.standard_normal(16),
+            dims=["kx"],
+            coords={"kx": np.arange(16)},
+        )
+        with xmris.set_options(auto_convert=False):
+            result = _time_scale_probe(kspace, dim="kx")
+        np.testing.assert_allclose(result.values, kspace.values * 2.0)
+
+    def test_context_manager_restores(self, valid_fid_da):
+        """Leaving the context restores automatic conversion."""
+        import xmris
+
+        with xmris.set_options(auto_convert=False):
+            pass
+        result = _ensure_spectral_probe(valid_fid_da)  # converts again
+        assert DIMS.frequency in result.dims
+
+    def test_unknown_option_raises(self):
+        """Misspelled options must fail loudly, listing the valid ones."""
+        import xmris
+
+        with pytest.raises(ValueError, match="Unknown xmris option"):
+            xmris.set_options(auto_conver=False)


### PR DESCRIPTION
Final implementation PR for the #63 resolution. **Stacked on #78** (base: `refactor/63-domain-rollout`); retarget after it merges.

## `xmris.set_options(auto_convert=False)`

Strict mode for quantitative work: domain coercion turns into a loud, actionable error naming the exact converter to call and the switch that was set. It never changes numbers — in-domain calls and explicit foreign-dim passthrough are unaffected. Usable globally or as a context manager (mirrors `xr.set_options`).

```python
with xmris.set_options(auto_convert=False):
    fid.xmr.autophase()
# ValueError: 'autophase' requires a spectral dimension … Convert explicitly first:
#     >>> obj = obj.xmr.to_spectrum()
```

## Contributor docs de-drifted

- **Commandment 5** is now the enforced biconditional (*`dim=None` ⟺ multi-label domain-decorated*) instead of an absolute "never None" that the code already violated.
- **Commandment 6** documents the two domain contracts, the undecorated-by-design list, and the converter-routing rule; the code template switches to free-function style with a `@computes_in` example.
- `new-processing-method` skill gains the funnel/preserving/undecorated decision tree; `new-widget` skill updated to `_resolve_dim`.
- (Full Commandments rewrite remains #72.)

## Verification

- `uv run test`: **182 passed** (174 on the rollout branch + 8)
- ruff: only the 4 pre-existing errors (#71); mypy unchanged (62, −8 vs main)

Merge order for the stack: **#77 → #76 (article) → #78 → this**. Closes the implementation side of #63.

Refs #63, #42, #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)