### PR TITLE
feat(config): harden XmrisTerm — freeze, uniqueness, canonical-only vocabulary (#65)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ flowchart TD
     subgraph Components ["DataArray Components"]
         direction LR
         NP["Raw NumPy Array<br><span style='color:#6c757d; font-size:0.9em; font-style:italic;'>Complex FID data</span>"]:::component
-        Dims["Dimensions<br><span style='color:#6c757d; font-size:0.9em; font-style:italic;'>'time', 'repetitions'</span>"]:::component
+        Dims["Dimensions<br><span style='color:#6c757d; font-size:0.9em; font-style:italic;'>'time', 'repetition'</span>"]:::component
         Coords["Coordinates<br><span style='color:#6c757d; font-size:0.9em; font-style:italic;'>- array of fid times [s]<br>- array of repetition times [s]</span>"]:::component
         Meta["Metadata (attrs)<br><span style='color:#6c757d; font-size:0.9em; font-style:italic;'>b0_field, reference_frequency</span>"]:::component
     end
@@ -108,7 +108,7 @@ flowchart TD
 
     %% 4a. The Native xarray benefit
     In --> Nat{"Native Methods"}:::native
-    Nat -->|"<span style='font-family:monospace;'>fid_data.mean(dim='repetitions')</span>"| OutNat["📉 Averaged FID DataArray"]:::output
+    Nat -->|"<span style='font-family:monospace;'>fid_data.mean(dim='repetition')</span>"| OutNat["📉 Averaged FID DataArray"]:::output
 
     %% 4b. The Custom processing pipeline
     In --> Acc{"⚙️ .xmr accessor"}:::accessor

--- a/docs/notebooks/fitting/pyamares.md
+++ b/docs/notebooks/fitting/pyamares.md
@@ -150,7 +150,7 @@ da_mrsi = xr.DataArray(
     data,
     dims=["voxel", "time"],
     coords={"voxel": np.arange(n_voxels), "time": time},
-    attrs={"MHz": mhz, "sw": sw},
+    attrs={"reference_frequency": mhz, "sw": sw},
 )
 
 # Plot the generated spectra

--- a/docs/notebooks/visualization/plot/02_plot_waterfall.md
+++ b/docs/notebooks/visualization/plot/02_plot_waterfall.md
@@ -20,7 +20,7 @@ In `xmris`, this visualization is built entirely around our `WaterfallConfig` ob
 Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **Dimensionality:** Must be at least 2D. 
 * **X-Axis (Horizontal):** The accessor will automatically search for dimensions named `chemical_shift` or `frequency`. If your spectral axis has a different name, you must specify it explicitly via the `x_dim` argument.
-* **Stack Axis (Vertical):** The accessor will automatically stack along the remaining dimension. If multiple dimensions remain, it looks for `averages` or `repetitions`, or you can specify it explicitly via the `stack_dim` argument.
+* **Stack Axis (Vertical):** The accessor will automatically stack along the remaining dimension. If multiple dimensions remain, it looks for `average` or `repetition` (the legacy plural names `averages`/`repetitions` are also recognized), or you can specify it explicitly via the `stack_dim` argument.
 
 ## 2. Generating Synthetic Data
 

--- a/docs/notebooks/visualization/plot/02_plot_waterfall.md
+++ b/docs/notebooks/visualization/plot/02_plot_waterfall.md
@@ -20,7 +20,7 @@ In `xmris`, this visualization is built entirely around our `WaterfallConfig` ob
 Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **Dimensionality:** Must be at least 2D. 
 * **X-Axis (Horizontal):** The accessor will automatically search for dimensions named `chemical_shift` or `frequency`. If your spectral axis has a different name, you must specify it explicitly via the `x_dim` argument.
-* **Stack Axis (Vertical):** The accessor will automatically stack along the remaining dimension. If multiple dimensions remain, it looks for `average` or `repetition` (the legacy plural names `averages`/`repetitions` are also recognized), or you can specify it explicitly via the `stack_dim` argument.
+* **Stack Axis (Vertical):** The accessor will automatically stack along the remaining dimension. If multiple dimensions remain, it looks for `average` or `repetition`, or you can specify it explicitly via the `stack_dim` argument.
 
 ## 2. Generating Synthetic Data
 

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -20,7 +20,7 @@ In `xmris`, this visualization is built around the `CarpetConfig` object, which 
 Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **Dimensionality:** Must be at least 2D. 
 * **X-Axis (Horizontal):** The accessor automatically searches for `chemical_shift` or `frequency`. 
-* **Y-Axis (Vertical):** The accessor automatically assigns the remaining dimension to the y-axis (e.g., `kinetic_time`, `average`, or `repetition`; the legacy plural names `averages`/`repetitions` are also recognized).
+* **Y-Axis (Vertical):** The accessor automatically assigns the remaining dimension to the y-axis (e.g., `kinetic_time`, `average`, or `repetition`).
 
 ## 2. Generating Synthetic Data
 

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -20,7 +20,7 @@ In `xmris`, this visualization is built around the `CarpetConfig` object, which 
 Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **Dimensionality:** Must be at least 2D. 
 * **X-Axis (Horizontal):** The accessor automatically searches for `chemical_shift` or `frequency`. 
-* **Y-Axis (Vertical):** The accessor automatically assigns the remaining dimension to the y-axis (e.g., `kinetic_time` or `averages`).
+* **Y-Axis (Vertical):** The accessor automatically assigns the remaining dimension to the y-axis (e.g., `kinetic_time`, `average`, or `repetition`; the legacy plural names `averages`/`repetitions` are also recognized).
 
 ## 2. Generating Synthetic Data
 

--- a/docs/notebooks/visualization/plot/03_plotting_1dfid.md
+++ b/docs/notebooks/visualization/plot/03_plotting_1dfid.md
@@ -126,7 +126,7 @@ da_dyn = xr.DataArray(
     data,
     dims=["repetition", "time"],
     coords={"repetition": rep_axis, "time": time_axis},
-    attrs={"MHz": mhz},
+    attrs={"reference_frequency": mhz},
 )
 
 # Assign proper units for plotting

--- a/src/xmris/core/accessor.py
+++ b/src/xmris/core/accessor.py
@@ -759,7 +759,8 @@ class XmrisAccessor(
         dim : str, optional
             The time dimension along which to fit, by default "time".
         mhz : float, optional
-            Spectrometer frequency in MHz. If None, attempts to read from attrs['MHz'].
+            Spectrometer frequency in MHz. If None, read from
+            ``attrs['reference_frequency']`` (legacy key ``'MHz'`` also accepted).
         sw : float, optional
             Spectral width in Hz. If None, attempts to calculate from `dim` coordinates.
         deadtime : float, optional

--- a/src/xmris/core/accessor.py
+++ b/src/xmris/core/accessor.py
@@ -760,7 +760,7 @@ class XmrisAccessor(
             The time dimension along which to fit, by default "time".
         mhz : float, optional
             Spectrometer frequency in MHz. If None, read from
-            ``attrs['reference_frequency']`` (legacy key ``'MHz'`` also accepted).
+            ``attrs['reference_frequency']``.
         sw : float, optional
             Spectral width in Hz. If None, attempts to calculate from `dim` coordinates.
         deadtime : float, optional

--- a/src/xmris/core/config.py
+++ b/src/xmris/core/config.py
@@ -11,9 +11,20 @@ class XmrisTerm(str):
 
     This allows xarray to treat it as a standard dimension/coordinate name,
     while allowing developers to access `.unit` and `.description` directly.
+    Instances are immutable: all metadata is fixed at construction time.
     """
 
-    def __new__(cls, value: str, description: str = "", unit: str = ""):
+    description: str
+    unit: str
+    aliases: tuple[str, ...]
+
+    def __new__(
+        cls,
+        value: str,
+        description: str = "",
+        unit: str = "",
+        aliases: tuple[str, ...] = (),
+    ):
         """Create a new :class:`XmrisTerm` instance with metadata.
 
         Parameters
@@ -24,16 +35,41 @@ class XmrisTerm(str):
             A human‑readable description of the term (default is empty).
         unit : str, optional
             The unit associated with the term, if any (default is empty).
+        aliases : tuple of str, optional
+            Legacy string values this term was previously known under (default
+            is empty). Readers resolve the canonical value first, then each
+            alias in order — see :func:`xmris.core.utils.read_attr`.
 
         Returns
         -------
         XmrisTerm
-            A new string instance with ``description`` and ``unit`` attributes.
+            A new string instance with ``description``, ``unit`` and
+            ``aliases`` attributes.
         """
         obj = str.__new__(cls, value)
-        obj.description = description
-        obj.unit = unit
+        # Instances are frozen (__setattr__ raises), so bypass it here.
+        object.__setattr__(obj, "description", description)
+        object.__setattr__(obj, "unit", unit)
+        object.__setattr__(obj, "aliases", tuple(str(a) for a in aliases))
         return obj
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Reject attribute mutation — terms are frozen at construction."""
+        raise AttributeError(
+            f"XmrisTerm is immutable: cannot set {name!r} on {str(self)!r}. "
+            "Define a new term in xmris.core.config instead."
+        )
+
+    def __delattr__(self, name: str) -> None:
+        """Reject attribute deletion — terms are frozen at construction."""
+        raise AttributeError(f"XmrisTerm is immutable: cannot delete {name!r} from {str(self)!r}.")
+
+    def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, object]]:
+        """Route pickle/copy through ``__new__`` so metadata survives round-trips."""
+        return (
+            (str(self),),
+            {"description": self.description, "unit": self.unit, "aliases": self.aliases},
+        )
 
     @property
     def long_name(self) -> str:
@@ -51,6 +87,28 @@ class BaseVocabulary:
     Provides rich HTML display for Jupyter Notebooks and utility
     methods to fetch metadata for validation decorators.
     """
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Enforce key uniqueness (canonical values and aliases) at import time.
+
+        Within one vocabulary class, every canonical term value and every alias
+        must be distinct — a duplicate would make attribute lookups ambiguous.
+        Cross-vocabulary duplicates (e.g. ``time`` in both DIMS and COORDS)
+        remain intentionally allowed.
+        """
+        super().__init_subclass__(**kwargs)
+        seen: dict[str, str] = {}
+        for prop, term in vars(cls).items():
+            if not isinstance(term, XmrisTerm):
+                continue
+            keys = [(str(term), "canonical value")] + [(a, "alias") for a in term.aliases]
+            for key, kind in keys:
+                if key in seen:
+                    raise ValueError(
+                        f"{cls.__name__}: duplicate vocabulary key {key!r} — "
+                        f"{kind} of {prop!r} collides with the {seen[key]}."
+                    )
+                seen[key] = f"{kind} of {prop!r}"
 
     def _get_terms(self) -> dict:
         """Help extract all XmrisTerm attributes from the class."""
@@ -76,6 +134,11 @@ class BaseVocabulary:
         for term in self._get_terms().values():
             if term == target_value:
                 return term.description or "No description provided."
+        for term in self._get_terms().values():
+            if target_value in term.aliases:
+                return f"Legacy alias of {str(term)!r}. " + (
+                    term.description or "No description provided."
+                )
         return "Unknown xarray key."
 
     def _repr_html_(self) -> str:
@@ -112,10 +175,15 @@ class BaseVocabulary:
                 else "<span style='color: #999;'>-</span>"
             )
 
