### PR TITLE
chore: kill import-time DeprecationWarning + gate ruff in CI (#67)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
       - name: Run Tests
         run: uv run test
 

--- a/src/xmris/__init__.py
+++ b/src/xmris/__init__.py
@@ -6,7 +6,6 @@ from . import config, core, fitting, processing, vendor, visualization
 # =============================================================================
 # 1. Global Configuration & Singletons (The Central Nervous System)
 # =============================================================================
-from .config import DEFAULTS  # Legacy patch (branch refactor/18)
 from .core import (
     ATTRS,
     COORDS,
@@ -67,7 +66,6 @@ __all__ = [
     "COORDS",
     "DIMS",
     "VARS",
-    "DEFAULTS",  # Legacy patch (branch refactor/18)
     # --- 2. Accessors ---
     "XmrisAccessor",
     "XmrisDatasetAccessor",

--- a/src/xmris/visualization/plot/plot_qc_grid.py
+++ b/src/xmris/visualization/plot/plot_qc_grid.py
@@ -37,14 +37,20 @@ class PlotQCGridConfig(BasePlotConfig):
         default=None,
         metadata={
             "group": "Grid Layout",
-            "description": "Max subplots. If None (default), plots all spectra. If N > max, samples evenly.",
+            "description": (
+                "Max subplots. If None (default), plots all spectra. "
+                "If N > max, samples evenly."
+            ),
         },
     )
     sharey: bool = field(
         default=False,
         metadata={
             "group": "Grid Layout",
-            "description": "Share Y-axis limits across all plots to accurately compare absolute amplitudes.",
+            "description": (
+                "Share Y-axis limits across all plots to accurately "
+                "compare absolute amplitudes."
+            ),
         },
     )
 

--- a/src/xmris/visualization/widget/_static_exporter.py
+++ b/src/xmris/visualization/widget/_static_exporter.py
@@ -184,7 +184,9 @@ class StandaloneModel {{
         evts.forEach(fn => fn());
     }}
     save_changes() {{ return Promise.resolve(); }}
-    send(msg, callbacks, buffers) {{ console.warn("Widget attempted to send message to missing kernel:", msg); }}
+    send(msg, callbacks, buffers) {{
+        console.warn("Widget attempted to send message to missing kernel:", msg);
+    }}
     on(events, fn) {{
         for (const evt of events.split(" ")) {{
             (this._listeners[evt] ||= []).push(fn);


### PR DESCRIPTION
Part of the JOSS/release-readiness epic (#67). Three small, independent hygiene fixes.

## What
- **Kill the import-time `DeprecationWarning`.** `src/xmris/__init__.py` did `from .config import DEFAULTS`, which triggers the deprecation shim's module-level `__getattr__` on **every** `import xmris`. Removed that import and its `__all__` entry. The `xmris.config` shim module is untouched, so genuine legacy callers (`from xmris.config import DEFAULTS`) still resolve it — with the warning.
- **Fix the 3 shipping ruff `E501` errors** (`plot_qc_grid.py:40/47`, `_static_exporter.py:187`).
- **Gate `ruff check` in CI** (`ci-fast.yml`) so lint regressions can't merge — CI previously gated neither ruff nor mypy.

## Verification
- `python -W error::DeprecationWarning -c "import xmris"` → exits 0 ✅
- `uv run ruff check .` → `All checks passed!` ✅
- `from xmris.config import DEFAULTS` still works (with the deprecation warning) ✅
- `uv run pytest tests/test_core.py -n0 --no-cov` → 172 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrVRQLhtJ7ZBi8xNDzxDC