### PR TITLE
fix(docs): repair the five render-breaking doc errors (#104)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ dims=["Voxel", "Time"]
 attrs={"B0_Field": 7.0, "MHz": 300.15}
 ```
 
-You are free to use any dimension names you like in your own data — xmris functions accept a `dim` argument to handle non-standard names. But when xmris creates or expects names internally, it uses lowercase. For the full rationale, see [The Architecture Guide](notebooks/basics/architecture.ipynb#the-lowercase-convention).
+You are free to use any dimension names you like in your own data — xmris functions accept a `dim` argument to handle non-standard names. But when xmris creates or expects names internally, it uses lowercase. For the full rationale, see [The Controlled Vocabulary](#the-lowercase-convention).
 :::
 
 ---
@@ -125,62 +125,10 @@ flowchart TD
 
 If you are curious about *why* xmris is built this way — why metadata lives in `.attrs`, why dimensions are flexible but attributes are strictly guarded, or what the `@requires_attrs` decorator does — read the architecture guide:
 
-* [**The xmris Architecture: Why We Built It This Way**](notebooks/basics/architecture.ipynb)
+* [**The xmris Architecture: Why We Built It This Way**](notebooks/basics/architecture.md)
 
 ---
 
 ## 🧭 Where do I start?
 
 We recommend going through the example notebooks. They are designed to be read more or less chronologically :)
-
-<!-- ### 1. The Basics
-
-Learn how <span style="color: #B05418;font-weight: bold;">x</span><span style="color: #002E7A;font-weight: bold;">mris</span> leverages `xarray` to make switching between the time and frequency domains completely painless.
-
-* [Basics of FFT](notebooks/basics/fft.ipynb)
-* [FID to Spectrum](notebooks/basics/fid_transformations.ipynb)
-* [Complex Number Handling](notebooks/basics/complex_numbers.ipynb)
-* [Hz and ppm Unit Handling](notebooks/basics/hz_and_ppm.ipynb)
-
-Or do a deeper dive on how <span style="color: #B05418;font-weight: bold;">x</span><span style="color: #002E7A;font-weight: bold;">mris</span> works:
-
-* [The xmris Architecture](notebooks/basics/architecture.ipynb)
-
-### 2. The Processing Pipeline
-
-This section guides you step-by-step through a complete MRS processing pipeline. We cover everything from loading raw data to state-of-the-art time-domain fitting using our `pyAMARES` integration.
-
-* [Zero Filling](notebooks/pipeline/zero_fill.ipynb)
-* [Apodization](notebooks/pipeline/apodization.ipynb)
-* [Manual Phasing](notebooks/pipeline/phase.ipynb)
-* [Automated Phasing](notebooks/pipeline/autophasing.ipynb)
-
-### 3. Fitting and Simulation
-
-* [FID simulation](notebooks/fitting/simufid.ipynb)
-* [pyAMARES Part I](notebooks/fitting/pyamares.ipynb)
-* [pyAMARES Part II ](notebooks/fitting/pyamares_advanced.ipynb)
-
-### 4. Visualization
-
-"Static" matplotlib based routines:
-
-* [Basics and the Ridge Plot (NMR Time Series)](notebooks/visualization/plot/01_plotting_basics.ipynb)
-* [The Heatmap Plot as an alternative NMR Time Series plot](notebooks/visualization/plot/02_plotting_heatmap.ipynb)
-* [Spectral Fitting Result Plotting](notebooks/visualization/plot/03_plotting_fit_1d.ipynb)
-
-Interactive routines:
-
-* [Interactive Spectrum Phasing](notebooks/visualization/widget/01_widget_phase.ipynb)
-
-### 5. Vendor Specific Routines
-
-* [Bruker Filter Removal](notebooks/vendor/bruker_filter_removal.ipynb)
-* [Bruker FID Building](notebooks/vendor/bruker_fid_loader.ipynb)
-
-### 6. API Reference
-
-Need to check the exact arguments for a function? The complete scope of the library can be found in the API reference.
-
-* [The `.xmr` Accessor](api_reference/accessor.md)
-* [API Index](api_reference/index.md) -->

--- a/docs/notebooks/basics/fft.md
+++ b/docs/notebooks/basics/fft.md
@@ -9,6 +9,9 @@ kernelspec:
   name: python3
 ---
 
+(fft)=
+# FFT Basics
+
 ```{code-cell} ipython3
 :tags: [remove-cell]
 

--- a/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
+++ b/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
@@ -31,7 +31,7 @@ plt.rcParams["figure.dpi"] = 150
 xr.set_options(display_expand_data=False)
 ```
 
-# Internal Validation: 13C NSPECT Slab Data
+## Internal Validation: 13C NSPECT Slab Data
 
 **Goal:** Strictly validate the Bruker data loader, memory reshaping, and coordinate calculation against a known ground-truth dataset (`nspect_slab_13C`). This ensures that future refactors to `xmris` do not break raw Paravision parsing or shift physical coordinate definitions.
 

--- a/docs/notebooks/visualization/widget/01_widget_phase.md
+++ b/docs/notebooks/visualization/widget/01_widget_phase.md
@@ -9,6 +9,9 @@ kernelspec:
   name: python3
 ---
 
+(widget-phase)=
+# Interactive Spectrum Phasing
+
 ```{code-cell} ipython3
 :tags: [remove-cell]
 


### PR DESCRIPTION
First half of #104. These five are the errors that produce a **wrong page today** — the other 136 are the mechanical missing-`(target)=` class, swept in a follow-up PR so the judgment work here isn't buried in diff noise.

## What was broken

| Where | Problem | Fix |
|---|---|---|
| `index.md:57`, `:128` | Both link a `.ipynb`. `myst.yml` excludes `notebooks/**/*.ipynb`, so both resolved to **null — on the landing page**, with no build warning | `:128` is a plain `.ipynb` → `.md` swap |
| `index.md:57` (again) | Also pointed at `#the-lowercase-convention`, a section since consolidated into `explanation/vocabulary.md:101`, so `.md` alone would still miss the anchor | Becomes the bare global reference `[The Controlled Vocabulary](#the-lowercase-convention)` — MyST resolves a `(target)=` wherever it's defined, and `architecture.md:415` already links it this way. Link text follows the target to its new home |
| `notebooks/basics/fft.md` | No H1 | `(fft)=` + `# FFT Basics` |
| `notebooks/visualization/widget/01_widget_phase.md` | No H1 | `(widget-phase)=` + `# Interactive Spectrum Phasing` |
| `notebooks/vendor/testonly_bruker_fid_loader_13C.md:34` | Second H1 | Demoted to H2 |

On the two no-H1 pages, mystmd was lifting an H2 into the title and rendering it **twice** — it only removes the heading from the body when it leads the page, and both opened with a hidden `remove-cell` setup cell. The H1 now goes first, setup cell second.

## Also: the dead nav block

`index.md` ended with a ~50-line commented-out `### 1. The Basics …` navigation block listing four notebooks that don't exist (`pyamares_advanced`, `01_plotting_basics`, `02_plotting_heatmap`, `03_plotting_fit_1d`). It rendered nothing, but its five headers and a third dead `.ipynb` link still counted against the checker. Deleted — **the rendered page is byte-identical before and after**, since the block was already invisible. The live "Where do I start?" section above it stands on its own next to the sidebar TOC.

## Verification

```
check_docs.py   141 → 131 errors   (every remaining one is the missing-(target)= class)
myst build --html   exit 0, zero warnings; both index links resolve (/vocabulary, /architecture),
                    no null or errored link nodes remain
nbmake          fft, 01_widget_phase, testonly_bruker_fid_loader_13C — 3 passed
```

Checked in the built output that both restructured pages now carry their title in `frontmatter.title` with **no duplicate heading in the body**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)