### PR TITLE
fix(ci): pin ipykernel<7 and harden docs build against hangs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       - dependency-name: "griffe" # held <0.40 to fix a quartodoc parsing bug
       - dependency-name: "pytest-cov"
         versions: [">=7.0"] # held <7 for nbmake subprocess coverage tracking
+      - dependency-name: "ipykernel"
+        versions: [">=7.0"] # held <7: ipykernel 7 hangs myst --execute (vscode-jupyter#17228)
 
     # Cap future pile-ups if the repo goes idle again.
     open-pull-requests-limit: 5

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # A healthy run is ~4 min; bound it so a hung kernel fails fast, not at GitHub's 6h ceiling.
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -12,6 +12,8 @@ jobs:
   full-test:
     name: ${{ matrix.os }} / Py ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # Bound each matrix leg so a hung kernel fails fast, not at GitHub's 6h ceiling.
+    timeout-minutes: 30
     # macOS failures won't fail the whole pipeline (Experimental)
     continue-on-error: ${{ matrix.os == 'macos-latest' }}
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,30 +3,33 @@ name: Documentation
 on:
   push:
     branches: [main]
+  # Build (execute) the docs on PRs too, so a docs-breaking or kernel-hanging
+  # dependency is caught pre-merge instead of only surfacing after landing on main.
+  pull_request:
+    branches: [main]
 
 env:
   BASE_URL: /xmris
 
+# Minimal default token; only the deploy job (main-only) elevates to Pages scopes.
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: 'pages'
-  cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Always runs (PR + push). Executes every notebook via `myst build --execute`,
+  # which is the check that a docs dependency didn't break/hang the build.
+  build:
     runs-on: ubuntu-latest
+    # A healthy build is ~2 min. This bound is the key guard: it turns a hung
+    # kernel into a fast, visible failure instead of a 6h burn at GitHub's ceiling.
+    timeout-minutes: 20
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
       - name: Setup GitHub Pages
+        # Bakes the Pages base path into the built site; only needed for real deploys.
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v6
 
       - name: Setup uv
@@ -51,10 +54,28 @@ jobs:
           uv run myst build --html --execute
 
       - name: Upload Build Artifacts
+        # Only publish the artifact on main; PR runs are build-only smoke tests.
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v5
         with:
           path: 'docs/_build/html'
 
+  # Deploy only from main (push). PRs never reach this job.
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: false
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,10 @@ dev = [
     "ipympl>=0.10.0",
     "matplotlib>=3.10.0",
     "jupytext>=1.19.1",
-    "ipykernel>=6.31.0",
+    # Pinned <7: ipykernel 7 hangs myst --execute kernels (never signals `idle`,
+    # so the docs build stalls until CI's 6h ceiling). See vscode-jupyter#17228.
+    # Revisit by removing this pin AND the dependabot ignore together.
+    "ipykernel>=6.31.0,<7",
 ]
 
 # ==============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -926,7 +926,7 @@ wheels = [
 
 [[package]]
 name = "ipykernel"
-version = "7.3.0"
+version = "6.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
@@ -937,16 +937,16 @@ dependencies = [
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
-    { name = "nest-asyncio2" },
+    { name = "nest-asyncio" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1d/d5ba6edbfe6fae4c3105bca3a9c889563cc752c7f2de45e333164c7f4846/ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6", size = 167493, upload-time = "2025-10-20T11:42:39.948Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl", hash = "sha256:abe5386f6ced727a70e0eb0cf1da801fa7c5fa6ff82147747d5a0406cd8c94af", size = 117003, upload-time = "2025-10-20T11:42:37.502Z" },
 ]
 
 [[package]]
@@ -1975,12 +1975,12 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio2"
-version = "1.7.2"
+name = "nest-asyncio"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -3536,7 +3536,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "griffe", specifier = "<0.40.0" },
-    { name = "ipykernel", specifier = ">=6.31.0" },
+    { name = "ipykernel", specifier = ">=6.31.0,<7" },
     { name = "ipympl", specifier = ">=0.10.0" },
     { name = "jupyter-server", specifier = ">=2.17.0" },
     { name = "jupytext", specifier = ">=1.19.1" },


### PR DESCRIPTION
## Problem

The **Documentation** workflow on `main` (commit 36cc14a) didn't error — it **hung for 6 hours** and was killed at GitHub's max-execution ceiling. Because `deploy.yml` used `concurrency: {group: pages, cancel-in-progress: false}`, the next run queued behind the stuck one (12h wall-clock).

**Root cause:** the preceding commit #86 refreshed the lockfile and floated `ipykernel` **6.31.0 → 7.3.0** (`pyproject.toml` had `ipykernel>=6.31.0`, no upper bound). [ipykernel 7 never signals `idle` after a cell](https://github.com/microsoft/vscode-jupyter/issues/17228), so `myst build --execute` waited forever on the last notebook, `contributing/static_widgets.md`.

**Why nothing caught it:**
1. The docs `--execute` build only ran on `push: main` — never on PRs — so #86's PR was green.
2. `static_widgets.md` isn't covered by nbmake (`Tests` uses a different kernel path and only scans `docs/notebooks/`).
3. `deploy.yml` had no `timeout-minutes`, so the hang burned the full 6h.

## Fix — now
- Pin `ipykernel>=6.31.0,<7` (with a comment linking the issue).
- Add a matching Dependabot `ignore` for `ipykernel >=7.0` (same convention as griffe / pytest-cov).
- Regenerate `uv.lock` → ipykernel **6.31.0**.

## Fix — for the future (defense in depth)
- **`deploy.yml`**: split into a `build` job (runs on **PRs + push**, `timeout-minutes: 20`) and a main-only `deploy` job (holds the Pages `permissions` + `pages` concurrency). A docs-breaking/hanging dependency now fails the **PR** check in ≤20 min, before it can reach `main`, and `static_widgets.md` is executed on every PR.
- **`ci-fast.yml` / `ci-publish.yml`**: added `timeout-minutes` so any future kernel hang fails fast instead of at the 6h ceiling.

## Verification
- `myst build --html --execute` locally → **exit 0**; `contributing/static_widgets.md` executed and *built in 23s* (previously infinite). 24 notebooks executed.
- `uv run pytest tests/test_core.py` → **158 passed**.
- All workflow / dependabot YAML validates.

> Note: the `deploy.yml` PR-trigger and concurrency changes only take full effect once this is merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)