+            key_str = f'<strong><code>"{term}"</code></strong>'
+            if term.aliases:
+                legacy = ", ".join(f'"{a}"' for a in term.aliases)
+                key_str += f"<br><small style='color: #999;'>legacy: {legacy}</small>"
+
             html.append(
                 "<tr style='border-bottom: 1px solid #eee;'>"
                 f"<td style='padding: 8px; white-space: nowrap;'><code>{prop_name}</code></td>"  # noqa: E501
-                f"<td style='padding: 8px; white-space: nowrap;'><strong><code>\"{term}\"</code></strong></td>"  # noqa: E501
+                f"<td style='padding: 8px; white-space: nowrap;'>{key_str}</td>"
                 f"<td style='padding: 8px; white-space: nowrap;'>{unit_str}</td>"
                 f"<td style='padding: 8px;'>{term.description}</td>"
                 "</tr>"
@@ -138,6 +206,7 @@ class XmrisAttributes(BaseVocabulary):
             "(0018,0084) or 'TransmitterFrequency' (0018,9098)."
         ),
         unit="MHz",
+        aliases=("MHz",),
     )
 
     carrier_ppm = XmrisTerm(
@@ -163,6 +232,7 @@ class XmrisAttributes(BaseVocabulary):
             "(TopSpin 'GRPDLY')."
         ),
         unit="samples",
+        aliases=("bruker_group_delay",),
     )
 
     group_delay_removed = XmrisTerm(
@@ -278,10 +348,25 @@ class XmrisDimensions(BaseVocabulary):
 
     component = XmrisTerm("component", description="Dimension separating real and imaginary parts.")
     # --- Standard Acquisition Dimensions ---
+    # Dimension names are uniformly singular; legacy plural spellings are aliases.
     average = XmrisTerm(
-        "average", description="Dimension for multiple signal acquisitions/averages."
+        "average",
+        description="Dimension for multiple signal acquisitions/averages.",
+        aliases=("averages",),
     )
-    coil = XmrisTerm("coil", description="Dimension for multi-coil phased array data.")
+    repetition = XmrisTerm(
+        "repetition",
+        description=(
+            "Dimension for repeated acquisitions over time (dynamic series), "
+            "one entry per TR block."
+        ),
+        aliases=("repetitions",),
+    )
+    coil = XmrisTerm(
+        "coil",
+        description="Dimension for multi-coil phased array data.",
+        aliases=("channels",),
+    )
     echo = XmrisTerm("echo", description="Dimension for multi-echo acquisitions.")
 
     # --- Spatial Frequency (k-space) ---

--- a/src/xmris/core/config.py
+++ b/src/xmris/core/config.py
@@ -46,6 +46,11 @@ class XmrisTerm(str):
             A new string instance with ``description``, ``unit`` and
             ``aliases`` attributes.
         """
+        if isinstance(aliases, str):
+            raise TypeError(
+                f"aliases must be a tuple of strings, not a bare str; got {aliases!r} "
+                f"for term {value!r} (did you forget a trailing comma?)."
+            )
         obj = str.__new__(cls, value)
         # Instances are frozen (__setattr__ raises), so bypass it here.
         object.__setattr__(obj, "description", description)
@@ -131,12 +136,14 @@ class BaseVocabulary:
         str
             The description string, or a fallback message if not found.
         """
+        # Import-time uniqueness (see __init_subclass__) guarantees target_value
+        # matches at most one term — as its canonical value or as one alias — so a
+        # single pass suffices.
         for term in self._get_terms().values():
             if term == target_value:
                 return term.description or "No description provided."
-        for term in self._get_terms().values():
             if target_value in term.aliases:
-                return f"Legacy alias of {str(term)!r}. " + (
+                return f"Legacy alias of {term!r}. " + (
                     term.description or "No description provided."
                 )
         return "Unknown xarray key."

--- a/src/xmris/core/config.py
+++ b/src/xmris/core/config.py
@@ -57,7 +57,11 @@ class XmrisTerm(str):
         raise AttributeError(f"XmrisTerm is immutable: cannot delete {name!r} from {str(self)!r}.")
 
     def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, object]]:
-        """Route pickle/copy through ``__new__`` so metadata survives round-trips."""
+        """Route pickle/copy through ``__new__`` so metadata survives round-trips.
+
+        Uses ``_ex_`` (not ``__getnewargs__``) so it doesn't override ``str``'s
+        own ``__getnewargs__`` signature — which mypy rejects.
+        """
         return ((str(self),), {"description": self.description, "unit": self.unit})
 
     @property
@@ -87,9 +91,7 @@ class BaseVocabulary:
         """
         super().__init_subclass__(**kwargs)
         seen: dict[str, str] = {}
-        for prop, term in vars(cls).items():
-            if not isinstance(term, XmrisTerm):
-                continue
+        for prop, term in cls._get_terms().items():
             key = str(term)
             if key in seen:
                 raise ValueError(
@@ -98,9 +100,10 @@ class BaseVocabulary:
                 )
             seen[key] = prop
 
-    def _get_terms(self) -> dict:
+    @classmethod
+    def _get_terms(cls) -> dict:
         """Help extract all XmrisTerm attributes from the class."""
-        return {key: val for key, val in vars(self.__class__).items() if isinstance(val, XmrisTerm)}
+        return {key: val for key, val in vars(cls).items() if isinstance(val, XmrisTerm)}
 
     def get_description(self, target_value: str) -> str:
         """

--- a/src/xmris/core/config.py
+++ b/src/xmris/core/config.py
@@ -16,14 +16,12 @@ class XmrisTerm(str):
 
     description: str
     unit: str
-    aliases: tuple[str, ...]
 
     def __new__(
         cls,
         value: str,
         description: str = "",
         unit: str = "",
-        aliases: tuple[str, ...] = (),
     ):
         """Create a new :class:`XmrisTerm` instance with metadata.
 
@@ -35,27 +33,16 @@ class XmrisTerm(str):
             A human‑readable description of the term (default is empty).
         unit : str, optional
             The unit associated with the term, if any (default is empty).
-        aliases : tuple of str, optional
-            Legacy string values this term was previously known under (default
-            is empty). Readers resolve the canonical value first, then each
-            alias in order — see :func:`xmris.core.utils.read_attr`.
 
         Returns
         -------
         XmrisTerm
-            A new string instance with ``description``, ``unit`` and
-            ``aliases`` attributes.
+            A new string instance with ``description`` and ``unit`` attributes.
         """
-        if isinstance(aliases, str):
-            raise TypeError(
-                f"aliases must be a tuple of strings, not a bare str; got {aliases!r} "
-                f"for term {value!r} (did you forget a trailing comma?)."
-            )
         obj = str.__new__(cls, value)
         # Instances are frozen (__setattr__ raises), so bypass it here.
         object.__setattr__(obj, "description", description)
         object.__setattr__(obj, "unit", unit)
-        object.__setattr__(obj, "aliases", tuple(str(a) for a in aliases))
         return obj
 
     def __setattr__(self, name: str, value: object) -> None:
@@ -71,10 +58,7 @@ class XmrisTerm(str):
 
     def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, object]]:
         """Route pickle/copy through ``__new__`` so metadata survives round-trips."""
-        return (
-            (str(self),),
-            {"description": self.description, "unit": self.unit, "aliases": self.aliases},
-        )
+        return ((str(self),), {"description": self.description, "unit": self.unit})
 
     @property
     def long_name(self) -> str:
