### PR TITLE
fix(plot): guard complex input + preserve time-axis units (#83 items 1 & 3)

### DIFF
--- a/docs/notebooks/vendor/bruker_filter_removal.md
+++ b/docs/notebooks/vendor/bruker_filter_removal.md
@@ -198,6 +198,11 @@ assert clean.sizes["time"] == raw.sizes["time"], "keep_length failed to preserve
 np.testing.assert_allclose(
     clean.coords["time"].values[0], 0.0, err_msg="time coordinate not reset to 0"
 )
+# Regression for #83: the origin reset must keep the coordinate's units metadata
+# (a bare-array assign_coords dropped it, mislabelling the time axis downstream).
+assert clean.coords["time"].attrs.get("units") == "s", (
+    "time coordinate lost its units metadata during remove_digital_filter"
+)
 np.testing.assert_allclose(
     clean.values[-76:], 0.0, atol=1e-9, err_msg="integer-delay tail not zero-filled"
 )

--- a/docs/notebooks/visualization/plot/02_plot_waterfall.md
+++ b/docs/notebooks/visualization/plot/02_plot_waterfall.md
@@ -167,3 +167,15 @@ assert "13" in x_label and "C" in x_label, "Chemical shift LaTeX formatting fail
 assert "kinetic_time" in da_kinetic.dims, "Time dimension was lost during processing."
 assert "chemical_shift" in da_kinetic.dims, "Chemical shift dimension was lost."
 ```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Regression for #83: complex input must raise, not be silently plotted as `.real`.
+import pytest
+
+da_complex = da_kinetic_fid.xmr.to_spectrum().xmr.to_ppm()
+assert np.iscomplexobj(da_complex.values), "expected a complex spectrum for this guard test"
+with pytest.raises(ValueError, match="real-valued view"):
+    da_complex.sel(chemical_shift=slice(160, 190)).xmr.plot.waterfall()
+```

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -145,3 +145,15 @@ assert "13" in x_label and "C" in x_label, "Chemical shift LaTeX formatting fail
 assert "kinetic_time" in da_kinetic.dims, "Time dimension was lost during processing."
 assert "chemical_shift" in da_kinetic.dims, "Chemical shift dimension was lost."
 ```
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Regression for #83: complex input must raise, not be silently plotted as `.real`.
+import pytest
+
+da_complex = da_kinetic_fid.xmr.to_spectrum().xmr.to_ppm()
+assert np.iscomplexobj(da_complex.values), "expected a complex spectrum for this guard test"
+with pytest.raises(ValueError, match="real-valued view"):
+    da_complex.sel(chemical_shift=slice(160, 190)).xmr.plot.carpet()
+```

--- a/src/xmris/vendor/bruker.py
+++ b/src/xmris/vendor/bruker.py
@@ -4,8 +4,8 @@ import numpy as np
 import scipy.optimize
 import xarray as xr
 
-from xmris.core.config import ATTRS, DIMS, VARS
-from xmris.core.utils import _check_dims
+from xmris.core.config import ATTRS, COORDS, DIMS, VARS
+from xmris.core.utils import _check_dims, as_variable
 from xmris.processing.fid import to_spectrum
 from xmris.processing.phasing import _acme_cost
 
@@ -124,9 +124,14 @@ def remove_digital_filter(
     # 5. Rebuild DataArray Safely (Functional Purity)
     da_new = template_da.copy(data=final_values)
 
-    # Ensure Time coordinate starts exactly at 0 after shifting
+    # Ensure Time coordinate starts exactly at 0 after shifting. Rebuild it via
+    # as_variable so the coordinate keeps its units/long_name — a bare-array
+    # assignment silently drops them, which later mislabels the axis downstream
+    # (e.g. a time axis rendered as "Time [ppm]" by the plotters).
     time_coords = da_new.coords[dim].values
-    da_new = da_new.assign_coords({dim: time_coords - time_coords[0]})
+    da_new = da_new.assign_coords(
+        {dim: as_variable(COORDS.time, dim, time_coords - time_coords[0])}
+    )
 
     # 6. Preserve Lineage — record only the quantifiable parameter applied (Commandment 3).
     new_attrs = da.attrs.copy()

--- a/src/xmris/visualization/plot/plot_carpet.py
+++ b/src/xmris/visualization/plot/plot_carpet.py
@@ -168,6 +168,14 @@ def plot_carpet(
     x_dim_str, stack_dim_str = parse_input_dims_timeseries(da, x_dim, stack_dim)
 
     da_plot = da.transpose(stack_dim_str, x_dim_str)
+
+    if np.iscomplexobj(da_plot.values):
+        raise ValueError(
+            "carpet() needs a real-valued view but got complex data. "
+            "For a phased spectrum use `da.real` (phase first with "
+            "`da.xmr.autophase()`); for a magnitude view use `np.abs(da)`."
+        )
+
     x_vals = da_plot.coords[x_dim_str].values
     stack_vals = da_plot.coords[stack_dim_str].values
     spectra = da_plot.values

--- a/src/xmris/visualization/plot/plot_waterfall.py
+++ b/src/xmris/visualization/plot/plot_waterfall.py
@@ -189,6 +189,14 @@ def plot_waterfall(
     x_dim_str, stack_dim_str = parse_input_dims_timeseries(da, x_dim, stack_dim)
 
     da_plot = da.transpose(stack_dim_str, x_dim_str)
+
+    if np.iscomplexobj(da_plot.values):
+        raise ValueError(
+            "waterfall() needs a real-valued view but got complex data. "
+            "For a phased spectrum use `da.real` (phase first with "
+            "`da.xmr.autophase()`); for a magnitude view use `np.abs(da)`."
+        )
+
     x_vals = da_plot.coords[x_dim_str].values
     stack_vals = da_plot.coords[stack_dim_str].values
 


### PR DESCRIPTION
Fixes two correctness bugs in `.xmr.plot.waterfall` / `.xmr.plot.carpet` from #83 (items 1 & 3). Items 2 (averages/repetitions vocab) and 4 (`set_xlim` clip) are tracked separately.

## 1. Complex input silently plotted as `.real` (item 1)
Calling the plotters on a complex `DataArray` (e.g. straight out of `.xmr.to_spectrum()`) discarded the imaginary part via matplotlib with a `ComplexWarning` cascade and no notice — a scientifically wrong plot for unphased spectra and FIDs.

Both plotters now **raise a guiding `ValueError`**:
> waterfall() needs a real-valued view but got complex data. For a phased spectrum use `da.real` (phase first with `da.xmr.autophase()`); for a magnitude view use `np.abs(da)`.

(The `autophase` tip sits directly beside the phased-spectrum branch, per review.) A `component="real"|"imag"|"abs"` opt-in knob is noted as a future enhancement under #39/#84.

## 2. Time axis mislabelled `[ppm]` after `remove_digital_filter` (item 3)
`remove_digital_filter` reset the time origin with a bare-array `assign_coords`, dropping the coordinate's `{units: "s", long_name: "Time"}`. The plotters' `attrs.get("units", "ppm")` fallback then rendered the time axis as **"Time [ppm]"**. The origin reset now rebuilds the coordinate via `as_variable(COORDS.time, ...)`, preserving the metadata at the source.

## Tests
- `02_plot_waterfall.md` / `03_plot_carpet.md`: hidden cells asserting complex input raises `ValueError`.
- `bruker_filter_removal.md`: hidden assert that `clean.coords["time"].attrs["units"] == "s"` survives the origin reset.

## Verification
- `uv run ruff check` on all three source files → clean ✅
- `uv run pytest {02_plot_waterfall,03_plot_carpet,bruker_filter_removal}.ipynb --nbmake --no-cov -n0` → 3 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QrVRQLhtJ7ZBi8xNDzxDC