### PR TITLE
fix(fitting): resolve reference_frequency from the modern attr key (#68)

### DIFF
--- a/docs/notebooks/fitting/pyamares.md
+++ b/docs/notebooks/fitting/pyamares.md
@@ -186,6 +186,30 @@ ds_fit = da_mrsi.xmr.fit_amares(
 )
 ```
 
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Regression for #68: fit_amares must resolve the spectrometer frequency from the
+# modern `reference_frequency` attr (written by simulate_fid / build_fid), not only
+# the legacy "MHz" key. Here we fit a single FID carrying ONLY reference_frequency
+# and pass no explicit `mhz=` — this raised a ValueError before the fix.
+from xmris.core.config import ATTRS
+
+fid_modern = da_mrsi.isel(voxel=0).copy()
+fid_modern.attrs = {str(ATTRS.reference_frequency): mhz, "sw": sw}
+assert "MHz" not in fid_modern.attrs  # ensure we exercise the modern-key path
+
+ds_modern = fid_modern.xmr.fit_amares(
+    prior_knowledge_file=pk_path, method="least_squares", num_workers=1
+)
+
+# It fit without raising, and produced finite amplitudes for both metabolites.
+assert np.all(np.isfinite(ds_modern["amplitude"].values)), (
+    "modern reference_frequency fit produced non-finite amplitudes"
+)
+assert float(ds_modern["amplitude"].sel(Metabolite="PCr")) > 0.0
+```
+
 :::{dropdown} Understanding the PyAMARES Warning
 If you look at the cell output above, you might notice this recurring warning:
 `[AMARES | WARNING] pm_index are all NaNs, return None so that P matrix is a identity matrix!`

--- a/src/xmris/fitting/amares.py
+++ b/src/xmris/fitting/amares.py
@@ -19,6 +19,8 @@ from pyAMARES.kernel.lmfit import fitAMARES as pyamares_fitAMARES
 from pyAMARES.libs.logger import set_log_level
 from tqdm.auto import tqdm
 
+from xmris.core.config import ATTRS
+
 
 def _fit_dataset_safe(
     fid_current,
@@ -268,9 +270,14 @@ def fit_amares(
 
     # 1. Extract/Infer Physical Parameters
     if mhz is None:
-        mhz = da.attrs.get("MHz")
+        # Prefer the modern vocabulary key written by simulate_fid / build_fid;
+        # fall back to the legacy "MHz" attr for back-compat.
+        mhz = da.attrs.get(ATTRS.reference_frequency, da.attrs.get("MHz"))
         if mhz is None:
-            raise ValueError("mhz must be provided or present in da.attrs['MHz']")
+            raise ValueError(
+                "mhz must be provided or present in "
+                f"da.attrs['{ATTRS.reference_frequency}'] (or legacy da.attrs['MHz'])."
+            )
 
     if sw is None:
         # Assuming the coordinate is in seconds


### PR DESCRIPTION
Fixes #68. Standalone bug fix — the #69 vocabulary rename it was originally bundled with is descoped (entangled blast radius, tracked separately).

## Problem
`fit_amares` inferred the spectrometer frequency **only** from the legacy `attrs["MHz"]` key:
```python
mhz = da.attrs.get("MHz")   # ← legacy / deprecated-shim key
```
But xmris's own generators write the **modern** `ATTRS.reference_frequency` (`"reference_frequency"`): `simulate_fid` (`fitting/simulation.py`) and `build_fid` (from Bruker `PVM_FrqRef`). So a FID straight out of `simulate_fid`, passed to `.xmr.fit_amares(pk)` with no explicit `mhz=`, raised `ValueError` even though the frequency **was** present — the package's own pipeline broke.

## Fix
Read `ATTRS.reference_frequency` first, fall back to `"MHz"` for back-compat, and point the error message at the modern key. No behavior change for existing data that still carries `"MHz"`.

## Test
Adds a hidden (`remove-cell`) regression cell to `docs/notebooks/fitting/pyamares.md` that fits a single FID carrying **only** `reference_frequency` (asserting `"MHz" not in attrs`) with no `mhz=`, and checks the amplitudes come back finite/positive.

## Verification
- `uv run ruff check src/xmris/fitting/amares.py` → clean ✅
- `uv run pytest tests/autogen_notebooks/fitting/pyamares.ipynb --nbmake --no-cov -n0` → 1 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrVRQLhtJ7ZBi8xNDzxDC