@@ -94,26 +78,25 @@ class BaseVocabulary:
     """
 
     def __init_subclass__(cls, **kwargs) -> None:
-        """Enforce key uniqueness (canonical values and aliases) at import time.
+        """Enforce canonical-value uniqueness at import time.
 
-        Within one vocabulary class, every canonical term value and every alias
-        must be distinct — a duplicate would make attribute lookups ambiguous.
-        Cross-vocabulary duplicates (e.g. ``time`` in both DIMS and COORDS)
-        remain intentionally allowed.
+        Within one vocabulary class, every canonical term value must be distinct —
+        a duplicate would make attribute lookups ambiguous. Cross-vocabulary
+        duplicates (e.g. ``time`` in both DIMS and COORDS) remain intentionally
+        allowed.
         """
         super().__init_subclass__(**kwargs)
         seen: dict[str, str] = {}
         for prop, term in vars(cls).items():
             if not isinstance(term, XmrisTerm):
                 continue
-            keys = [(str(term), "canonical value")] + [(a, "alias") for a in term.aliases]
-            for key, kind in keys:
-                if key in seen:
-                    raise ValueError(
-                        f"{cls.__name__}: duplicate vocabulary key {key!r} — "
-                        f"{kind} of {prop!r} collides with the {seen[key]}."
-                    )
-                seen[key] = f"{kind} of {prop!r}"
+            key = str(term)
+            if key in seen:
+                raise ValueError(
+                    f"{cls.__name__}: duplicate vocabulary key {key!r} — "
+                    f"{prop!r} collides with {seen[key]!r}."
+                )
+            seen[key] = prop
 
     def _get_terms(self) -> dict:
         """Help extract all XmrisTerm attributes from the class."""
@@ -129,23 +112,16 @@ class BaseVocabulary:
         ----------
         target_value : str
             The actual string value of the attribute/dimension/coordinate
