### PR TITLE
ci: pay down the docs-checker backlog to zero, then gate it (#104)

### DIFF
--- a/.claude/skills/docs-page/SKILL.md
+++ b/.claude/skills/docs-page/SKILL.md
@@ -27,6 +27,7 @@ example so you copy rather than reinvent.
 **Two paths never route here:**
 
 - `docs/diary/` belongs to the **`dev-diary`** skill. Hand off; do not write an entry from here.
+  (`check_docs.py` still checks entries — the structural rules in §2 bind every page in the tree.)
 - `docs/api_reference/` is **generated and gitignored**. `docs_api()` clears the directory before
   regenerating, so a hand edit there is destroyed with no git history to recover it. Fix the
   docstring in `src/` instead.
@@ -39,8 +40,9 @@ guide makes it worse.
 
 ## 2. Rules that survive genre
 
-Every one of these is enforced by `check_docs.py`, and every one is currently violated somewhere
-in the repo — the build is silent about all of them.
+Every one of these is enforced by `check_docs.py`, which the `Docs style` CI job runs over the
+whole tree on every PR. The build is silent about all of them; the gate is not. The tree is at
+zero errors — do not be the change that reopens the backlog.
 
 - **Frontmatter is exact**, and `display_name: Python 3 (xmris)` is the frozen project label. If
   your local Jupyter rewrites it (to `.venv`, `Python 3 (ipykernel)`, …), fix it back before
@@ -69,10 +71,11 @@ Background an expert would skip goes in a `:::{dropdown}`, off the main line.
 
 Most doc work is editing, and the house rules make thinning **expected work, not scope creep**.
 
-- Run the checker on the page *before* you start. Pre-existing errors are not yours to fix
-  silently, but say what you found — several pages carry them today.
-- Adding a `(target)=` above a header **changes its slug**. Grep for inbound links first:
-  `git grep -nF "#old-slug" -- docs`.
+- Run the checker on the page *before* you start. It should already be at zero errors; if it is
+  not, you inherited a broken page and CI will blame your PR for it — fix it and say so.
+- Every header already carries a target, so the live risk is **renaming** one: targets are
+  page-global in MyST, and a rename breaks every deep link to it. Grep first —
+  `git grep -nF "#old-slug" -- docs` — and prefer adding a new section over re-keying an old one.
 - Consolidating across pages is the *one home per concept* rule doing its job. Say what you moved
   in the PR body, and keep the orienting recap on the page you thinned.
 
@@ -82,7 +85,8 @@ Most doc work is editing, and the house rules make thinning **expected work, not
 uv run python .claude/skills/docs-page/check_docs.py docs/<path>/<page>.md
 ```
 
-Errors are render-breaking and exit 1; warnings are drift and exit 0. Then, for a **tutorial or an
+Errors are render-breaking and exit 1 — the same exit code the `Docs style` CI job gates on, so
+this run is the gate, locally. Warnings are drift and exit 0. Then, for a **tutorial or an
 explainer** — `test-gen` walks `docs/notebooks/` *and* `docs/explanation/`, so both are in the
 pytest suite:
 

--- a/.claude/skills/docs-page/check_docs.py
+++ b/.claude/skills/docs-page/check_docs.py
@@ -24,15 +24,18 @@ import sys
 from pathlib import Path
 
 # --- genre ------------------------------------------------------------------
-# Location is genre: the directory segment under docs/ names it. Diary entries
-# belong to the `dev-diary` skill and api_reference/ is generated + gitignored,
-# so neither is checked here.
+# Location is genre: the directory segment under docs/ names it. Writing a diary
+# entry belongs to the `dev-diary` skill, but the structural rules bind it like
+# any other page -- an entry missing from the TOC never renders, and the diary
+# is a review gate that only works if it does. Only api_reference/ escapes:
+# it is generated and gitignored, so there is nothing to hand-fix.
 GENRES = {
     "notebooks": "tutorial",
     "explanation": "explainer",
     "contributing": "guide",
+    "diary": "diary",
 }
-SKIP_DIRS = ("_build", "api_reference", "diary")
+SKIP_DIRS = ("_build", "api_reference")
 
 KERNEL_DISPLAY_NAME = "Python 3 (xmris)"
 
@@ -73,11 +76,29 @@ class Page:
         """Index of the first line past the closing frontmatter ``---``."""
         return self.frontmatter.count("\n") + 3 if self.frontmatter else 0
 
+    @staticmethod
+    def _uncomment(line: str, incomment: bool) -> tuple[str, bool]:
+        """Return the part of the line that renders, carrying block state.
+
+        Inline comments close on their own line; block comments span lines, so
+        the state has to be carried. Applied once here rather than per check, so
+        every rule sees the same page the reader does.
+        """
+        line = INLINE_COMMENT_RE.sub("", line)
+        if incomment:
+            if "-->" not in line:
+                return "", True
+            line, incomment = line.split("-->", 1)[1], False
+        if "<!--" in line:
+            return line.split("<!--", 1)[0], True
+        return line, False
+
     def _scan(self) -> None:
         fence: str | None = None
         info = ""
         body: list[str] = []
         cell_start = 0
+        incomment = False
         for i in range(self._body_start, len(self.lines)):
             line = self.lines[i]
             m = FENCE_RE.match(line)
@@ -92,10 +113,15 @@ class Page:
             if fence is not None:
                 body.append(line)
                 continue
-            self.prose.append((i, line))
-            hm = HEADER_RE.match(line)
+            # Commented-out prose is dead weight, not a broken page: a header or
+            # a link inside `<!-- -->` renders nothing, so neither is an error.
+            # Fences are already excluded above, which is why the state machine
+            # lives here -- a `<!--` inside a code cell must not flip it.
+            visible, incomment = self._uncomment(line, incomment)
+            self.prose.append((i, visible))
+            hm = HEADER_RE.match(visible)
             if hm:
-                self.headers.append((i, len(hm.group(1)), line.lstrip("#").strip()))
+                self.headers.append((i, len(hm.group(1)), visible.lstrip("#").strip()))
 
     def first_content_line(self) -> int | None:
         """Index of the first non-blank, non-frontmatter line."""
@@ -165,20 +191,9 @@ def check(page: Page, toc: set[str]) -> tuple[list[str], list[str]]:
 
     # --- dead .ipynb links --------------------------------------------------
     # myst.yml excludes notebooks/**/*.ipynb, so these resolve to null -- and
-    # the build emits no warning.
-    # Commented-out links never render, so they are dead weight rather than a
-    # broken page. Inline comments close on their own line; block comments span
-    # lines, so carry the state. Fences are already excluded -- page.prose is
-    # what _scan saw outside every one of them.
-    incomment = False
-    for i, raw in page.prose:
-        line = INLINE_COMMENT_RE.sub("", raw)
-        if incomment:
-            if "-->" not in line:
-                continue
-            incomment, line = False, line.split("-->", 1)[1]
-        if "<!--" in line:
-            incomment, line = True, line.split("<!--", 1)[0]
+    # the build emits no warning. page.prose is what _scan saw outside every
+    # fence, already stripped of anything a comment hides.
+    for i, line in page.prose:
         if IPYNB_LINK_RE.search(line):
             err(i, "links a .ipynb -- excluded from the build, so the link is dead")
 

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -8,6 +8,23 @@ on:
     branches: [ main ]
 
 jobs:
+  docs-check:
+    name: Docs style
+    runs-on: ubuntu-latest
+    # Stdlib-only and whole-tree: seconds, so it gets its own job rather than
+    # riding the test matrix. A docs failure then reads as a docs failure.
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Errors gate (exit 1) -- each one renders wrong or dies as a link, and
+      # `myst build` is silent about all of them. Warnings exit 0 by design:
+      # real drift, too judgment-dependent to block a PR on.
+      - name: Check docs style
+        run: python3 .claude/skills/docs-page/check_docs.py
+
   test:
     runs-on: ubuntu-latest
     # A healthy run is ~4 min; bound it so a hung kernel fails fast, not at GitHub's 6h ceiling.

--- a/docs/contributing/contract.md
+++ b/docs/contributing/contract.md
@@ -98,8 +98,12 @@ data)` bundles data and term metadata into a fully formed `xr.Variable` for `.as
 ### 8. Explicit MyST targets in docs
 
 Every docs header carries an explicit `(kebab-target)=` and is linked via `[text](#target)`, never
-an auto-generated slug. The full documentation law lives with the
-[docs-page workflow](#contribute-docs). *Enforced: `check_docs.py`.*
+an auto-generated slug — which mystmd numbers by *document position*, so inserting one section
+silently renumbers every anchor below it. The target is kebab-case and prefixed with the page
+topic (`baseline-visualizing-the-results`, not `visualizing-the-results`), since targets resolve
+page-globally. The full documentation law lives with the
+[docs-page workflow](#contribute-docs). *Enforced: `check_docs.py`, run over the whole tree by
+the `Docs style` job in `ci-fast.yml`.*
 
 (contract-c9)=
 ### 9. The accessor method is a thin delegator

--- a/docs/contributing/docs_pages.md
+++ b/docs/contributing/docs_pages.md
@@ -21,7 +21,15 @@ Documentation style](https://github.com/andrewendlinger/xmris/blob/main/CLAUDE.m
 
 The **`docs-page`** skill owns the cell structure, the hidden-assert convention, and the TOC step,
 and it ships a stdlib-only checker (`check_docs.py`) that catches what the build stays silent about
-— a missing target, a dead `.ipynb` link, a drifted kernel name. Its checklist:
+— a missing target, a dead `.ipynb` link, a drifted kernel name. Run it on the page you are editing:
+
+```bash
+uv run python .claude/skills/docs-page/check_docs.py docs/<path>/<page>.md
+```
+
+Its errors **gate CI** — the `Docs style` job in `ci-fast.yml` runs the same command over the whole
+tree on every PR, so a page with errors is a red build. Its warnings deliberately do not: they are
+real drift, but too judgment-dependent to block a merge on. The checklist:
 
 ```{literalinclude} ../../.claude/skills/docs-page/SKILL.md
 :language: markdown

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -1,8 +1,10 @@
+(setup)=
 # Recommended Setup
 
 
 We use modern, Rust-based tooling to keep the development environment blisteringly fast, completely reproducible, and free of dependency conflicts.
 
+(setup-uv)=
 ### 1. `uv` (Environment & Package Management)
 
 `uv` replaces `pip`, `virtualenv`, and `poetry`. It manages our dependencies, locks versions, and ensures perfectly isolated virtual environments.
@@ -12,6 +14,7 @@ We use modern, Rust-based tooling to keep the development environment blistering
 * **Run commands:** Always prefix development commands with `uv run` to ensure they execute inside the isolated environment (e.g., `uv run pytest` or `uv run jupyter lab`).
 * **Add dependencies:** If your contribution requires a new package, do not use `pip install`. Instead, run `uv add <package_name>`. This automatically updates the `pyproject.toml` and lockfile.
 
+(setup-ruff)=
 ### 2. `ruff` (Linting & Formatting)
 
 `ruff` is our single source of truth for code style, replacing `black`, `flake8`, and `isort` with a single tool that runs in milliseconds.
@@ -20,6 +23,7 @@ We use modern, Rust-based tooling to keep the development environment blistering
 * **Lint code:** Run `uv run ruff check .`
 * **Auto-fix issues:** Run `uv run ruff check . --fix` (This automatically fixes safe issues like unused imports or variables).
 
+(setup-vscode)=
 ### 3. VS Code Configuration
 
 To ensure a seamless, "it-just-works" experience, we use the official **Ruff extension**. This configuration enables "Format on Save" and organizes imports automatically using the project's specific `ruff` rules.

--- a/docs/diary/2026-07-22-authoring-skills.md
+++ b/docs/diary/2026-07-22-authoring-skills.md
@@ -1,7 +1,7 @@
 (diary-authoring-skills)=
 # The skills remember the rules so you don't
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-23 · #103</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-25 · #103, #104</span>
 
 Every change to xmris has to clear the same stack of contracts at once. A new function, for
 example, has to honour
@@ -65,6 +65,12 @@ refinements, now law in it:
   absorbed its later turns rather than spawning sequels, and its *Last edited* line says the
   story is current.
 
-New here? The [Contribute](#contribute-home) section is the map — start there. A stdlib-only
-checker (`check_docs.py`) enforces the docs-style half; the backlog it surfaced is
-[issue #104](https://github.com/andrewendlinger/xmris/issues/104).
+The docs-style half has a second enforcer, and it is not a skill. A stdlib-only checker
+(`check_docs.py`) measures the rules `myst build` stays silent about, and it first ran as an
+advisory: 141 errors across the tree, which is too many to gate on and too many to read. Paying
+them down ([#104](https://github.com/andrewendlinger/xmris/issues/104)) was worth doing only
+because of what it bought — at zero, `exit 1` became trustworthy, and the checker moved into
+`ci-fast.yml` as the **`Docs style`** job. The rules now hold the way the Commandments do: a
+missing target is a red build, not a note in a review.
+
+New here? The [Contribute](#contribute-home) section is the map — start there.

--- a/docs/explanation/vocabulary.md
+++ b/docs/explanation/vocabulary.md
@@ -22,6 +22,7 @@ Which raises the obvious question the moment you bring your own data:
 
 That single question shapes the whole vocabulary design. Let's follow it.
 
+(vocabulary-dialect)=
 ## Your data speaks a different dialect
 
 MR data arrives under a hundred naming conventions. A Bruker export, a Siemens twix file, a labmate's
@@ -43,6 +44,7 @@ fid.xmr.to_ppm()
 The frequency is *right there* under `spec_freq` — xmris simply refuses to assume `spec_freq` means
 what it hopes. Fair enough. But how should it let you fix that?
 
+(vocabulary-tempting-answer)=
 ## The tempting answer (and why we didn't)
 
 The friendly-looking move is to teach xmris your names: let each term carry a little table of aliases
@@ -70,6 +72,7 @@ at all.
 
 ❌ **The road not taken:** bend the vocabulary to fit the data.
 
+(vocabulary-bend-the-data)=
 ## The xmris way: bend the data to fit the vocabulary
 
 So we flipped it. The vocabulary stays fixed and small; *you* translate your data onto it, once, at
@@ -116,6 +119,7 @@ ecosystem rather than invented from scratch:
 you like (every function takes a `dim=` argument); it's only when xmris creates a name itself — the
 `chemical_shift` coordinate from `to_ppm()`, say — that it is guaranteed lowercase.
 
+(vocabulary-why-strict)=
 ## Why the vocabulary can afford to be this strict
 
 All of this only works because the vocabulary is a *fixed point* you can trust. So we make it one,
@@ -150,6 +154,7 @@ one concept across two places; `pint` is the right tool for *unit math* but the 
 does the job. (Full deliberation: [issue #65](https://github.com/andrewendlinger/xmris/issues/65).)
 :::
 
+(vocabulary-adding-a-word)=
 ## Adding a word
 
 Extending xmris and need a name that isn't there yet? Add it to `xmris.core.config` — never reach for

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
+(home)=
 # Welcome to xmris
 
 <span style="color: #B05418;font-weight: bold;">x</span><span style="color: #002E7A;font-weight: bold;">mris</span> is an [xarray](https://xarray.dev)-based toolkit for Magnetic Resonance Imaging and Spectroscopy (MRIS).
@@ -8,6 +9,7 @@ By keeping your multi-dimensional data permanently linked to its named dimension
 
 ---
 
+(home-quick-start)=
 ## ⚡ Quick Start: A Minimal Working Example
 
 Because <span style="color: #B05418;font-weight: bold;">x</span><span style="color: #002E7A;font-weight: bold;">mris</span> functions return standard `xarray` objects, you can chain methods together to build readable, N-dimensional processing pipelines without writing a single `for` loop:
@@ -59,6 +61,7 @@ You are free to use any dimension names you like in your own data — xmris func
 
 ---
 
+(home-how-it-works)=
 ## 🧠 How it Works: xarray + xmris
 
 By simply importing `xmris`, standard `xarray` DataArrays instantly gain specialized MRIS functionality. You put an `xarray` in, apply a method, and get a processed `xarray` out.
@@ -84,7 +87,7 @@ It is the exact same data object, meaning you never have to switch contexts or c
 
 Here is a conceptual look at how your raw data might be structured and processed through the <span style="color: #B05418;font-weight: bold;">x</span><span style="color: #002E7A;font-weight: bold;">mris</span> pipeline:
 
-```mermaid
+```{mermaid}
 flowchart TD
     %% 1. Reusable Class Definitions
     classDef component fill:#ffffff,stroke:#adb5bd,stroke-width:1px,stroke-dasharray: 2 2
@@ -121,6 +124,7 @@ flowchart TD
 
 ---
 
+(home-design)=
 ## 🏗️ Want to Understand the Design?
 
 If you are curious about *why* xmris is built this way — why metadata lives in `.attrs`, why dimensions are flexible but attributes are strictly guarded, or what the `@requires_attrs` decorator does — read the architecture guide:
@@ -129,6 +133,7 @@ If you are curious about *why* xmris is built this way — why metadata lives in
 
 ---
 
+(home-where-to-start)=
 ## 🧭 Where do I start?
 
 We recommend going through the example notebooks. They are designed to be read more or less chronologically :)

--- a/docs/notebooks/basics/architecture.md
+++ b/docs/notebooks/basics/architecture.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(architecture)=
 # The xmris Architecture: Why We Built It This Way
 
 Welcome to the engine room of `xmris`! If you are wondering why we rely so heavily on `xarray`, why we don't just pass sequence parameters as function arguments, or what the deal is with our decorators, you are in the right place.
@@ -21,6 +22,7 @@ Let's dive in.
 
 +++
 
+(architecture-parameter-soup)=
 ## 1. The Parameter Soup Problem
 
 Imagine you are writing Python functions to process an MRI Free Induction Decay (FID) signal.  You need the raw data, but to do anything meaningful — converting frequencies to ppm, removing a digital filter, auto-phasing — you also need the scanner metadata: the spectrometer frequency, the B0 field, the dwell time, and so on.
@@ -61,6 +63,7 @@ data = autophase(data, mhz=300.15, dwell_time=0.0005)
 
 ```
 
+(architecture-xarray-solution)=
 ### The `xarray` Solution
 
 To avoid parameter soup, `xmris` is built natively on top of [xarray](https://docs.xarray.dev/en/stable/). An `xarray.DataArray` bundles together the raw data, **named dimensions** ("numpy axes"), coordinates (axis labels), and arbitrary metadata (`.attrs`) into a single, self-describing object.
@@ -145,6 +148,7 @@ which integer axis is which. The metadata and the axis semantics travel
 
 +++
 
+(architecture-hidden-state)=
 ## 2. The Danger of "Hidden State"
 
 Encapsulation is beautiful, but it introduces a dangerous new problem: **magic strings and hidden state.**
@@ -267,6 +271,7 @@ an `AttributeError` at import time — not a silent bug three hours into a proce
 
 ```
 
+(architecture-dictionary-internals)=
 ### How the Dictionary Is Used Internally
 
 Throughout the `xmris` codebase, **no function uses a bare string to access metadata.** Every
@@ -344,6 +349,7 @@ flowchart LR
 
 The decorator does two things:
 
+(architecture-fail-fast)=
 ### 1. Fail-Fast with Helpful Errors
 
 If a required attribute is missing, the bouncer intercepts the call *before* any math runs
@@ -364,6 +370,7 @@ copy-pasteable fix code.
 
 :::
 
+(architecture-self-documenting)=
 ### 2. Self-Documenting Functions
 
 At import time, the decorator dynamically injects a **"Required Attributes"** section into
@@ -394,6 +401,7 @@ sync with the code.
 
 +++
 
+(architecture-dims-vs-attrs)=
 ## 5. Dimensions vs. Attributes: The Great Divide
 
 You might be wondering: *"If decorators are so great for attributes, why don't you use them for dimensions to enforce consistent use of e.g. `time` or `frequency`?"*
@@ -402,12 +410,14 @@ This was the single most important architectural decision we made. We treat **Di
 and **Attributes** with different strategies, because they play fundamentally
 different roles.
 
+(architecture-attrs-hidden-state)=
 ### Attributes Are "Hidden State"
 
 A B0 field strength is a physical constant of the experiment. You don't apply an operation
 *to* the B0 field; the math just requires it to exist in the background. Because it is
 invisible, it needs strict guarding by our `@requires_attrs` decorator.
 
+(architecture-dims-action-space)=
 ### Dimensions Are an "Action Space"
 
 When you apply an FFT or an apodization, you are actively choosing *which axis* to act upon.
@@ -452,6 +462,7 @@ or rename your data's axes using xarray:
 
 :::
 
+(architecture-design-rule)=
 ### The Design Rule
 
 Here is the rule we follow throughout the entire codebase:
@@ -467,6 +478,7 @@ Here is the rule we follow throughout the entire codebase:
 
 +++
 
+(architecture-putting-it-together)=
 ## Putting It All Together
 
 Let's trace through a single function call — `spectrum.xmr.to_ppm()` — to see every
@@ -494,6 +506,7 @@ Every layer serves a distinct purpose:
 
 +++
 
+(architecture-summary)=
 ## Summary
 
 By combining `xarray` encapsulation, a strongly-typed Data Dictionary, fail-fast decorators

--- a/docs/notebooks/basics/complex_numbers.md
+++ b/docs/notebooks/basics/complex_numbers.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(complex-numbers)=
 # Complex Number Handling
 
 ```{code-cell} ipython3
@@ -21,6 +22,7 @@ matplotlib_inline.backend_inline.set_matplotlib_formats("retina")
 plt.rcParams["figure.dpi"] = 150
 ```
 
+(complex-mri-data)=
 ## Handling Complex MRI/MRS Data
 
 Magnetic resonance data is inherently complex-valued, but many standard tools lack native support for complex numbers. Splitting this data into separate real and imaginary channels is frequently required for:
@@ -49,9 +51,10 @@ import xarray as xr
 import xmris
 ```
 
+(complex-split)=
 ### 1. Splitting Complex Data into Channels
 
-```mermaid
+```{mermaid}
 flowchart LR
     %% Define Nodes
     A["<b>da_complex</b><br>Shape: (time: 512)<br>Dtype: complex128<br>Values: a + bi"]
@@ -112,6 +115,7 @@ ax.set_title("FID Split into Real and Imaginary Components")
 plt.show()
 ```
 
+(complex-split-dim)=
 ### 2. Customizing the Split Dimension
 
 If your specific ML pipeline expects the channel dimension to have a specific name (e.g., `"channel"` instead of `"component"`), you can pass these arguments directly to the function.
@@ -121,6 +125,7 @@ da_torch = da_complex.xmr.to_real_imag(dim="channel", coords=("ch0", "ch1"))
 print("Custom Dimension:", da_torch.dims)
 ```
 
+(complex-reconstruct)=
 ### 3. Reconstructing the Complex Array
 
 After processing the split channels (e.g., passing them through a neural network), you can seamlessly collapse the dimension back down to a standard complex array for downstream signal processing (like an FFT) using `.xmr.to_complex()`.

--- a/docs/notebooks/basics/fft.md
+++ b/docs/notebooks/basics/fft.md
@@ -31,6 +31,7 @@ While `numpy.fft` is incredibly fast, applying it directly to physical data is n
 
 The `xmris` Fourier module provides a mathematically rigorous, `xarray`-native toolbox to solve these issues. It handles orthogonal normalization, coordinate math, and shifting automatically.
 
+(fft-overview)=
 ## Overview of Available Functions
 
 The module provides three pairs of functions to handle any transformation scenario:
@@ -47,7 +48,7 @@ The module provides three pairs of functions to handle any transformation scenar
 
     Convenience wrappers for symmetrically sampled data (like imaging). It chains shifts *before* and *after* the transform to keep the zero-frequency component dead center.
 
-```mermaid
+```{mermaid}
 flowchart TD
     subgraph Centered Transform
         D2[(Input Data)] --> S1[ifftshift] --> F2[xmris.fft] --> S2[fftshift] --> O2[(Centered Output)]
@@ -72,6 +73,7 @@ import xmris  # Registers the .xmr accessor
 
 ---
 
+(fft-1d-signal)=
 ## 1. 1D Signal: Time Domain to Frequency Domain
 
 Let's generate a simple, synthetic time-domain signal: a decaying sine wave with a 50 Hz frequency offset.
@@ -138,6 +140,7 @@ assert np.isclose(energy_time, energy_freq), "FFT energy conservation failed!"
 
 ---
 
+(fft-2d-kspace)=
 ## 2. Imaging: 2D $k$-space to Image Space
 
 The true power of `xarray` + `xmris` shines in multi-dimensional data. Let's create a synthetic 2D $k$-space using custom dimension strings (`"kx"` and `"ky"`). We will use a simple 2D rectangle, which analytically transforms into a 2D sinc function in the image domain.

--- a/docs/notebooks/basics/fid_transformations.md
+++ b/docs/notebooks/basics/fid_transformations.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(fid-transforms)=
 # FID - Transformations
 
 ```{code-cell} ipython3
@@ -28,15 +29,14 @@ In Magnetic Resonance Spectroscopy (MRS), the raw data acquired by the scanner i
 
 To visualize the chemical resonances, this digital FID signal is processed by a discrete Fourier transformation (DFT) to produce a digital MR spectrum. Because an FID conventionally starts at $t=0$, we perform a standard Fast Fourier Transform (FFT) followed by a frequency-domain shift (`fftshift`) to center the zero-frequency (DC) component.
 
-```mermaid
+```{mermaid}
 flowchart LR
     A[Time-Domain / FID] --> B(FFT) --> C(fftshift) --> D[Frequency-Domain / Spectrum]
 
     style A fill:#e1f5fe,stroke:#01579b,stroke-width:2px
-    style D fill:#e8f5e9,stroke:#2e7d32,s
-
+    style D fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
 ```
-```mermaid
+```{mermaid}
 flowchart LR
     D[Frequency-Domain / Spectrum] --> E(ifftshift) --> F(IFFT) --> A[Time-Domain / FID]
 
@@ -53,6 +53,7 @@ import xarray as xr
 import xmris.core.accessor
 ```
 
+(fid-transforms-simulate)=
 ## 1. Generate a Synthetic FID
 Let's create an FID with two distinct resonances (at 50 Hz and -150 Hz).
 
@@ -79,6 +80,7 @@ plt.title("Synthetic FID (Real Part)")
 plt.show()
 ```
 
+(fid-transforms-to-spectrum)=
 ## 2. Convert to Spectrum
 We use `.xmr.to_spectrum()` to perform the FFT and automatically rename the dimension to "frequency". Notice how the resulting coordinates automatically represent the correct centered frequency axis (ranging from -500 Hz to 500 Hz).
 
@@ -127,6 +129,7 @@ np.testing.assert_allclose(
 )
 ```
 
+(fid-transforms-to-fid)=
 ## 3. Convert back to FID
 We can accurately recover the original time-domain signal using `.xmr.to_fid()`.
 

--- a/docs/notebooks/basics/hz_and_ppm.md
+++ b/docs/notebooks/basics/hz_and_ppm.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(hz-ppm)=
 # Spectrum - Coordinate Transformations (Hz to ppm)
 
 ```{code-cell} ipython3
@@ -30,6 +31,7 @@ To compare spectra across different scanners (e.g., 1.5T vs 3T vs 7T), we conver
 
 `xmris` provides dedicated methods to swap between these coordinate systems seamlessly while tracking the physical metadata.
 
+(hz-ppm-physics)=
 ## The Physics & Math
 
 The conversion relies on two critical pieces of metadata that must be stored in your `xarray.DataArray.attrs`:
@@ -43,7 +45,7 @@ $$ \text{ppm} = \text{carrier\_ppm} + \left( \frac{\text{Hz}}{\text{reference\_f
 
 $$ \text{Hz} = (\text{ppm} - \text{carrier\_ppm}) \times \text{reference\_frequency} $$
 
-```mermaid
+```{mermaid}
 flowchart LR
 
     freq[/"<b>Frequency</b><br>Hz"/]
@@ -77,6 +79,7 @@ import xarray as xr
 import xmris
 ```
 
+(hz-ppm-simulate)=
 ## 1. Generating a Synthetic Spectrum
 
 Let's generate a mock frequency-domain spectrum (in Hz) acquired on a 3T scanner. We must stamp the required physics metadata into the `.attrs`.
@@ -119,6 +122,7 @@ plt.show()
 
 ---
 
+(hz-ppm-to-ppm)=
 ## 2. Converting to Chemical Shift (ppm)
 
 Using `.xmr.to_ppm()`, `xmris` calculates the new chemical shift coordinates, creates a properly labeled axis, and automatically swaps the primary dimension of the DataArray from `"frequency"` to `"chemical_shift"`.
@@ -145,6 +149,7 @@ This strict validation guarantees that your physical conversions are always root
 
 ---
 
+(hz-ppm-to-hz)=
 ## 3. Converting back to Frequency (Hz)
 
 The operation is perfectly invertible using `.xmr.to_hz()`.

--- a/docs/notebooks/fitting/pyamares.md
+++ b/docs/notebooks/fitting/pyamares.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(pyamares)=
 # Time-Domain Fitting with AMARES
 
 ```{code-cell} ipython3
@@ -39,6 +40,7 @@ In contrast, frequency-domain fitting methods like LCModel require all metabolit
 LCModel and AMARES have been compared directly and proven to be comparable, each with its own advantages. However, AMARES is often the preferred method for quantifying X-nuclei MRS data, such as 13C and 31P MRS, where spectra typically exhibit fewer peaks and less J-coupling compared to 1H MRS.
 :::
 
+(pyamares-nd-advantage)=
 ## The N-Dimensional Advantage
 
 
@@ -47,7 +49,7 @@ Traditional fitting tools often force you to write `for` loops to fit multiple s
 
 You pass in an N-dimensional `DataArray`, and the package automatically flattens the spatial dimensions, distributes the fitting across your CPU cores, and reconstructs the results into an aligned `xarray.Dataset`.
 
-```mermaid
+```{mermaid}
 graph LR
     A[Input DataArray<br>Dims: Voxel, Time] --> B(xmris Auto-Flatten)
     B --> C{joblib/loky Parallel Pool}
@@ -74,6 +76,7 @@ import xarray as xr
 import xmris.core.accessor
 ```
 
+(pyamares-prior-knowledge)=
 ## 1. Define Prior Knowledge
 AMARES requires Prior Knowledge (PK) to know how many peaks to look for and what constraints to place on their parameters (amplitude, frequency, linewidth, phase). This is provided as a CSV file.
 
@@ -101,6 +104,7 @@ pk_path = Path("example_pk.csv")
 pk_path.write_text(pk_csv_content)
 ```
 
+(pyamares-simulate)=
 ## 2. Generate N-Dimensional Synthetic Data
 We will simulate a 1D spatial array containing 5 voxels. To make it realistic, we will vary the amplitude of the PCr peak across the voxels, representing a spatial concentration gradient, while keeping ATP constant.
 
@@ -163,6 +167,7 @@ ax.set_title("Synthetic MRSI Data: PCr Gradient & Constant ATP")
 plt.show()
 ```
 
+(pyamares-fit)=
 ## 3. Fit the Data with xmris
 We pass the `DataArray` to `.xmr.fit_amares()`.
 
@@ -224,6 +229,7 @@ PyAMARES safely catches this and defaults the P matrix to an identity matrix. Th
 
 +++
 
+(pyamares-result-dataset)=
 ### Exploring the Resulting Dataset
 
 The returned `Dataset` is incredibly powerful. Instead of returning raw numbers, `xmris` neatly categorizes the fitting outputs into two sets of variables, mapped along their natural physical dimensions:
@@ -279,6 +285,7 @@ ax.legend()
 plt.show()
 ```
 
+(pyamares-quality-control)=
 ### Quality Control (Tabular & Visual)
 
 In quantitative MRS, simply looking at a plot is not enough to confirm a successful fit. The gold standard for assessing fit quality is the **Cramér-Rao Lower Bound (CRLB)**, which estimates the minimum variance of the fitted parameters.

--- a/docs/notebooks/fitting/simufid.md
+++ b/docs/notebooks/fitting/simufid.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(simufid)=
 # Simulating NMR Spectra with xmris
 
 In this tutorial, we will use the `xmris.processing.simulation` module to generate synthetic Free Induction Decay (FID) signals. Generating synthetic data is a critical step for validating fitting algorithms, building test suites, and understanding the physical parameters that govern magnetic resonance spectroscopy (MRS).
@@ -19,6 +20,7 @@ We will generate two distinct datasets with realistic parameters and physical no
 
 +++
 
+(simufid-theory)=
 ## Theory: The AMARES Simulation Model
 
 The signal generation in `xmris` is grounded in the AMARES (Advanced Method for Accurate, Robust, and Efficient Spectral fitting) algorithm, originally introduced by Vanhamme, van den Boogaart, and Van Huffel in 1997.
@@ -39,6 +41,7 @@ Where the parameters for each peak $k$ are defined as:
 
 +++
 
+(simufid-setup)=
 ## 1. Environment Setup
 
 First, let's import the necessary libraries. We will use `numpy` for array math, `xarray` for data structures, `matplotlib.pyplot` for figure management, and our updated `simulate_fid` function.
@@ -52,6 +55,7 @@ import matplotlib.pyplot as plt
 from xmris.fitting.simulation import simulate_fid
 ```
 
+(simufid-proton)=
 ## 2. Simulating a Noisy 1H (Proton) Spectrum
 
 Proton spectroscopy in tissue is dominated by the massive water peak and the lipid backbone resonances. For this simulation, we assume a 3T clinical scanner (Larmor frequency ~127.7 MHz). We will also inject a realistic noise floor using our `target_snr` feature.
@@ -124,6 +128,7 @@ ax.text(0.9, 2, "-CH3", ha='center', va='bottom', fontsize=10)
 plt.show()
 ```
 
+(simufid-carbon)=
 ## 3. Simulating a 13C (Carbon-13) Spectrum with Carrier Offsets
 
 Carbon-13 MRS spans a much wider chemical shift range. We will simulate the downstream metabolites of [1-13C]pyruvate. If we simulated this relative to 0 ppm, the massive frequency offsets would violate the Nyquist limit at standard sampling rates, causing the peaks to wrap (alias) to the wrong side of the spectrum.

--- a/docs/notebooks/pipeline/apodization.md
+++ b/docs/notebooks/pipeline/apodization.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(apodization)=
 # FID - Apodization
 
 ```{code-cell} ipython3
@@ -37,6 +38,7 @@ import xarray as xr
 import xmris
 ```
 
+(apodization-simulate)=
 ## 1. Generating Synthetic Data
 
 Let's generate a synthetic FID consisting of a single decaying resonance with added Gaussian noise. We pack this into an `xarray.DataArray` to preserve physical coordinates and metadata.
@@ -75,6 +77,7 @@ plt.show()
 
 ---
 
+(apodization-exponential)=
 ## 2. Exponential Apodization (Line Broadening)
 
 A common filter function is the decreasing mono-exponential weighting: $f_{filter}(t) = e^{-t/T_L}$.
@@ -175,6 +178,7 @@ assert da_exp.attrs.get("apodization_lb") == _lb, "Lineage failed: missing lb fa
 
 ---
 
+(apodization-lorentz-gauss)=
 ## 3. Lorentzian-to-Gaussian Transformation
 
 The Lorentzian-to-Gaussian filter converts a standard Lorentzian line shape into a Gaussian line shape, which decays to the baseline in a narrower frequency range. A standard Lorentzian shape produces longer "tails", which is a disadvantage when trying to accurately integrate overlapping resonance lines.

--- a/docs/notebooks/pipeline/baseline.md
+++ b/docs/notebooks/pipeline/baseline.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(baseline)=
 # Asymmetric Least Squares (AsLS) Baseline Correction
 
 Magnetic Resonance Spectroscopy (MRS) signals often ride on top of a broad, rolling baseline. This distortion is typically caused by macromolecules with extremely short $T_2$ relaxation times (creating very broad frequency-domain peaks), acoustic ringing, or incomplete water suppression. 
@@ -17,6 +18,7 @@ To accurately quantify the sharp, narrow metabolite peaks, this baseline must be
 
 
 
+(baseline-mathematics)=
 ## The Mathematics of AsLS
 
 In `xmris`, we use the **Asymmetric Least Squares (AsLS)** algorithm introduced by @eilers2005baseline. Unlike simple polynomial fitting, AsLS does not require the user to manually define "signal-free" noise regions. Instead, it balances two competing goals: minimizing the distance between the experimental data and the baseline, and maximizing the smoothness of the baseline itself.
@@ -110,6 +112,7 @@ corrected_spectrum = spectrum.xmr.baseline_als(
 )
 ```
 
+(baseline-visualizing-the-results)=
 ### Visualizing the Results
 
 Let's look at the original real spectrum, the isolated baseline, and the final corrected spectrum.

--- a/docs/notebooks/pipeline/domain_agnostic_autophase.md
+++ b/docs/notebooks/pipeline/domain_agnostic_autophase.md
@@ -54,7 +54,7 @@ filled with the spectral dimension actually present (`frequency` [Hz] or
 `autophase` is a **funnel** operation — you phase in order to inspect the
 spectrum, so the result lands there:
 
-```mermaid
+```{mermaid}
 flowchart TD
     A["fid.xmr.autophase()"] --> B{"@ensures_domain(SPECTRAL_DIMS)"}
     B -- "time-domain FID" --> C["auto-FFT → spectrum"]
@@ -116,6 +116,7 @@ def plot_real(spectra, title):
 
 :::
 
+(domain-agnostic-autophase-fid)=
 ## Hand it a raw FID
 
 We simulate a noisy, **time-domain** FID with a 65° zero-order phase error baked in.
@@ -180,6 +181,7 @@ assert ATTRS.phase_p1 in phased.attrs
 assert np.real(phased).max() > np.real(raw_spectrum).max()
 ```
 
+(domain-agnostic-autophase-spectrum)=
 ## Already a spectrum? No extra FFT.
 
 The same call on data that is *already* spectral is a no-op on the domain — the

--- a/docs/notebooks/pipeline/phase.md
+++ b/docs/notebooks/pipeline/phase.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(phase)=
 # Spectrum - Phase Correction
 
 ```{code-cell} ipython3
@@ -48,6 +49,7 @@ import xarray as xr
 import xmris
 ```
 
+(phase-simulate)=
 ## 1. Generating Synthetic Unphased Data
 
 Let's generate a synthetic, noisy Free Induction Decay (FID) with two distinct peaks,
@@ -90,6 +92,7 @@ plt.tight_layout()
 plt.show()
 ```
 
+(phase-manual)=
 ## 2. Manual Phase Correction
 
 :::{tip} Interactive manual phase correction
@@ -163,6 +166,7 @@ When you apply phase correction, `xmris` appends the following attributes to the
 $$\phi(x) = p_0 + p_1 \cdot \frac{x - x_{pivot}}{x_{max} - x_{min}}$$
 :::
 
+(phase-next-autophase)=
 ## Next up: Automated Phase Correction (`autophase`)
 
 Finding the perfect phase angles manually is tedious. We can use algorithms such as entropy-minimization

--- a/docs/notebooks/pipeline/zero_fill.md
+++ b/docs/notebooks/pipeline/zero_fill.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(zero-fill)=
 # FID - Zero Filling
 
 ```{code-cell} ipython3
@@ -26,6 +27,7 @@ plt.rcParams["figure.dpi"] = 150
 
 In Magnetic Resonance, **zero filling** involves artificially extending a dataset in the time domain (FID) or spatial-frequency domain (k-space) by padding it with zeros.
 
+(zero-fill-physics)=
 ### The Physics of Zero Filling
 
 While it is often mistaken for increasing "true" resolution, zero filling does **not** add new information. According to the Fourier Shift Theorem and DFT properties:
@@ -44,6 +46,7 @@ import xarray as xr
 import xmris
 ```
 
+(zero-fill-simulate)=
 ## 1. Generating a Realistic FID: Sampled Data
 
 Let's define a function to simulate a multi-component FID with $T_2^*$ decay and specific frequency offsets.
@@ -76,6 +79,7 @@ da_fid_sampled = xr.DataArray(
 )
 ```
 
+(zero-fill-time-domain)=
 ## 2. Time-Domain Zero Filling
 
 We apply zero filling to the sampled data, extending it from 64 points to 512 points by padding zeros at the end of the acquisition window.
@@ -123,6 +127,7 @@ This architecture allows `xmris` to intercept your request and automatically inj
 For more info see [xmris Architecture: Why We Built It This Way](../basics/architecture.md)
 :::
 
+(zero-fill-interpolation)=
 ### Interpolating the Truth (Frequency Domain)
 
 When we transform the zero-filled data, the zeros act as mathematical anchors, forcing the FFT to interpolate the discrete points, resulting in a much smoother spectrum. Note that the peaks do not become narrower (resolution has not increased), but their shapes are better defined.
@@ -205,6 +210,7 @@ assert da_fid_zf.attrs.get("zero_fill_position") == "end", "Lineage failed: miss
 
 ---
 
+(zero-fill-kspace)=
 ## 3. Spatial Frequency Zero Filling (2D K-Space)
 
 In MRI imaging, we zero-fill k-space symmetrically to artificially boost the digital resolution matrix (e.g., from 32x32 to 128x128).
@@ -227,6 +233,7 @@ da_k2d_zf = da_k2d.xmr.zero_fill(dim="kx", target_points=target_k_points, positi
 da_k2d_zf = da_k2d_zf.xmr.zero_fill(dim="ky", target_points=target_k_points, position="symmetric")
 ```
 
+(zero-fill-image-reconstruction)=
 ### Image Reconstruction
 
 Transforming back to image space demonstrates how zero-filling smooths the blocky pixels of the low-resolution acquisition. Because we use symmetric padding in k-space, the resulting image remains centered.

--- a/docs/notebooks/vendor/bruker_fid_loader.md
+++ b/docs/notebooks/vendor/bruker_fid_loader.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(bruker-fid)=
 # Visual Verification: FID Loader and Processing Pipeline
 
 ```{warning} **Work in Progress 🚧**
@@ -39,6 +40,7 @@ from xmris.core.config import DIMS, COORDS
 xr.set_options(display_expand_data=False)
 ```
 
+(bruker-fid-load)=
 ## 1. Data Loading and Reshaping
 
 Raw Bruker data is read as a continuous 1D array. To make it useful, we must reshape it into an N-dimensional C-contiguous array based on the acquisition parameters, and then wrap it in an `xarray.DataArray` with the correct physical coordinates.
@@ -60,6 +62,7 @@ print(f"Constructed FID Shape: {fid_xr.shape}")
 print(f"Assigned Attributes: {list(fid_xr.attrs.keys())}")
 ```
 
+(bruker-fid-time-domain)=
 ## 2. Inspecting the Time Domain (FID)
 
 To simplify our visual inspection, we will select the first repetition, channel, or average if the data is multi-dimensional. We then plot the Free Induction Decay (FID) to verify signal decay shape, complex quadrature, and the absence of truncation artifacts.
@@ -84,6 +87,7 @@ ax.grid(True, alpha=0.3)
 plt.show()
 ```
 
+(bruker-fid-digital-filter)=
 ### Removing the Digital Filter
 
 Bruker spectrometers utilize digital filters that introduce a group delay at the beginning of the FID. `build_fid` already stored that value in the FID's metadata (`group_delay`), so the default `remove_digital_filter()` reads it automatically — no need to pass the delay by hand. If the header value is unreliable, pass `group_delay="measure"` instead to estimate the true delay from the data (see [The Digital Filter Group Delay](bruker_filter_removal.md)).
@@ -104,6 +108,7 @@ ax.grid(True, alpha=0.3)
 plt.show()
 ```
 
+(bruker-fid-pipeline)=
 ## 3. The `xmris` Spectral Pipeline
 
 With the FID corrected, we can pass it through the `xmris` processing pipeline. Here, we apply an exponential apodization to smooth the signal, transform it to the frequency domain, and automatically correct the phase.
@@ -120,6 +125,7 @@ spectrum = (
 spectrum
 ```
 
+(bruker-fid-frequency-domain)=
 ### Visualizing the Frequency Domain
 
 We can visualize the resulting spectrum. Note how `xarray` automatically handles the coordinate labels. We invert the x-axis to adhere to standard NMR/MRI conventions.
@@ -162,6 +168,7 @@ plt.tight_layout()
 plt.show()
 ```
 
+(bruker-fid-ppm)=
 ## 4. Chemical Shift Conversion
 
 For chemical analysis, viewing the spectrum in parts per million (ppm) is more useful than raw Hertz. The `.xmr.to_ppm()` accessor handles this conversion automatically using the spectrometer frequency metadata.
@@ -207,6 +214,7 @@ plt.tight_layout()
 plt.show()
 ```
 
+(bruker-fid-reverse)=
 ## 5. Reverse Transformation
 
 The `xmris` accessors preserve metadata and coordinates perfectly, allowing seamless reverse transformations. We can convert our processed spectrum back into the time domain using `.xmr.to_fid()`.

--- a/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
+++ b/docs/notebooks/vendor/testonly_bruker_fid_loader_13C.md
@@ -9,6 +9,7 @@ kernelspec:
   display_name: Python 3 (xmris)
 ---
 
+(bruker-13c)=
 # Internal Test: Bruker 13C Slab Reshaping and Validation
 
 ```{code-cell} ipython3
@@ -31,10 +32,12 @@ plt.rcParams["figure.dpi"] = 150
 xr.set_options(display_expand_data=False)
 ```
 
+(bruker-13c-validation)=
 ## Internal Validation: 13C NSPECT Slab Data
 
 **Goal:** Strictly validate the Bruker data loader, memory reshaping, and coordinate calculation against a known ground-truth dataset (`nspect_slab_13C`). This ensures that future refactors to `xmris` do not break raw Paravision parsing or shift physical coordinate definitions.
 
+(bruker-13c-ground-truth)=
 ## 1. Load Ground Truth
 
 We dynamically load the exact acquisition parameters and expected spectral peak locations derived from the `ground_truth.toml` file.
@@ -53,6 +56,7 @@ print(f"Loaded Ground Truth for: {gt_13c['dataset_name']}")
 print(f"System: {gt_13c['system']} ({gt_13c['vendor_version']})")
 ```
 
+(bruker-13c-reshape)=
 ## 2. Load and Reshape Data
 
 Load the continuous 1D complex array and pass it through the `xmris` Bruker reshaping utilities.
@@ -75,6 +79,7 @@ print(f"Dimensions: {fid_xr.dims}")
 print(f"Minimal Attributes: {fid_xr.attrs}")
 ```
 
+(bruker-13c-metadata)=
 ## 3. Metadata Assertions
 
 Verify that `build_fid` accurately mapped the minimal required physical metadata to the `xarray` attributes by comparing them directly against the values in the TOML file.
@@ -97,6 +102,7 @@ assert fid_xr.sizes[DIMS.time] == params["general"]["acq_points"]["value"], "Acq
 print("✅ Minimal metadata and dimension assertions passed.")
 ```
 
+(bruker-13c-coordinates)=
 ## 4. Pipeline & Coordinate Validation
 
 Apply the standard `xmris` processing pipeline. This validates that the `remove_digital_filter`, `to_spectrum`, and `to_ppm` accessors execute correctly using the minimal metadata map.
@@ -121,6 +127,7 @@ spectrum_hz = (
 spectrum_ppm = spectrum_hz.xmr.to_ppm()
 ```
 
+(bruker-13c-visual-check)=
 ## 5. Visual Peak Sanity Check
 
 Visually verify that the peaks align with our expected ground truth markers in both the `Hz` and `ppm` domains.
@@ -156,6 +163,7 @@ plt.tight_layout()
 plt.show()
 ```
 
+(bruker-13c-peak-assertions)=
 ## 6. Quantitative Peak Assertions
 
 Finally, we programmatically verify that the maximum signal intensities lie within a very narrow tolerance ($\pm 2.5$ Hz and $\pm 0.1$ ppm) of the declared ground truth coordinates. This guarantees the coordinate math inside `to_spectrum` and `to_ppm` is exact.
@@ -187,6 +195,7 @@ for peak_name, locs in gt_13c["spectrum_view"].items():
 print("\n🚀 All pipeline and coordinate assertions passed.")
 ```
 
+(bruker-13c-group-delay)=
 ## 7. Group-Delay Estimator Sanity Check
 
 Validate `estimate_group_delay` against the real acquisition. There is no ground-truth "true" delay for this probe, so we assert conservatively: the measured delay is physically plausible and, being the residual-phase minimiser over the search window, never leaves *more* residual phase than the vendor header value.

--- a/docs/notebooks/visualization/plot/01_plot_basics.md
+++ b/docs/notebooks/visualization/plot/01_plot_basics.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(plot-basics)=
 # Introduction to Config-Based Plotting
 
 Generating publication-ready figures directly from code often results in function signatures cluttered with dozens of keyword arguments (`figsize`, `cmap`, `linewidth`, `alpha`, etc.). This leads to unreadable code and makes it difficult to maintain consistent styling across a project.
@@ -25,6 +26,7 @@ To get familiar with this concept we will use the [waterfall plot](./02_plot_wat
 :::
 
 
+(plot-basics-setup)=
 ## 1. Environment Setup
 
 ```{code-cell} ipython3
@@ -48,6 +50,7 @@ import matplotlib.pyplot as plt
 from xmris.visualization import WaterfallConfig
 ```
 
+(plot-basics-config-object)=
 ## 2. The Configuration Object
 
 Instead of passing styling arguments directly to the plotting function, we instantiate a specific configuration object.
@@ -62,6 +65,7 @@ CFG = WaterfallConfig()
 CFG
 ```
 
+(plot-basics-customizing)=
 ## 3. Customizing the Configuration
 
 You can easily modify the config object using standard attribute assignment. Thanks to the underlying architecture, your IDE will catch typos and warn you if you try to pass a string to a parameter that expects a float.
@@ -79,6 +83,7 @@ print(f"Current colormap: {CFG.cmap}")
 print(f"Current alpha: {CFG.alpha}")
 ```
 
+(plot-basics-applying)=
 ## 4. Applying the Configuration
 
 Once your configuration object is tailored to your liking, simply pass it to the corresponding `xarray` accessor.

--- a/docs/notebooks/visualization/plot/02_plot_waterfall.md
+++ b/docs/notebooks/visualization/plot/02_plot_waterfall.md
@@ -9,12 +9,14 @@ kernelspec:
   name: python3
 ---
 
+(waterfall)=
 # Waterfall Plots
 
 Waterfall plots (also known as ridge or joy plots) are essential in Magnetic Resonance Spectroscopy (MRS) for visualizing kinetic, dynamic, or relaxation series. By vertically stacking and horizontally offsetting 1D spectra, they allow the human eye to easily track peak growth, decay, and frequency shifts over an independent variable like time . 
 
 In `xmris`, this visualization is built entirely around our `WaterfallConfig` object, giving you publication-ready results without cluttering your function calls.
 
+(waterfall-data-requirements)=
 ## 1. Data Requirements
 
 Before plotting, your `xarray.DataArray` must meet the following criteria:
@@ -22,6 +24,7 @@ Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **X-Axis (Horizontal):** The accessor will automatically search for dimensions named `chemical_shift` or `frequency`. If your spectral axis has a different name, you must specify it explicitly via the `x_dim` argument.
 * **Stack Axis (Vertical):** The accessor will automatically stack along the remaining dimension. If multiple dimensions remain, it looks for `average` or `repetition`, or you can specify it explicitly via the `stack_dim` argument.
 
+(waterfall-simulate)=
 ## 2. Generating Synthetic Data
 
 We will generate a realistic kinetic time-course of a hyperpolarized 13C experiment where Pyruvate decays and Lactate grows over 60 seconds.
@@ -71,6 +74,7 @@ da_kinetic = da_kinetic_fid.xmr.to_spectrum().xmr.to_ppm().real
 
 :::
 
+(waterfall-basic-usage)=
 ## 3. Basic Usage
 
 Because we utilize an intelligent xarray accessor, the simplest plotting call requires zero arguments. The accessor dynamically reads the dataset's units and dimensions to build the axes automatically.
@@ -81,6 +85,7 @@ ax = da_kinetic.sel(chemical_shift=slice(160, 190)).xmr.plot.waterfall()
 plt.show()
 ```
 
+(waterfall-config)=
 ## 4. Advanced Configuration
 
 To customize the plot, do not pass endless keyword arguments. Instead, instantiate a `WaterfallConfig`. Outputting this object in a notebook renders a table of all available styling options.
@@ -105,6 +110,7 @@ ax = da_kinetic.sel(chemical_shift=slice(160, 190)).xmr.plot.waterfall(config=CF
 plt.show()
 ```
 
+(waterfall-subplots)=
 ## 5. Subplot Integration (Wireframe Mode)
 
 Professional library functions should never hijack your global plotting environment. Because `plot.waterfall()` returns a standard `matplotlib.Axes` object and accepts an `ax` keyword argument, you can easily embed these visualizations into multi-panel figures.

--- a/docs/notebooks/visualization/plot/03_plot_carpet.md
+++ b/docs/notebooks/visualization/plot/03_plot_carpet.md
@@ -9,12 +9,14 @@ kernelspec:
   name: python3
 ---
 
+(carpet)=
 # Carpet Plots
 
 As a quantitative alternative to the 2D waterfall plot (see [2. Waterfall Plots](./02_plot_waterfall.md)), carpet plots provide a top-down, 2D image representation of stacked spectra . They are 2D rasterized visualizations of 1D time-series data, effectively "rolling out" the time-domain flat on the floor. This approach eliminates visual occlusion, allowing for direct observation of signal intensities and frequency shifts across the stacking dimension (e.g., time or repetitions).
 
 In `xmris`, this visualization is built around the `CarpetConfig` object, which includes specialized logic for truncating colormaps so your data never gets lost in absolute white or absolute black on printed paper.
 
+(carpet-data-requirements)=
 ## 1. Data Requirements
 
 Before plotting, your `xarray.DataArray` must meet the following criteria:
@@ -22,6 +24,7 @@ Before plotting, your `xarray.DataArray` must meet the following criteria:
 * **X-Axis (Horizontal):** The accessor automatically searches for `chemical_shift` or `frequency`. 
 * **Y-Axis (Vertical):** The accessor automatically assigns the remaining dimension to the y-axis (e.g., `kinetic_time`, `average`, or `repetition`).
 
+(carpet-simulate)=
 ## 2. Generating Synthetic Data
 
 To ensure a 1:1 comparison with the waterfall plot, we will generate the exact same synthetic kinetic time-course. We simulate a hyperpolarized 13C experiment where Pyruvate decays and Lactate grows over 60 seconds.
@@ -71,6 +74,7 @@ da_kinetic = da_kinetic_fid.xmr.to_spectrum().xmr.to_ppm().real
 
 :::
 
+(carpet-basic-usage)=
 ## 3. Basic Usage
 
 Because `plot.carpet()` shares the same intelligent dimension parser as `plot.waterfall()`, you can call it without any dimension arguments.
@@ -81,6 +85,7 @@ ax = da_kinetic.sel(chemical_shift=slice(160, 190)).xmr.plot.carpet()
 plt.show()
 ```
 
+(carpet-config)=
 ## 4. Advanced Configuration
 
 Instantiating the `CarpetConfig` reveals specialized controls for the 2D grid. Notice how the default setting (`grid_on=True`) utilizes a subtle overlaid grid and inward-facing ticks to make reading exact coordinates effortless.
@@ -103,6 +108,7 @@ ax = da_kinetic.sel(chemical_shift=slice(160, 190)).xmr.plot.carpet(config=CFG_C
 plt.show()
 ```
 
+(carpet-subplots)=
 ## 5. Subplot Integration
 
 Because our plotting functions return standard `matplotlib.Axes` objects, we can easily build a comprehensive, multi-panel figure combining the qualitative intuition of the Waterfall Plot with the quantitative rigor of the Carpet Plot.

--- a/docs/notebooks/visualization/plot/03_plotting_1dfid.md
+++ b/docs/notebooks/visualization/plot/03_plotting_1dfid.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(plot-trajectory)=
 # Visualizing Dynamic AMARES Fits
 
 ```{code-cell} ipython3
@@ -66,6 +67,7 @@ pk_path = Path("dyn_pk.csv")
 pk_path.write_text(pk_csv)
 ```
 
+(plot-trajectory-simulate)=
 ## 1. Simulating a Dynamic Exercise Paradigm
 We will simulate 60 consecutive repetitions representing a dynamic muscle exercise paradigm.
 * **Rest (Repetitions 0-14):** Phosphocreatine (PCr) is stable at baseline.
@@ -140,6 +142,7 @@ plt.title("Repetition 0: Raw Spectrum")
 plt.show()
 ```
 
+(plot-trajectory-fit)=
 ## 2. Fitting the Time Series
 We fit the dynamic series using the parallel batch processor.
 
@@ -160,6 +163,7 @@ ds_dyn = da_dyn.xmr.fit_amares(
 )
 ```
 
+(plot-trajectory-bands)=
 ## 3. Plotting Trajectories with Confidence Bands
 
 The `.xmr.plot.trajectory()` tool plots the extracted amplitudes over the dimension.
@@ -173,6 +177,7 @@ Think of a standard NMR spectrum. If a peak is sharp (narrow linewidth) and your
 
 In MRS, the CRLB calculates the mathematical **"best-case scenario"** for this uncertainty. It represents the absolute minimum variance (error) that *any* unbiased fitting algorithm can possibly achieve, based purely on data quality and model constraints.
 
+(plot-trajectory-uncertainty)=
 ### The Mathematics of Uncertainty
 Mathematically, the variance of your estimated amplitude ($\hat{A}$) will always be greater than or equal to the CRLB variance:
 
@@ -182,6 +187,7 @@ In practice, we look at the standard deviation: $\sigma \ge \sqrt{\text{CRLB}_{\
 
 By convention, pyAMARES outputs this error as a relative percentage of the fitted amplitude. To find the absolute error, simply calculate:  ` Absolute Error = Amplitude * (%CRLB / 100)`. *(Note: Our `xmris.plot.trajectory()` tool does this automatically to draw shaded confidence bands!)*
 
+(plot-trajectory-crlb)=
 ### Comparing CRLB values
 You should be careful when comparing %CRLB values across studies or peaks, as the CRLB is highly sensitive to:
 
@@ -203,6 +209,7 @@ plt.show()
 
 Look at the spikes around **repetition time 30s** (index 15) and **90s** (index 45)! The shaded bands immediately draw attention to the uncertainty caused by the noise spikes. The default `PlotTrajectoryConfig` also highlights the exact points where the CRLB exceeded 20% by rendering them as hollow circles.
 
+(plot-trajectory-qc-grid)=
 ## 4. The Spectral Quality Control Grid
 
 While the trajectory plot confirms the kinetics, it is recommended to visually inspect the raw spectra to ensure the mathematical model didn't fail catastrophically (e.g., fitting noise instead of a peak).

--- a/docs/notebooks/visualization/widget/01_widget_phase.md
+++ b/docs/notebooks/visualization/widget/01_widget_phase.md
@@ -36,6 +36,7 @@ import xarray as xr
 import xmris
 ```
 
+(widget-phase-simulate)=
 ## 1. Generating Unphased Data
 
 Let's generate the same ruined synthetic spectrum we used in the pipeline documentation.
@@ -61,6 +62,7 @@ da_spec = da_fid.xmr.to_spectrum()
 da_ruined = da_spec.xmr.phase(p0=120.0, p1=-45.0)
 ```
 
+(widget-phase-launch)=
 ## 2. Launching the Widget
 
 You can launch the interactive viewer directly from the `xmris` package. Pass your complex-valued 1D frequency-domain `DataArray` to the `phase_spectrum` function.
@@ -88,6 +90,7 @@ export_widget_static(
 )
 ```
 
+(widget-phase-controls)=
 ### Using the Widget
 
 Once the widget is rendered in your notebook, you can interact with it using the following controls:
@@ -97,6 +100,7 @@ Once the widget is rendered in your notebook, you can interact with it using the
 * **Fine-Tuning:** You can manually type exact degree values into the input boxes in the control bar.
 * **Visual Feedback:** The real component is rendered in blue, and the imaginary component is rendered in red. Your goal is usually to maximize the symmetry and positivity of the blue peaks while zeroing out the red dispersive twists at the peak centers.
 
+(widget-phase-extract)=
 ## 3. Extracting the Parameters
 
 Interactive widgets are great for exploration, but they are generally bad for reproducible science if the parameters stay trapped in the UI.

--- a/docs/notebooks/visualization/widget/02_widget_scroller.md
+++ b/docs/notebooks/visualization/widget/02_widget_scroller.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(widget-scroller)=
 # Interactive Spectra Scrolling Widget
 
 ```{code-cell} ipython3
@@ -35,6 +36,7 @@ import xarray as xr
 import xmris
 ```
 
+(widget-scroller-simulate)=
 ## 1. Generating a 2D Time Series
 
 Let's generate a synthetic 2D dataset representing 50 transient repetitions. We will simulate a decaying signal (e.g., relaxation) and inject a massive motion artifact at repetition #25.
@@ -82,6 +84,7 @@ da_series = xr.DataArray(
 )
 ```
 
+(widget-scroller-launch)=
 ## 2. Launching the Widget
 
 You can launch the interactive viewer directly from the `.xmr.widget` accessor. Pass your 2D `DataArray` to the `scroll_spectra` function.
@@ -112,6 +115,7 @@ export_widget_static(
 )
 ```
 
+(widget-scroller-controls)=
 ### Using the Widget
 
 Once rendered in your notebook, you can interact with the dataset using the following controls:
@@ -121,6 +125,7 @@ Once rendered in your notebook, you can interact with the dataset using the foll
 * **Playback:** Click the `▶` button (or press the `Spacebar`) to animate the sequence automatically. This is incredibly useful for spotting transient motion artifacts that flash on screen.
 * **History Trails:** Toggle the "History Trails" checkbox and adjust the "Depth" slider to show fading previous traces (in lighter blue) behind the active trace. This provides instant visual context for signal decay or growth.
 
+(widget-scroller-extract)=
 ## 3. Extracting a Target Slice
 
 While scrolling, you will likely notice the massive artifact we injected halfway through the acquisition.

--- a/docs/notebooks/visualization/widget/03_apodization.md
+++ b/docs/notebooks/visualization/widget/03_apodization.md
@@ -9,6 +9,7 @@ kernelspec:
   name: python3
 ---
 
+(widget-apodization)=
 # Interactive Apodization
 
 ```{code-cell} ipython3
@@ -35,6 +36,7 @@ import xmris
 from xmris import simulate_fid
 ```
 
+(widget-apodization-simulate)=
 ## 1. Generate Synthetic Data
 
 We create a noisy FID with two closely spaced peaks to demonstrate resolution enhancement.
@@ -54,6 +56,7 @@ da_fid = simulate_fid(
 )
 ```
 
+(widget-apodization-launch)=
 ## 2. Launch the Widget
 
 Pass a 1D time-domain `DataArray` to the `apodize` method. The widget computes the Fourier transform in the browser and renders the FID (top) and spectrum (bottom) side by side.
@@ -85,6 +88,7 @@ export_widget_static(
 )
 ```
 
+(widget-apodization-controls)=
 ### Widget Controls
 
 | Control | Description |
@@ -94,6 +98,7 @@ export_widget_static(
 | **Show Original** | Overlay the un-apodized data as a gray trace for comparison. |
 | **LB / GB Sliders** | Adjust apodization parameters. The orange dashed line on the FID canvas shows the weighting envelope being applied. |
 
+(widget-apodization-extract)=
 ## 3. Extract and Apply Parameters
 
 Once you are satisfied with the result, click **Close**. The widget displays a copyable Python snippet so your parameters are recorded in your notebook.


### PR DESCRIPTION
Second half of #104, **stacked on #109** (base is `fix/docs-render-breaking`; retarget to `main` after that squash-merges). #109 handled the 5 render-breaking errors; this drives the remaining 131 to zero and turns the checker into a gate.

```
             errors  warnings  pages
before #109     141        17     35
after  #109     131        17     35
this PR           0         9     38
```

## 1. Explicit targets — 131 across 24 pages

Commandment 8 wants them because mystmd numbers auto-slugs by *document position* (`id-1-`, `id-2-`), so inserting one section silently renumbers every anchor below it — and nothing warns.

Names are kebab-case and **prefixed with the page topic** (`baseline-visualizing-the-results`, not `visualizing-the-results`): MyST resolves targets page-globally, so the prefix is what keeps them unique across the tree. One prefix per page — `architecture-*`, `zero-fill-*`, `widget-scroller-*`, `bruker-13c-*`, …

**This cannot break a link.** No existing target was renamed, and every inbound `](#…)` link in `docs/` already pointed at an explicit target — nothing linked an auto-slug. Verified after the fact: zero duplicate targets tree-wide, and 337 of 338 targets resolve in `myst.xref.json` (the one that doesn't lives in the `testonly_` page, which is deliberately not in the TOC).

## 2. The last 8 bare ` ```mermaid ` fences

Finishes a split that sat at 8 bare / 8 directive. These had **never rendered as diagrams** — a bare fence is a code block. Which is how one of them was hiding a truncated line, `style D fill:#e8f5e9,stroke:#2e7d32,s`, harmless as text and now completed to match its sibling diagram.

Since I was turning code blocks into diagrams sight-unseen, I checked all 12 in a real browser (Playwright against the static export): every one renders as SVG, no console errors, nothing left unrendered — including the 4 that already used the directive, as a control.

## 3. Two fixes the checker needed *before* it could gate

- **The header scan now sees the page the reader sees.** It counted `#` headers inside `<!-- -->` as real — exactly how `index.md`'s dead nav block contributed 5 errors. Post-gate that would fail a build over text that never renders. The comment state machine moves into `_scan` (where fences are already excluded, so a `<!--` inside a code cell can't flip it) and the link check drops its duplicate copy. Net: one state machine instead of two, and every rule agrees on what is visible.
- **`docs/diary/` is no longer skipped** (35 → 38 pages). Writing an entry still routes to the `dev-diary` skill, but the structural rules bind it like any page — and an entry missing from the TOC never renders, which makes for a review gate that only works when it does. All three entries already passed clean, so this costs nothing today and closes the hole before the gate goes on.

## 4. The gate

```yaml
docs-check:
  name: Docs style
  runs-on: ubuntu-latest
  timeout-minutes: 5
  steps:
    - uses: actions/checkout@v7
    - run: python3 .claude/skills/docs-page/check_docs.py
```

Its own job, not a step in `test`: stdlib-only means no `uv sync` and no matrix duplication, it finishes in seconds, and a docs failure reads as a docs failure. Errors gate (exit 1); warnings still exit 0 by design.

> [!IMPORTANT]
> **`Docs style` needs adding to the branch-protection required checks** — otherwise it can go red without blocking anything.

## 5. Docs-on-docs reconciled

The checker changed status, so every page describing it changed with it:

- `contract.md` — Commandment 8 now states the naming law (page-topic prefix, and *why* auto-slugs are unsafe) and names the CI job.
- `contributing/docs_pages.md` — gains the invocation and the errors-gate / warnings-advisory split.
- `docs-page/SKILL.md` — §2 stopped claiming every rule "is currently violated somewhere"; §3's "pre-existing errors are not yours to fix" is now false and says so; §4 notes the local run *is* the gate.
- `diary/2026-07-22-authoring-skills.md` — **reconciled rather than given a sibling entry.** It closed by pointing at #104 as an open backlog; it now tells how that resolved and why paying it down was worth doing (at zero, `exit 1` becomes trustworthy). `Last edited` bumped.

## What this deliberately does not do

The 9 remaining warnings — 5 config singletons in visible cells, 4 tutorials that run code but assert nothing — each need a per-page content decision, and one of them means writing real assertions into 4 tutorials. That is authoring work, not cleanup, and warnings exit 0 so none of it blocks the gate. Follow-up issue to come.

## Verification

```
check_docs.py                      38 pages: 0 errors, 9 warnings (exit 0)
                                   also passes under system python3.9 — no toolchain needed
duplicate targets tree-wide        none
myst build --html                  exit 0, zero warnings
mermaid (Playwright, static site)  12/12 diagrams render as SVG, 0 console errors
test-gen + pytest --no-cov         219 passed
ruff check / format                clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)