-            (e.g., "MHz", "time").
+            (e.g., "reference_frequency", "time").
 
         Returns
         -------
         str
             The description string, or a fallback message if not found.
         """
-        # Import-time uniqueness (see __init_subclass__) guarantees target_value
-        # matches at most one term — as its canonical value or as one alias — so a
-        # single pass suffices.
         for term in self._get_terms().values():
             if term == target_value:
                 return term.description or "No description provided."
-            if target_value in term.aliases:
-                return f"Legacy alias of {term!r}. " + (
-                    term.description or "No description provided."
-                )
         return "Unknown xarray key."
 
     def _repr_html_(self) -> str:
@@ -182,15 +158,10 @@ class BaseVocabulary:
                 else "<span style='color: #999;'>-</span>"
             )
 
-            key_str = f'<strong><code>"{term}"</code></strong>'
-            if term.aliases:
-                legacy = ", ".join(f'"{a}"' for a in term.aliases)
-                key_str += f"<br><small style='color: #999;'>legacy: {legacy}</small>"
-
             html.append(
                 "<tr style='border-bottom: 1px solid #eee;'>"
                 f"<td style='padding: 8px; white-space: nowrap;'><code>{prop_name}</code></td>"  # noqa: E501
-                f"<td style='padding: 8px; white-space: nowrap;'>{key_str}</td>"
+                f"<td style='padding: 8px; white-space: nowrap;'><strong><code>\"{term}\"</code></strong></td>"  # noqa: E501
                 f"<td style='padding: 8px; white-space: nowrap;'>{unit_str}</td>"
                 f"<td style='padding: 8px;'>{term.description}</td>"
                 "</tr>"
@@ -213,7 +184,6 @@ class XmrisAttributes(BaseVocabulary):
             "(0018,0084) or 'TransmitterFrequency' (0018,9098)."
         ),
         unit="MHz",
-        aliases=("MHz",),
     )
 
     carrier_ppm = XmrisTerm(
@@ -239,7 +209,6 @@ class XmrisAttributes(BaseVocabulary):
             "(TopSpin 'GRPDLY')."
         ),
         unit="samples",
-        aliases=("bruker_group_delay",),
     )
 
     group_delay_removed = XmrisTerm(
@@ -355,11 +324,9 @@ class XmrisDimensions(BaseVocabulary):
 
     component = XmrisTerm("component", description="Dimension separating real and imaginary parts.")
     # --- Standard Acquisition Dimensions ---
-    # Dimension names are uniformly singular; legacy plural spellings are aliases.
+    # Dimension names are uniformly singular.
     average = XmrisTerm(
-        "average",
-        description="Dimension for multiple signal acquisitions/averages.",
-        aliases=("averages",),
+        "average", description="Dimension for multiple signal acquisitions/averages."
     )
     repetition = XmrisTerm(
         "repetition",
@@ -367,13 +334,8 @@ class XmrisDimensions(BaseVocabulary):
             "Dimension for repeated acquisitions over time (dynamic series), "
             "one entry per TR block."
         ),
-        aliases=("repetitions",),
     )
-    coil = XmrisTerm(
-        "coil",
-        description="Dimension for multi-coil phased array data.",
-        aliases=("channels",),
-    )
+    coil = XmrisTerm("coil", description="Dimension for multi-coil phased array data.")
     echo = XmrisTerm("echo", description="Dimension for multi-echo acquisitions.")
 
     # --- Spatial Frequency (k-space) ---

--- a/src/xmris/core/utils.py
+++ b/src/xmris/core/utils.py
@@ -1,4 +1,7 @@
 # src/xmris/core/utils.py
+from collections.abc import Iterable
+from typing import Any
+
 import numpy as np
 import xarray as xr
 
@@ -123,3 +126,42 @@ def as_variable(term: XmrisTerm, dims: str | tuple, data: np.ndarray) -> xr.Vari
         attrs["units"] = term.unit
 
     return xr.Variable(dims, data, attrs=attrs)
+
+
+def read_attr(obj: xr.DataArray | xr.Dataset, term: XmrisTerm, default: Any = None) -> Any:
+    """Read an attribute from ``obj.attrs``, falling back to the term's legacy aliases.
+
+    Looks up the canonical key first, then each entry of ``term.aliases`` in
+    declaration order. This is the single shared resolver for attribute keys
+    that were renamed at some point (e.g. legacy ``"MHz"`` →
+    ``"reference_frequency"``): the rename is declared once on the term in
+    :mod:`xmris.core.config` and every reader inherits the fallback.
+
+    Parameters
+    ----------
+    obj : xr.DataArray or xr.Dataset
+        Object whose ``.attrs`` to read.
+    term : XmrisTerm
+        Vocabulary term naming the attribute (e.g. ``ATTRS.reference_frequency``).
+    default : Any, optional
+        Value returned when neither the canonical key nor any alias is present,
+        by default None.
+
+    Returns
+    -------
+    Any
+        The stored attribute value, or ``default`` if absent.
+    """
+    for key in (term, *term.aliases):
+        if key in obj.attrs:
+            return obj.attrs[key]
+    return default
+
+
+def _first_matching_name(term: XmrisTerm, names: Iterable[str]) -> str | None:
+    """Return the first of (canonical value, *aliases) present in ``names``, else None."""
+    available = set(names)
+    for key in (term, *term.aliases):
+        if key in available:
+            return str(key)
+    return None

--- a/src/xmris/core/utils.py
+++ b/src/xmris/core/utils.py
@@ -1,7 +1,4 @@
 # src/xmris/core/utils.py
-from collections.abc import Iterable
-from typing import Any
-
 import numpy as np
 import xarray as xr
 
@@ -126,42 +123,3 @@ def as_variable(term: XmrisTerm, dims: str | tuple, data: np.ndarray) -> xr.Vari
         attrs["units"] = term.unit
 
     return xr.Variable(dims, data, attrs=attrs)
-
-
-def read_attr(obj: xr.DataArray | xr.Dataset, term: XmrisTerm, default: Any = None) -> Any:
-    """Read an attribute from ``obj.attrs``, falling back to the term's legacy aliases.
-
-    Looks up the canonical key first, then each entry of ``term.aliases`` in
-    declaration order. This is the single shared resolver for attribute keys
-    that were renamed at some point (e.g. legacy ``"MHz"`` →
-    ``"reference_frequency"``): the rename is declared once on the term in
-    :mod:`xmris.core.config` and every reader inherits the fallback.
-
-    Parameters
-    ----------
-    obj : xr.DataArray or xr.Dataset
-        Object whose ``.attrs`` to read.
-    term : XmrisTerm
-        Vocabulary term naming the attribute (e.g. ``ATTRS.reference_frequency``).
-    default : Any, optional
-        Value returned when neither the canonical key nor any alias is present,
-        by default None.
-
-    Returns
-    -------
-    Any
-        The stored attribute value, or ``default`` if absent.
-    """
-    for key in (term, *term.aliases):
-        if key in obj.attrs:
-            return obj.attrs[key]
-    return default
-
-
-def _first_matching_name(term: XmrisTerm, names: Iterable[str]) -> str | None:
-    """Return the first of (canonical value, *aliases) present in ``names``, else None."""
-    available = set(names)
-    for key in (term, *term.aliases):
-        if key in available:
-            return str(key)
-    return None

--- a/src/xmris/fitting/amares.py
+++ b/src/xmris/fitting/amares.py
@@ -20,6 +20,7 @@ from pyAMARES.libs.logger import set_log_level
 from tqdm.auto import tqdm
 
 from xmris.core.config import ATTRS
+from xmris.core.utils import read_attr
 
 
 def _fit_dataset_safe(
@@ -239,7 +240,8 @@ def fit_amares(
     dim : str, optional
         The time dimension along which to fit, by default "time".
     mhz : float, optional
-        Spectrometer frequency in MHz. If None, attempts to read from da.attrs['MHz'].
+        Spectrometer frequency in MHz. If None, read from
+        ``da.attrs['reference_frequency']`` (legacy key ``'MHz'`` also accepted).
     sw : float, optional
         Spectral width in Hz. If None, attempts to calculate from `dim` coordinates.
     deadtime : float, optional
@@ -270,13 +272,14 @@ def fit_amares(
 
     # 1. Extract/Infer Physical Parameters
     if mhz is None:
-        # Prefer the modern vocabulary key written by simulate_fid / build_fid;
-        # fall back to the legacy "MHz" attr for back-compat.
-        mhz = da.attrs.get(ATTRS.reference_frequency, da.attrs.get("MHz"))
+        # Resolve the canonical reference_frequency, falling back to the legacy
+        # "MHz" alias, via the shared vocabulary-aware resolver.
+        mhz = read_attr(da, ATTRS.reference_frequency)
         if mhz is None:
             raise ValueError(
-                "mhz must be provided or present in "
-                f"da.attrs['{ATTRS.reference_frequency}'] (or legacy da.attrs['MHz'])."
+                f"mhz must be provided or present in "
+                f"da.attrs[{str(ATTRS.reference_frequency)!r}] "
+                "(legacy key 'MHz' is also accepted)."
             )
 
     if sw is None:
@@ -457,20 +460,12 @@ def fit_amares(
     else:
         # Handle the 1D case directly without unstacking
         ds["raw_data"] = da
-        ds["fit_data"] = xr.DataArray(
-            fit_data[0], dims=[dim], coords={dim: da.coords[dim]}
-        )
+        ds["fit_data"] = xr.DataArray(fit_data[0], dims=[dim], coords={dim: da.coords[dim]})
 
         param_coords = {"Metabolite": metabolites}
-        ds["amplitude"] = xr.DataArray(
-            amplitudes[0], dims=["Metabolite"], coords=param_coords
-        )
-        ds["chem_shift"] = xr.DataArray(
-            chem_shifts[0], dims=["Metabolite"], coords=param_coords
-        )
-        ds["linewidth"] = xr.DataArray(
-            linewidths[0], dims=["Metabolite"], coords=param_coords
-        )
+        ds["amplitude"] = xr.DataArray(amplitudes[0], dims=["Metabolite"], coords=param_coords)
+        ds["chem_shift"] = xr.DataArray(chem_shifts[0], dims=["Metabolite"], coords=param_coords)
+        ds["linewidth"] = xr.DataArray(linewidths[0], dims=["Metabolite"], coords=param_coords)
         ds["phase"] = xr.DataArray(phases[0], dims=["Metabolite"], coords=param_coords)
         ds["crlb"] = xr.DataArray(crlbs[0], dims=["Metabolite"], coords=param_coords)
         ds["snr"] = xr.DataArray(snrs[0], dims=["Metabolite"], coords=param_coords)

--- a/src/xmris/fitting/amares.py
+++ b/src/xmris/fitting/amares.py
@@ -274,7 +274,7 @@ def fit_amares(
         mhz = da.attrs.get(ATTRS.reference_frequency)
         if mhz is None:
             raise ValueError(
-                f"mhz must be provided or present in da.attrs[{str(ATTRS.reference_frequency)!r}]."
+                f"mhz must be provided or present in da.attrs[{ATTRS.reference_frequency!r}]."
             )
 
     if sw is None:

--- a/src/xmris/fitting/amares.py
+++ b/src/xmris/fitting/amares.py
@@ -20,7 +20,6 @@ from pyAMARES.libs.logger import set_log_level
 from tqdm.auto import tqdm
 
 from xmris.core.config import ATTRS
-from xmris.core.utils import read_attr
 
 
 def _fit_dataset_safe(
@@ -241,7 +240,7 @@ def fit_amares(
         The time dimension along which to fit, by default "time".
     mhz : float, optional
         Spectrometer frequency in MHz. If None, read from
-        ``da.attrs['reference_frequency']`` (legacy key ``'MHz'`` also accepted).
+        ``da.attrs['reference_frequency']``.
     sw : float, optional
         Spectral width in Hz. If None, attempts to calculate from `dim` coordinates.
     deadtime : float, optional
@@ -272,14 +271,10 @@ def fit_amares(
 
     # 1. Extract/Infer Physical Parameters
     if mhz is None:
-        # Resolve the canonical reference_frequency, falling back to the legacy
-        # "MHz" alias, via the shared vocabulary-aware resolver.
-        mhz = read_attr(da, ATTRS.reference_frequency)
+        mhz = da.attrs.get(ATTRS.reference_frequency)
         if mhz is None:
             raise ValueError(
-                f"mhz must be provided or present in "
-                f"da.attrs[{str(ATTRS.reference_frequency)!r}] "
-                "(legacy key 'MHz' is also accepted)."
+                f"mhz must be provided or present in da.attrs[{str(ATTRS.reference_frequency)!r}]."
             )
 
     if sw is None:

--- a/src/xmris/vendor/bruker.py
+++ b/src/xmris/vendor/bruker.py
@@ -5,7 +5,7 @@ import scipy.optimize
 import xarray as xr
 
 from xmris.core.config import ATTRS, COORDS, DIMS, VARS
-from xmris.core.utils import _check_dims, as_variable
+from xmris.core.utils import _check_dims, _first_matching_name, as_variable, read_attr
 from xmris.processing.fid import to_spectrum
 from xmris.processing.phasing import _acme_cost
 
@@ -140,24 +140,14 @@ def remove_digital_filter(
     return da_new.assign_attrs(new_attrs)
 
 
-# Legacy attr key, read-only, for backward compatibility with FIDs saved before the
-# vendor-agnostic ATTRS.group_delay ("group_delay") rename (#85 metadata tidy).
-_LEGACY_GROUP_DELAY_KEY = "bruker_group_delay"
-
-
-def _read_group_delay_attr(da: xr.DataArray) -> float | None:
-    """Read the stored group-delay attr, falling back to the legacy Bruker key."""
-    val = da.attrs.get(ATTRS.group_delay, da.attrs.get(_LEGACY_GROUP_DELAY_KEY))
-    return None if val is None else float(val)
-
-
 def _resolve_group_delay(da: xr.DataArray, group_delay: float | str, dim: str) -> float:
     """Resolve a ``group_delay`` argument (float or ``"header"``/``"measure"``) to samples."""
     if not isinstance(group_delay, str):
         return float(group_delay)
 
     if group_delay == "header":
-        header = _read_group_delay_attr(da)
+        val = read_attr(da, ATTRS.group_delay)
+        header = None if val is None else float(val)
         if header is None:
             raise ValueError(
                 f"remove_digital_filter(group_delay='header') needs the "
@@ -257,7 +247,8 @@ def estimate_group_delay(
     # Resolve the header anchor (explicit hint wins, else the stored attr).
     header = header_hint
     if header is None:
-        header = _read_group_delay_attr(da)
+        val = read_attr(da, ATTRS.group_delay)
+        header = None if val is None else float(val)
 
     # Resolve the search window.
     if search_range is not None:
@@ -474,8 +465,10 @@ def reshape_bruker_raw(raw_data_1d: np.ndarray, pv_params: dict) -> tuple[np.nda
     n_ph1 = 1
     n_ph2 = 1
 
-    # 2. Map standard Bruker order
-    dims = [DIMS.time, "channels", "slices", "averages", "ph1", "ph2", "repetitions"]
+    # 2. Map standard Bruker order. "slices"/"ph1"/"ph2" stay literal: hardcoded
+    # to size 1 above (unlocalized spectroscopy only), they are always filtered
+    # out below and can never appear in the output.
+    dims = [DIMS.time, DIMS.coil, "slices", DIMS.average, "ph1", "ph2", DIMS.repetition]
     sizes = [n_points, n_channels, n_slices, n_averages, n_ph1, n_ph2, n_rep]
 
     # 3. Filter out empty dimensions (size == 1)
@@ -509,7 +502,7 @@ def build_fid(
     Expected Bruker Parameters in `pv_params`:
     ------------------------------------------
     * PVM_SpecSWH        (float): Spectral width in Hz. Used to calculate dwell time.
-    * PVM_RepetitionTime (float): TR in ms. Used to calculate the repetitions coordinate.
+    * PVM_RepetitionTime (float): TR in ms. Used to calculate the repetition coordinate.
     * PVM_FrqRef         (float): Reference Larmor frequency in MHz. (Required for to_ppm)
     * PVM_FrqWorkPpm     (float): Carrier chemical shift in ppm. (Required for to_ppm)
     * groupDelay         (float): Bruker specific FID delay. In `ACQ_RxFilterInfo`.
@@ -548,7 +541,7 @@ def build_fid(
     groupDelay = _get_strict("groupDelay")
 
     # 2. Build explicit coordinates
-    coords = {}
+    coords: dict[str, tuple] = {}
 
     # Time Coordinate
     time_idx = dims.index(DIMS.time)
@@ -560,13 +553,15 @@ def build_fid(
         {"units": "s", "long_name": "Time"},
     )
 
-    # Repetition Coordinate (if present)
-    if "repetitions" in dims:
-        rep_idx = dims.index("repetitions")
+    # Repetition Coordinate (if present). Written under the caller's actual dim
+    # name so legacy plural-named dims (``"repetitions"``) still get the TR coord.
+    rep_dim = _first_matching_name(DIMS.repetition, dims)
+    if rep_dim is not None:
+        rep_idx = dims.index(rep_dim)
         n_rep = data.shape[rep_idx]
         tr_s = tr_ms * 1e-3
-        coords["repetitions"] = (
-            "repetitions",
+        coords[rep_dim] = (
+            rep_dim,
             np.arange(n_rep) * tr_s + tr_s,
             {"units": "s", "long_name": "Elapsed Repetition Time"},
         )

--- a/src/xmris/vendor/bruker.py
+++ b/src/xmris/vendor/bruker.py
@@ -5,7 +5,7 @@ import scipy.optimize
 import xarray as xr
 
 from xmris.core.config import ATTRS, COORDS, DIMS, VARS
-from xmris.core.utils import _check_dims, _first_matching_name, as_variable, read_attr
+from xmris.core.utils import _check_dims, as_variable
 from xmris.processing.fid import to_spectrum
 from xmris.processing.phasing import _acme_cost
 
@@ -146,7 +146,7 @@ def _resolve_group_delay(da: xr.DataArray, group_delay: float | str, dim: str) -
         return float(group_delay)
 
     if group_delay == "header":
-        val = read_attr(da, ATTRS.group_delay)
+        val = da.attrs.get(ATTRS.group_delay)
         header = None if val is None else float(val)
         if header is None:
             raise ValueError(
@@ -247,7 +247,7 @@ def estimate_group_delay(
     # Resolve the header anchor (explicit hint wins, else the stored attr).
     header = header_hint
     if header is None:
-        val = read_attr(da, ATTRS.group_delay)
+        val = da.attrs.get(ATTRS.group_delay)
         header = None if val is None else float(val)
 
     # Resolve the search window.
@@ -553,15 +553,13 @@ def build_fid(
         {"units": "s", "long_name": "Time"},
     )
 
-    # Repetition Coordinate (if present). Written under the caller's actual dim
-    # name so legacy plural-named dims (``"repetitions"``) still get the TR coord.
-    rep_dim = _first_matching_name(DIMS.repetition, dims)
-    if rep_dim is not None:
-        rep_idx = dims.index(rep_dim)
+    # Repetition Coordinate (if present)
+    if DIMS.repetition in dims:
+        rep_idx = dims.index(DIMS.repetition)
         n_rep = data.shape[rep_idx]
         tr_s = tr_ms * 1e-3
-        coords[rep_dim] = (
-            rep_dim,
+        coords[DIMS.repetition] = (
+            DIMS.repetition,
             np.arange(n_rep) * tr_s + tr_s,
             {"units": "s", "long_name": "Elapsed Repetition Time"},
         )

--- a/src/xmris/vendor/bruker.py
+++ b/src/xmris/vendor/bruker.py
@@ -140,14 +140,19 @@ def remove_digital_filter(
     return da_new.assign_attrs(new_attrs)
 
 
+def _group_delay_attr(da: xr.DataArray) -> float | None:
+    """Read the canonical group-delay attr as a float, or None if absent."""
+    val = da.attrs.get(ATTRS.group_delay)
+    return None if val is None else float(val)
+
+
 def _resolve_group_delay(da: xr.DataArray, group_delay: float | str, dim: str) -> float:
     """Resolve a ``group_delay`` argument (float or ``"header"``/``"measure"``) to samples."""
     if not isinstance(group_delay, str):
         return float(group_delay)
 
     if group_delay == "header":
-        val = da.attrs.get(ATTRS.group_delay)
-        header = None if val is None else float(val)
+        header = _group_delay_attr(da)
         if header is None:
             raise ValueError(
                 f"remove_digital_filter(group_delay='header') needs the "
@@ -247,8 +252,7 @@ def estimate_group_delay(
     # Resolve the header anchor (explicit hint wins, else the stored attr).
     header = header_hint
     if header is None:
-        val = da.attrs.get(ATTRS.group_delay)
-        header = None if val is None else float(val)
+        header = _group_delay_attr(da)
 
     # Resolve the search window.
     if search_range is not None:

--- a/src/xmris/visualization/plot/_input_parsing.py
+++ b/src/xmris/visualization/plot/_input_parsing.py
@@ -74,13 +74,10 @@ def parse_input_dims_timeseries(
         elif len(remaining_dims) == 1:
             stack_dim = remaining_dims[0]
         else:
-            # Try to find a logical secondary dimension
-            if DIMS.average in remaining_dims:
-                stack_dim = DIMS.average
-            elif DIMS.repetition in remaining_dims:
-                stack_dim = DIMS.repetition
-            else:
-                # Fallback to the first available non-x dimension
-                stack_dim = remaining_dims[0]
+            # Prefer a logical secondary dimension, else the first available non-x dim.
+            stack_dim = next(
+                (d for d in (DIMS.average, DIMS.repetition) if d in remaining_dims),
+                remaining_dims[0],
+            )
 
     return str(x_dim), str(stack_dim)

--- a/src/xmris/visualization/plot/_input_parsing.py
+++ b/src/xmris/visualization/plot/_input_parsing.py
@@ -1,7 +1,6 @@
 import xarray as xr
 
 from xmris.core import DIMS
-from xmris.core.utils import _first_matching_name
 
 
 def parse_input_dims_timeseries(
@@ -14,7 +13,7 @@ def parse_input_dims_timeseries(
     This function attempts to automatically identify the most logical dimensions for
     a 2D (1D spectra + time) contour or ridge plot if they are not explicitly provided.
     It prefers 'chemical_shift' or 'frequency' for the x-axis and 'average' or
-    'repetition' (legacy plural spellings also recognized) for the stacked axis.
+    'repetition' for the stacked axis.
 
     Parameters
     ----------
@@ -75,15 +74,12 @@ def parse_input_dims_timeseries(
         elif len(remaining_dims) == 1:
             stack_dim = remaining_dims[0]
         else:
-            # Try to find a logical secondary dimension (canonical singular name
-            # or its legacy plural alias, whichever the data actually carries).
-            stack_dim = None
-            for term in (DIMS.average, DIMS.repetition):
-                match = _first_matching_name(term, remaining_dims)
-                if match is not None:
-                    stack_dim = match
-                    break
-            if stack_dim is None:
+            # Try to find a logical secondary dimension
+            if DIMS.average in remaining_dims:
+                stack_dim = DIMS.average
+            elif DIMS.repetition in remaining_dims:
+                stack_dim = DIMS.repetition
+            else:
                 # Fallback to the first available non-x dimension
                 stack_dim = remaining_dims[0]
 

--- a/src/xmris/visualization/plot/_input_parsing.py
+++ b/src/xmris/visualization/plot/_input_parsing.py
@@ -1,6 +1,7 @@
 import xarray as xr
 
 from xmris.core import DIMS
+from xmris.core.utils import _first_matching_name
 
 
 def parse_input_dims_timeseries(
@@ -12,8 +13,8 @@ def parse_input_dims_timeseries(
 
     This function attempts to automatically identify the most logical dimensions for
     a 2D (1D spectra + time) contour or ridge plot if they are not explicitly provided.
-    It prefers 'chemical_shift' or 'frequency' for the x-axis and 'averages' or
-    'repetitions' for the stacked axis .
+    It prefers 'chemical_shift' or 'frequency' for the x-axis and 'average' or
+    'repetition' (legacy plural spellings also recognized) for the stacked axis.
 
     Parameters
     ----------
@@ -36,14 +37,12 @@ def parse_input_dims_timeseries(
     ValueError
         If the required dimensions cannot be found or unambiguously resolved.
     """
-    dims = list(da.dims)
+    dims = [str(d) for d in da.dims]
 
     # 1. Resolve X-Axis
     if user_x_dim:
         if user_x_dim not in dims:
-            raise ValueError(
-                f"Requested x-axis dimension '{user_x_dim}' not found in DataArray."
-            )
+            raise ValueError(f"Requested x-axis dimension '{user_x_dim}' not found in DataArray.")
         x_dim = user_x_dim
     else:
         # Auto-detect common spectral axes
@@ -76,12 +75,15 @@ def parse_input_dims_timeseries(
         elif len(remaining_dims) == 1:
             stack_dim = remaining_dims[0]
         else:
-            # Try to find a logical secondary dimension
-            if DIMS.averages in remaining_dims:
-                stack_dim = DIMS.averages
-            elif DIMS.repetitions in remaining_dims:
-                stack_dim = DIMS.repetitions
-            else:
+            # Try to find a logical secondary dimension (canonical singular name
+            # or its legacy plural alias, whichever the data actually carries).
+            stack_dim = None
+            for term in (DIMS.average, DIMS.repetition):
+                match = _first_matching_name(term, remaining_dims)
+                if match is not None:
+                    stack_dim = match
+                    break
+            if stack_dim is None:
                 # Fallback to the first available non-x dimension
                 stack_dim = remaining_dims[0]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,6 +43,9 @@ or user pipelines depend on.
   class here exists solely as a structural integration test of the pipeline.
 """
 
+import copy
+import pickle
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -55,8 +58,10 @@ from xmris.core.config import (
     SPECTRAL_DIMS,
     TIME_DIMS,
     VARS,
+    BaseVocabulary,
+    XmrisTerm,
 )
-from xmris.core.utils import _resolve_dim
+from xmris.core.utils import _resolve_dim, read_attr
 from xmris.core.validation import computes_in, ensures_domain, requires_attrs
 from xmris.processing.fid import to_fid, to_spectrum
 
@@ -288,6 +293,186 @@ class TestConfigMetadata:
         assert "<table" in html
         for term in vocab._get_terms().values():
             assert str(term) in html
+
+
+# =============================================================================
+# 3b. Configuration: Term Hardening (immutability, aliases, uniqueness)
+# =============================================================================
+
+
+class TestXmrisTermHardening:
+    """Vocabulary terms are frozen value objects whose metadata survives round-trips."""
+
+    def test_mutation_raises(self):
+        """Setting an attribute on a singleton term must raise."""
+        with pytest.raises(AttributeError, match="immutable"):
+            ATTRS.reference_frequency.unit = "Hz"
+
+    def test_deletion_raises(self):
+        """Deleting an attribute from a singleton term must raise."""
+        with pytest.raises(AttributeError, match="immutable"):
+            del ATTRS.reference_frequency.unit
+
+    def test_aliases_are_plain_string_tuples(self):
+        """Aliases must be tuples of *plain* str (metadata-free by construction)."""
+        for vocab in (ATTRS, DIMS, COORDS, VARS):
+            for prop_name, term in vocab._get_terms().items():
+                assert isinstance(term.aliases, tuple)
+                assert all(type(a) is str for a in term.aliases), (
+                    f"{vocab.__class__.__name__}.{prop_name} aliases must be plain str."
+                )
+
+    def test_alias_normalization(self):
+        """Alias inputs are normalized to plain strings, even when given as terms."""
+        term = XmrisTerm("modern", description="d", aliases=(XmrisTerm("legacy"), "older"))
+        assert term.aliases == ("legacy", "older")
+        assert all(type(a) is str for a in term.aliases)
+
+    @pytest.mark.parametrize("proto", range(pickle.HIGHEST_PROTOCOL + 1))
+    def test_pickle_roundtrip_preserves_metadata_and_freeze(self, proto):
+        """Pickle round-trips keep value, metadata, and immutability on every protocol."""
+        term = pickle.loads(pickle.dumps(ATTRS.reference_frequency, proto))
+        assert term == ATTRS.reference_frequency
+        assert term.description == ATTRS.reference_frequency.description
+        assert term.unit == "MHz"
+        assert term.aliases == ("MHz",)
+        with pytest.raises(AttributeError):
+            term.unit = "Hz"
+
+    def test_deepcopy_roundtrip(self):
+        """``copy.deepcopy`` keeps value, metadata, and immutability."""
+        term = copy.deepcopy(ATTRS.group_delay)
+        assert term == ATTRS.group_delay
+        assert term.unit == "samples"
+        assert term.aliases == ("bruker_group_delay",)
+        with pytest.raises(AttributeError):
+            term.unit = "x"
+
+
+class TestVocabularyUniqueness:
+    """Duplicate keys (canonical or alias) inside one vocabulary fail at import time."""
+
+    def test_duplicate_canonical_value_raises(self):
+        """Two terms with the same canonical value must fail at class definition."""
+        with pytest.raises(ValueError, match="duplicate vocabulary key 'twin'"):
+
+            class _Broken(BaseVocabulary):
+                a = XmrisTerm("twin", description="d")
+                b = XmrisTerm("twin", description="d")
+
+    def test_alias_colliding_with_canonical_raises(self):
+        """An alias shadowing another term's canonical value must fail."""
+        with pytest.raises(ValueError, match="duplicate vocabulary key 'taken'"):
+
+            class _Broken(BaseVocabulary):
+                a = XmrisTerm("taken", description="d")
+                b = XmrisTerm("other", description="d", aliases=("taken",))
+
+    def test_alias_colliding_with_alias_raises(self):
+        """Two terms claiming the same alias must fail."""
+        with pytest.raises(ValueError, match="duplicate vocabulary key 'legacy'"):
+
+            class _Broken(BaseVocabulary):
+                a = XmrisTerm("a", description="d", aliases=("legacy",))
+                b = XmrisTerm("b", description="d", aliases=("legacy",))
+
+    def test_well_formed_vocabulary_constructs(self):
+        """Distinct values and aliases construct without error."""
+
+        class _Fine(BaseVocabulary):
+            a = XmrisTerm("a", description="d", aliases=("old_a",))
+            b = XmrisTerm("b", description="d")
+
+        assert _Fine()._get_terms().keys() == {"a", "b"}
+
+    def test_get_description_resolves_alias(self):
+        """``get_description`` on a legacy alias points at the canonical term."""
+        desc = ATTRS.get_description("MHz")
+        assert "Legacy alias of 'reference_frequency'" in desc
+
+
+class TestReadAttr:
+    """The shared alias-aware attrs resolver: canonical key wins, aliases fall back."""
+
+    @staticmethod
+    def _da(attrs: dict) -> xr.DataArray:
+        return xr.DataArray(np.zeros(4), dims=[DIMS.time], attrs=attrs)
+
+    def test_canonical_wins_over_alias(self):
+        """The canonical key is preferred when both canonical and alias are present."""
+        da = self._da({ATTRS.reference_frequency: 400.1, "MHz": 999.0})
+        assert read_attr(da, ATTRS.reference_frequency) == 400.1
+
+    def test_alias_fallback(self):
+        """A legacy alias key is read when the canonical key is absent."""
+        da = self._da({"MHz": 120.3})
+        assert read_attr(da, ATTRS.reference_frequency) == 120.3
+
+    def test_missing_returns_default(self):
+        """Neither key present returns the default (None unless overridden)."""
+        da = self._da({"unrelated": 1.0})
+        assert read_attr(da, ATTRS.reference_frequency) is None
+        assert read_attr(da, ATTRS.reference_frequency, default=1.5) == 1.5
+
+
+class TestParseInputDims:
+    """Stack-dim auto-detect uses singular vocabulary dims + legacy plural aliases."""
+
+    @staticmethod
+    def _da(dims: tuple[str, ...]) -> xr.DataArray:
+        return xr.DataArray(np.zeros((4, 3, 2)), dims=list(dims))
+
+    @pytest.mark.parametrize("stack", ["average", "averages", "repetition", "repetitions"])
+    def test_detects_singular_and_legacy_plural(self, stack):
+        """Auto-detect matches the name the data actually carries (was AttributeError)."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.chemical_shift, stack, DIMS.coil))
+        x_dim, stack_dim = parse_input_dims_timeseries(da)
+        assert x_dim == DIMS.chemical_shift
+        assert stack_dim == stack
+
+    def test_average_preferred_over_repetition(self):
+        """Historical preference order (average before repetition) is preserved."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.chemical_shift, DIMS.repetition, DIMS.average))
+        assert parse_input_dims_timeseries(da)[1] == DIMS.average
+
+
+class TestBrukerVocabularyDims:
+    """The Bruker loader emits singular vocabulary dim names (no plural magic strings)."""
+
+    _PV_PARAMS = {
+        "PVM_SpecMatrix": 8,
+        "PVM_EncNReceivers": 2,
+        "PVM_NAverages": 3,
+        "PVM_NRepetitions": 4,
+        "PVM_SpecSWH": 10000.0,
+        "PVM_RepetitionTime": 1000.0,
+        "PVM_FrqRef": 120.3,
+        "PVM_FrqWorkPpm": 0.0,
+        "groupDelay": 0.0,
+    }
+
+    def test_reshape_emits_singular_dims(self):
+        """``reshape_bruker_raw`` labels axes with the singular vocabulary terms."""
+        from xmris.vendor.bruker import reshape_bruker_raw
+
+        raw = np.zeros(8 * 2 * 3 * 4, dtype=complex)
+        _, dims = reshape_bruker_raw(raw, self._PV_PARAMS)
+        assert dims == [DIMS.time, DIMS.coil, DIMS.average, DIMS.repetition]
+
+    @pytest.mark.parametrize("rep_dim", [str(DIMS.repetition), "repetitions"])
+    def test_build_fid_writes_tr_coordinate(self, rep_dim):
+        """The TR coordinate is written for canonical and legacy plural dim names."""
+        from xmris.vendor.bruker import build_fid
+
+        data = np.zeros((8, 4), dtype=complex)
+        da = build_fid(data, [DIMS.time, rep_dim], self._PV_PARAMS)
+        assert rep_dim in da.coords
+        np.testing.assert_allclose(da.coords[rep_dim].values, np.arange(1, 5) * 1.0)
+        assert da.coords[rep_dim].attrs["units"] == "s"
 
 
 # =============================================================================
@@ -1411,13 +1596,12 @@ class TestGroupDelayAttr:
         out = remove_digital_filter(da, group_delay="header")
         assert out.attrs[ATTRS.group_delay_removed] == 50.0
 
-    def test_read_helper_prefers_canonical_and_falls_back(self):
-        """``_read_group_delay_attr`` prefers the new key, falls back, else None."""
-        from xmris.vendor.bruker import _read_group_delay_attr
-
-        assert _read_group_delay_attr(self._fid_with_attr("bruker_group_delay", 76.125)) == 76.125
-        assert _read_group_delay_attr(self._fid_with_attr(ATTRS.group_delay, 84.0)) == 84.0
-        assert _read_group_delay_attr(self._fid_with_attr("unrelated", 1.0)) is None
+    def test_read_attr_prefers_canonical_and_falls_back(self):
+        """``read_attr(da, ATTRS.group_delay)`` prefers the new key, falls back, else None."""
+        legacy = self._fid_with_attr("bruker_group_delay", 76.125)
+        assert read_attr(legacy, ATTRS.group_delay) == 76.125
+        assert read_attr(self._fid_with_attr(ATTRS.group_delay, 84.0), ATTRS.group_delay) == 84.0
+        assert read_attr(self._fid_with_attr("unrelated", 1.0), ATTRS.group_delay) is None
 
 
 class TestEstimateGroupDelayRobustness:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -45,6 +45,7 @@ or user pipelines depend on.
 
 import copy
 import pickle
+import re
 
 import numpy as np
 import pytest
@@ -364,7 +365,7 @@ class TestParseInputDims:
 
     @staticmethod
     def _da(dims: tuple[str, ...]) -> xr.DataArray:
-        return xr.DataArray(np.zeros((4, 3, 2)), dims=list(dims))
+        return xr.DataArray(np.zeros((2,) * len(dims)), dims=list(dims))
 
     @pytest.mark.parametrize("stack", ["average", "repetition"])
     def test_detects_stack_dim(self, stack):
@@ -387,6 +388,36 @@ class TestParseInputDims:
 
         da = self._da((DIMS.chemical_shift, DIMS.repetition, DIMS.average))
         assert parse_input_dims_timeseries(da)[1] == DIMS.average
+
+    def test_single_remaining_dim_is_stack(self):
+        """With exactly one non-spectral dim, it becomes the stack axis."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.chemical_shift, DIMS.coil))
+        assert parse_input_dims_timeseries(da) == (DIMS.chemical_shift, DIMS.coil)
+
+    def test_frequency_used_as_x_axis(self):
+        """When chemical_shift is absent, frequency is the x-axis."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.frequency, DIMS.coil))
+        assert parse_input_dims_timeseries(da) == (DIMS.frequency, DIMS.coil)
+
+    def test_one_dimensional_raises(self):
+        """A 1-D spectral array has no stack axis and must raise."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.chemical_shift,))
+        with pytest.raises(ValueError, match="at least two dimensions"):
+            parse_input_dims_timeseries(da)
+
+    def test_no_spectral_axis_raises(self):
+        """Without chemical_shift or frequency, the x-axis cannot be resolved."""
+        from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
+
+        da = self._da((DIMS.coil, DIMS.echo))
+        with pytest.raises(ValueError, match="resolve x-axis"):
+            parse_input_dims_timeseries(da)
 
 
 class TestBrukerVocabularyDims:
@@ -1540,7 +1571,7 @@ class TestGroupDelayAttr:
         from xmris.vendor.bruker import remove_digital_filter
 
         da = self._fid_with_attr("unrelated", 1.0)
-        with pytest.raises(ValueError, match=str(ATTRS.group_delay)):
+        with pytest.raises(ValueError, match=re.escape(str(ATTRS.group_delay))):
             remove_digital_filter(da, group_delay="header")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,7 +61,7 @@ from xmris.core.config import (
     BaseVocabulary,
     XmrisTerm,
 )
-from xmris.core.utils import _resolve_dim, read_attr
+from xmris.core.utils import _resolve_dim
 from xmris.core.validation import computes_in, ensures_domain, requires_attrs
 from xmris.processing.fid import to_fid, to_spectrum
 
@@ -296,7 +296,7 @@ class TestConfigMetadata:
 
 
 # =============================================================================
-# 3b. Configuration: Term Hardening (immutability, aliases, uniqueness)
+# 3b. Configuration: Term Hardening (immutability, uniqueness)
 # =============================================================================
 
 
@@ -319,26 +319,6 @@ class TestXmrisTermHardening:
         with pytest.raises(AttributeError, match="immutable"):
             del term.unit
 
-    def test_bare_string_alias_rejected(self):
-        """A bare-str ``aliases`` (missing trailing comma) must raise, not explode per-char."""
-        with pytest.raises(TypeError, match="not a bare str"):
-            XmrisTerm("modern", description="d", aliases="legacy")
-
-    def test_aliases_are_plain_string_tuples(self):
-        """Aliases must be tuples of *plain* str (metadata-free by construction)."""
-        for vocab in (ATTRS, DIMS, COORDS, VARS):
-            for prop_name, term in vocab._get_terms().items():
-                assert isinstance(term.aliases, tuple)
-                assert all(type(a) is str for a in term.aliases), (
-                    f"{vocab.__class__.__name__}.{prop_name} aliases must be plain str."
-                )
-
-    def test_alias_normalization(self):
-        """Alias inputs are normalized to plain strings, even when given as terms."""
-        term = XmrisTerm("modern", description="d", aliases=(XmrisTerm("legacy"), "older"))
-        assert term.aliases == ("legacy", "older")
-        assert all(type(a) is str for a in term.aliases)
-
     @pytest.mark.parametrize("proto", range(pickle.HIGHEST_PROTOCOL + 1))
     def test_pickle_roundtrip_preserves_metadata_and_freeze(self, proto):
         """Pickle round-trips keep value, metadata, and immutability on every protocol."""
@@ -346,7 +326,6 @@ class TestXmrisTermHardening:
         assert term == ATTRS.reference_frequency
         assert term.description == ATTRS.reference_frequency.description
         assert term.unit == "MHz"
-        assert term.aliases == ("MHz",)
         with pytest.raises(AttributeError):
             term.unit = "Hz"
 
@@ -355,13 +334,12 @@ class TestXmrisTermHardening:
         term = copy.deepcopy(ATTRS.group_delay)
         assert term == ATTRS.group_delay
         assert term.unit == "samples"
-        assert term.aliases == ("bruker_group_delay",)
         with pytest.raises(AttributeError):
             term.unit = "x"
 
 
 class TestVocabularyUniqueness:
-    """Duplicate keys (canonical or alias) inside one vocabulary fail at import time."""
+    """Duplicate canonical values inside one vocabulary fail at import time."""
 
     def test_duplicate_canonical_value_raises(self):
         """Two terms with the same canonical value must fail at class definition."""
@@ -371,75 +349,30 @@ class TestVocabularyUniqueness:
                 a = XmrisTerm("twin", description="d")
                 b = XmrisTerm("twin", description="d")
 
-    def test_alias_colliding_with_canonical_raises(self):
-        """An alias shadowing another term's canonical value must fail."""
-        with pytest.raises(ValueError, match="duplicate vocabulary key 'taken'"):
-
-            class _Broken(BaseVocabulary):
-                a = XmrisTerm("taken", description="d")
-                b = XmrisTerm("other", description="d", aliases=("taken",))
-
-    def test_alias_colliding_with_alias_raises(self):
-        """Two terms claiming the same alias must fail."""
-        with pytest.raises(ValueError, match="duplicate vocabulary key 'legacy'"):
-
-            class _Broken(BaseVocabulary):
-                a = XmrisTerm("a", description="d", aliases=("legacy",))
-                b = XmrisTerm("b", description="d", aliases=("legacy",))
-
     def test_well_formed_vocabulary_constructs(self):
-        """Distinct values and aliases construct without error."""
+        """Distinct values construct without error."""
 
         class _Fine(BaseVocabulary):
-            a = XmrisTerm("a", description="d", aliases=("old_a",))
+            a = XmrisTerm("a", description="d")
             b = XmrisTerm("b", description="d")
 
         assert _Fine()._get_terms().keys() == {"a", "b"}
 
-    def test_get_description_resolves_alias(self):
-        """``get_description`` on a legacy alias points at the canonical term."""
-        desc = ATTRS.get_description("MHz")
-        assert "Legacy alias of 'reference_frequency'" in desc
-
-
-class TestReadAttr:
-    """The shared alias-aware attrs resolver: canonical key wins, aliases fall back."""
-
-    @staticmethod
-    def _da(attrs: dict) -> xr.DataArray:
-        return xr.DataArray(np.zeros(4), dims=[DIMS.time], attrs=attrs)
-
-    def test_canonical_wins_over_alias(self):
-        """The canonical key is preferred when both canonical and alias are present."""
-        da = self._da({ATTRS.reference_frequency: 400.1, "MHz": 999.0})
-        assert read_attr(da, ATTRS.reference_frequency) == 400.1
-
-    def test_alias_fallback(self):
-        """A legacy alias key is read when the canonical key is absent."""
-        da = self._da({"MHz": 120.3})
-        assert read_attr(da, ATTRS.reference_frequency) == 120.3
-
-    def test_missing_returns_default(self):
-        """Neither key present returns the default (None unless overridden)."""
-        da = self._da({"unrelated": 1.0})
-        assert read_attr(da, ATTRS.reference_frequency) is None
-        assert read_attr(da, ATTRS.reference_frequency, default=1.5) == 1.5
-
 
 class TestParseInputDims:
-    """Stack-dim auto-detect uses singular vocabulary dims + legacy plural aliases."""
+    """Stack-dim auto-detect uses the singular vocabulary dims."""
 
     @staticmethod
     def _da(dims: tuple[str, ...]) -> xr.DataArray:
         return xr.DataArray(np.zeros((4, 3, 2)), dims=list(dims))
 
-    @pytest.mark.parametrize("stack", ["average", "averages", "repetition", "repetitions"])
-    def test_detects_singular_and_legacy_plural(self, stack):
-        """Auto-detect matches the name the data actually carries (was AttributeError).
+    @pytest.mark.parametrize("stack", ["average", "repetition"])
+    def test_detects_stack_dim(self, stack):
+        """Auto-detect finds the acquisition axis (was AttributeError on DIMS.averages).
 
         ``coil`` is placed FIRST so it is ``remaining_dims[0]`` (the positional
-        fallback). Only correct alias-matching returns ``stack``; a broken match
-        loop would fall back to ``coil`` and fail the assertion.
+        fallback). Only correct name-matching returns ``stack``; a broken match
+        would fall back to ``coil`` and fail the assertion.
         """
         from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
 
@@ -479,16 +412,15 @@ class TestBrukerVocabularyDims:
         _, dims = reshape_bruker_raw(raw, self._PV_PARAMS)
         assert dims == [DIMS.time, DIMS.coil, DIMS.average, DIMS.repetition]
 
-    @pytest.mark.parametrize("rep_dim", [str(DIMS.repetition), "repetitions"])
-    def test_build_fid_writes_tr_coordinate(self, rep_dim):
-        """The TR coordinate is written for canonical and legacy plural dim names."""
+    def test_build_fid_writes_tr_coordinate(self):
+        """The TR coordinate is written for the canonical repetition dim."""
         from xmris.vendor.bruker import build_fid
 
         data = np.zeros((8, 4), dtype=complex)
-        da = build_fid(data, [DIMS.time, rep_dim], self._PV_PARAMS)
-        assert rep_dim in da.coords
-        np.testing.assert_allclose(da.coords[rep_dim].values, np.arange(1, 5) * 1.0)
-        assert da.coords[rep_dim].attrs["units"] == "s"
+        da = build_fid(data, [DIMS.time, DIMS.repetition], self._PV_PARAMS)
+        assert DIMS.repetition in da.coords
+        np.testing.assert_allclose(da.coords[DIMS.repetition].values, np.arange(1, 5) * 1.0)
+        assert da.coords[DIMS.repetition].attrs["units"] == "s"
 
 
 # =============================================================================
@@ -1582,7 +1514,7 @@ class TestSetOptions:
 
 
 class TestGroupDelayAttr:
-    """The ``group_delay`` attr rename keeps reading legacy ``bruker_group_delay`` keys."""
+    """``group_delay='header'`` reads the canonical ``group_delay`` attr."""
 
     @staticmethod
     def _fid_with_attr(key: str, value: float) -> xr.DataArray:
@@ -1595,29 +1527,21 @@ class TestGroupDelayAttr:
             attrs={key: value},
         )
 
-    def test_header_reads_legacy_key(self):
-        """``group_delay='header'`` falls back to the legacy ``bruker_group_delay`` attr."""
+    def test_header_reads_canonical_key(self):
+        """``group_delay='header'`` reads the canonical ``group_delay`` attr."""
         from xmris.vendor.bruker import remove_digital_filter
 
-        da = self._fid_with_attr("bruker_group_delay", 40.0)
+        da = self._fid_with_attr(ATTRS.group_delay, 40.0)
         out = remove_digital_filter(da, group_delay="header")
         assert out.attrs[ATTRS.group_delay_removed] == 40.0
 
-    def test_header_prefers_canonical_key(self):
-        """The canonical ``group_delay`` key wins when both keys are present."""
+    def test_header_missing_attr_raises(self):
+        """``group_delay='header'`` raises a guiding error when the attr is absent."""
         from xmris.vendor.bruker import remove_digital_filter
 
-        da = self._fid_with_attr("bruker_group_delay", 40.0)
-        da.attrs[ATTRS.group_delay] = 50.0
-        out = remove_digital_filter(da, group_delay="header")
-        assert out.attrs[ATTRS.group_delay_removed] == 50.0
-
-    def test_read_attr_prefers_canonical_and_falls_back(self):
-        """``read_attr(da, ATTRS.group_delay)`` prefers the new key, falls back, else None."""
-        legacy = self._fid_with_attr("bruker_group_delay", 76.125)
-        assert read_attr(legacy, ATTRS.group_delay) == 76.125
-        assert read_attr(self._fid_with_attr(ATTRS.group_delay, 84.0), ATTRS.group_delay) == 84.0
-        assert read_attr(self._fid_with_attr("unrelated", 1.0), ATTRS.group_delay) is None
+        da = self._fid_with_attr("unrelated", 1.0)
+        with pytest.raises(ValueError, match=str(ATTRS.group_delay)):
+            remove_digital_filter(da, group_delay="header")
 
 
 class TestEstimateGroupDelayRobustness:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1571,7 +1571,7 @@ class TestGroupDelayAttr:
         from xmris.vendor.bruker import remove_digital_filter
 
         da = self._fid_with_attr("unrelated", 1.0)
-        with pytest.raises(ValueError, match=re.escape(str(ATTRS.group_delay))):
+        with pytest.raises(ValueError, match=re.escape(ATTRS.group_delay)):
             remove_digital_filter(da, group_delay="header")
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -304,14 +304,25 @@ class TestXmrisTermHardening:
     """Vocabulary terms are frozen value objects whose metadata survives round-trips."""
 
     def test_mutation_raises(self):
-        """Setting an attribute on a singleton term must raise."""
+        """Setting an attribute on a term must raise (frozen).
+
+        Uses a local term, not the shared ATTRS singleton: were the freeze to
+        regress, mutating the singleton here would corrupt it for every later test.
+        """
+        term = XmrisTerm("probe", description="d", unit="s")
         with pytest.raises(AttributeError, match="immutable"):
-            ATTRS.reference_frequency.unit = "Hz"
+            term.unit = "Hz"
 
     def test_deletion_raises(self):
-        """Deleting an attribute from a singleton term must raise."""
+        """Deleting an attribute from a term must raise (frozen)."""
+        term = XmrisTerm("probe", description="d", unit="s")
         with pytest.raises(AttributeError, match="immutable"):
-            del ATTRS.reference_frequency.unit
+            del term.unit
+
+    def test_bare_string_alias_rejected(self):
+        """A bare-str ``aliases`` (missing trailing comma) must raise, not explode per-char."""
+        with pytest.raises(TypeError, match="not a bare str"):
+            XmrisTerm("modern", description="d", aliases="legacy")
 
     def test_aliases_are_plain_string_tuples(self):
         """Aliases must be tuples of *plain* str (metadata-free by construction)."""
@@ -424,10 +435,15 @@ class TestParseInputDims:
 
     @pytest.mark.parametrize("stack", ["average", "averages", "repetition", "repetitions"])
     def test_detects_singular_and_legacy_plural(self, stack):
-        """Auto-detect matches the name the data actually carries (was AttributeError)."""
+        """Auto-detect matches the name the data actually carries (was AttributeError).
+
+        ``coil`` is placed FIRST so it is ``remaining_dims[0]`` (the positional
+        fallback). Only correct alias-matching returns ``stack``; a broken match
+        loop would fall back to ``coil`` and fail the assertion.
+        """
         from xmris.visualization.plot._input_parsing import parse_input_dims_timeseries
 
-        da = self._da((DIMS.chemical_shift, stack, DIMS.coil))
+        da = self._da((DIMS.chemical_shift, DIMS.coil, stack))
         x_dim, stack_dim = parse_input_dims_timeseries(da)
         assert x_dim == DIMS.chemical_shift
         assert stack_dim == stack


### PR DESCRIPTION
Resolves the #65 design decision. Hardens the vocabulary and makes it **canonical-only** (no aliases).

## Decision (#65)
Keep the `XmrisTerm(str)` subclass as the vocabulary front-end and **harden it in place** — but with **one legal spelling per key** (no aliases).

The design evolved during review:
- The `str`-subclass carrying `.unit`/`.long_name` earns its keep (single source of truth, discoverable schema, coordinate-units payload). The freeze + import-time uniqueness + pickle support are the guardrails for a mutable object-that-is-a-string.
- **Aliases were removed.** They didn't serve the real goal — adapting arbitrary *foreign naming conventions* (too many spellings to hardcode) — and they created a **distributed, opt-in ambiguity**: only `read_attr` callers honored the fallback, so legacy-keyed data fit via `fit_amares` but was rejected by `to_ppm`. Canonical-only makes "canonical or invalid" a total invariant and dissolves that asymmetry.

## What's in this PR
- **`XmrisTerm`**: frozen (mutation/deletion raise), pickle/copy-safe via `__getnewargs_ex__`, import-time **canonical-value uniqueness** via `BaseVocabulary.__init_subclass__`. No `aliases`.
- **Singular acquisition dims**: new `DIMS.repetition`; the Bruker loader emits `coil`/`average`/`repetition` (fixes a latent `AttributeError` on the nonexistent `DIMS.averages` in the plot stack-dim auto-detect).
- **Fixes #68**: `fit_amares` reads the canonical `reference_frequency` (the key xmris's own `simulate_fid`/`build_fid` write), so those FIDs fit with no manual `mhz=`. Hidden regression cell in `pyamares.md`.
- Bruker group-delay reads the canonical `group_delay` directly.

## New vocabulary (flagged per Commandment 4)
`DIMS.repetition`. No aliases.

## ⚠️ Notes
- Bruker multi-receiver data now loads with dim **`coil`** (was `channels`).
- **Behavior change:** the pre-existing `bruker_group_delay` legacy fallback (#85) is dropped — canonical-only, consistent with the no-back-compat stance (<1.0, no known users).
- Foreign-convention adaptation is a planned **follow-up**: `da.xmr.map_vocab(...)` renames a user's dims/coords/attr-keys onto the fixed vocabulary.

## Verification
- `uv run test` — 212 passed (incl. the #68 regression cell); `uv run ruff check .` clean; `uv run mypy src/xmris` no new errors (54, == baseline).

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)