### PR TITLE
docs: the roadmap — five bands, a decision board, and the release line (#116)

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -41,10 +41,14 @@
      .roadmap-end       the closing dissolve
 
    Two authoring rules the CSS depends on:
-     · the FIRST paragraph of an item or phase block is its title/lead line
+     · the FIRST paragraph of an item or phase block is its title/lead line;
+       a phase block adds exactly ONE more paragraph, of ONE sentence, which
+       shows only in the hover card (see the phase-block section below)
      · issue chips need no markup — a plain link to /issues/ becomes a pill;
        a decision's status chip is a <span class="roadmap-status --decided|--arguing">
-       inside the title line
+       inside the title line; a decided card's lifecycle line is a
+       <span class="roadmap-progress"> as its second-to-last paragraph
+       (done stages carry ✓ and link their artifact; <strong> marks what's next)
 
    Theme note — measured against the built site, not assumed. book-theme's
    toggle swaps a `light`/`dark` CLASS on <html>; `data-theme` is never set,
@@ -389,36 +393,44 @@
    motion that survived is the motion that means something: the in-motion
    band's dashes flow, because that band is the one in flight.
 
-   The ghosted band ordinal. Decoration, but it gives each band a landmark you
-   can scroll to without reading. */
+   The ghosted release label. It repeats the band's `.roadmap-ver` chip at
+   scale, so scrolling gives you the release you are in without reading — and
+   it is a release, not an ordinal, because bare `01`–`05` collided with the
+   hand-typed decision IDs (`03 ·`, `04 ·`) inside the decisions band. Mono, at
+   roughly half the old size, so a five-glyph string occupies about the width
+   two numerals did. A new band renders NO ghost until it gets a rule below. */
 .roadmap-band::after {
   position: absolute;
   z-index: 0;
-  top: -1.1rem;
+  top: -0.35rem;
   inset-inline-end: 0.25rem;
-  font-size: clamp(4rem, 11vw, 7.5rem);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: clamp(2.4rem, 6vw, 4.25rem);
   font-weight: 800;
   line-height: 1;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.02em;
   color: var(--roadmap-accent);
-  opacity: 0.07;
+  opacity: 0.09;
   pointer-events: none;
 }
 
+/* Shipped is `main`, not `v0.6`: the band runs deliberately ahead of PyPI, so a
+   released version number there would be a lie. Outward spans v0.8 – v0.9 — its
+   chip says so precisely; the ghost takes v0.9 to keep the ladder monotonic. */
 .roadmap-band--shipped::after {
-  content: "01";
+  content: "main";
 }
 .roadmap-band--motion::after {
-  content: "02";
+  content: "v0.7";
 }
 .roadmap-band--decisions::after {
-  content: "03";
+  content: "v0.8";
 }
 .roadmap-band--outward::after {
-  content: "04";
+  content: "v0.9";
 }
 .roadmap-band--horizon::after {
-  content: "05";
+  content: "v1.0";
 }
 
 /* Sticky band header: scrolling deep into a band never loses which horizon
@@ -476,11 +488,13 @@
    re-renders the block WITHOUT its `.roadmap-band` wrapper:
 
      in the page   only the first paragraph — a one-line definition
-     in the popup  every paragraph — what the band means and what to do about it
+     in the popup  both paragraphs — the definition, then why the band exists
 
    So the rule below is deliberately ancestor-scoped. Un-scoping it would blank
-   the popup. Authoring contract: FIRST paragraph is the one-liner, the rest is
-   popup-only. */
+   the popup. Authoring contract: FIRST paragraph is the one-liner, and there is
+   exactly ONE more, of exactly ONE sentence — a hover card is read at a glance
+   or not at all, so the whole popup stays under two sentences. Anything longer
+   belongs in the band's own prose or in "How this page changes". */
 .roadmap-band .roadmap-phase > p ~ p {
   display: none;
 }
@@ -721,6 +735,25 @@
   border: 1px solid color-mix(in srgb, var(--roadmap-rust) 40%, transparent);
   background: color-mix(in srgb, var(--roadmap-rust) 12%, transparent);
   color: var(--roadmap-rust);
+}
+
+/* A decided card's lifecycle line: explored → decided → solution spec →
+   implementation. Done stages carry ✓ and link their artifact (the frozen
+   exploration notebook, later the spec), so the line accretes links as the
+   paper trail grows; the <strong> stage is what happens next, in the same
+   navy the decided chip borrows for certainty. */
+.roadmap-progress {
+  display: inline-block;
+  margin-block-start: 0.3rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.74em;
+  letter-spacing: 0.02em;
+  color: color-mix(in srgb, currentColor 55%, transparent);
+}
+
+.roadmap-progress strong {
+  font-weight: 600;
+  color: var(--roadmap-navy);
 }
 
 /* An item carrying a dropdown gets a hairline above it, so the disclosure

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -24,22 +24,27 @@
    THE ROADMAP PAGE — docs/roadmap.md
    ═══════════════════════════════════════════════════════════════════════════
    Stages the page as a journey from solid ground into fog: a hero, a segmented
-   map, then four bands whose shared vertical rail loses its confidence as it
+   map, then five bands whose shared vertical rail loses its confidence as it
    descends — solid navy for what shipped, flowing rust for what is in flight,
-   dashed slate for what is next, and a dotted grey that masks itself away.
+   dashed slate for the decision board, a paler dash for the outward work, and
+   a dotted grey that masks itself away.
 
    Markup contract — every block is a `{div}` carrying a `:class:`:
 
      .roadmap-hero      the opening panel (kicker / statement / tenets inside)
-     .roadmap-map       four segments; each links to a phase block below
-     .roadmap-band      one confidence horizon, + --shipped|motion|next|horizon
+     .roadmap-map       five segments; each links to a phase block below
+     .roadmap-band      one confidence horizon,
+                        + --shipped|motion|decisions|outward|horizon
        .roadmap-phase     what the band MEANS, + the matching --modifier
-       .roadmap-item      one milestone; add --minor for a one-line entry
+       .roadmap-item      one milestone; add --minor for a one-line entry,
+                          --decided for a decision whose argument is settled
      .roadmap-end       the closing dissolve
 
    Two authoring rules the CSS depends on:
      · the FIRST paragraph of an item or phase block is its title/lead line
-     · issue chips need no markup — a plain link to /issues/ becomes a pill
+     · issue chips need no markup — a plain link to /issues/ becomes a pill;
+       a decision's status chip is a <span class="roadmap-status --decided|--arguing">
+       inside the title line
 
    Theme note — measured against the built site, not assumed. book-theme's
    toggle swaps a `light`/`dark` CLASS on <html>; `data-theme` is never set,
@@ -280,6 +285,9 @@
   --seg: var(--roadmap-slate);
 }
 .roadmap-map > p > *:nth-child(4) {
+  --seg: color-mix(in srgb, var(--roadmap-slate) 55%, var(--roadmap-grey));
+}
+.roadmap-map > p > *:nth-child(5) {
   --seg: var(--roadmap-grey);
 }
 
@@ -298,8 +306,12 @@
 .roadmap-band--motion {
   --roadmap-accent: var(--roadmap-rust);
 }
-.roadmap-band--next {
+.roadmap-band--decisions {
   --roadmap-accent: var(--roadmap-slate);
+  --roadmap-rail: 2px;
+}
+.roadmap-band--outward {
+  --roadmap-accent: color-mix(in srgb, var(--roadmap-slate) 55%, var(--roadmap-grey));
   --roadmap-rail: 2px;
 }
 .roadmap-band--horizon {
@@ -343,11 +355,19 @@
   }
 }
 
-.roadmap-band--next::before {
+.roadmap-band--decisions::before {
   background: repeating-linear-gradient(
     to bottom,
     var(--roadmap-accent) 0 7px,
     transparent 7px 15px
+  );
+}
+
+.roadmap-band--outward::before {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--roadmap-accent) 0 5px,
+    transparent 5px 14px
   );
 }
 
@@ -391,11 +411,14 @@
 .roadmap-band--motion::after {
   content: "02";
 }
-.roadmap-band--next::after {
+.roadmap-band--decisions::after {
   content: "03";
 }
-.roadmap-band--horizon::after {
+.roadmap-band--outward::after {
   content: "04";
+}
+.roadmap-band--horizon::after {
+  content: "05";
 }
 
 /* Sticky band header: scrolling deep into a band never loses which horizon
@@ -489,8 +512,11 @@
 .roadmap-phase--motion {
   --roadmap-accent: var(--roadmap-rust);
 }
-.roadmap-phase--next {
+.roadmap-phase--decisions {
   --roadmap-accent: var(--roadmap-slate);
+}
+.roadmap-phase--outward {
+  --roadmap-accent: color-mix(in srgb, var(--roadmap-slate) 55%, var(--roadmap-grey));
 }
 .roadmap-phase--horizon {
   --roadmap-accent: var(--roadmap-grey);
@@ -562,10 +588,18 @@
   box-shadow: 0 0 0 3px var(--roadmap-bg);
 }
 
-.roadmap-band--next .roadmap-item::before,
+.roadmap-band--decisions .roadmap-item::before,
+.roadmap-band--outward .roadmap-item::before,
 .roadmap-band--horizon .roadmap-item::before {
   background: var(--roadmap-bg);
   border: 2px solid var(--roadmap-accent);
+}
+
+/* A settled decision gets its node back: solid, like the shipped band's —
+   decided is decided, even while the implementation is still ahead. */
+.roadmap-band--decisions .roadmap-item--decided::before {
+  background: var(--roadmap-accent);
+  border: 0;
 }
 
 .roadmap-band--motion .roadmap-item:not(.roadmap-item--minor)::before {
@@ -658,6 +692,35 @@
 
 .roadmap-item a[href*="/issues/"]:hover {
   background: color-mix(in srgb, var(--roadmap-accent) 24%, transparent) !important;
+}
+
+/* A decision's status chip, sitting inside the card's title line. Colours are
+   borrowed with intent: navy is the shipped band's certainty, rust is the
+   in-motion band's activity. */
+.roadmap-status {
+  display: inline-block;
+  margin-inline-start: 0.45rem;
+  padding: 0.14em 0.6em;
+  border-radius: 999px;
+  vertical-align: 0.12em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.6em;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.roadmap-status--decided {
+  border: 1px solid color-mix(in srgb, var(--roadmap-navy) 40%, transparent);
+  background: color-mix(in srgb, var(--roadmap-navy) 12%, transparent);
+  color: var(--roadmap-navy);
+}
+
+.roadmap-status--arguing {
+  border: 1px solid color-mix(in srgb, var(--roadmap-rust) 40%, transparent);
+  background: color-mix(in srgb, var(--roadmap-rust) 12%, transparent);
+  color: var(--roadmap-rust);
 }
 
 /* An item carrying a dropdown gets a hairline above it, so the disclosure

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -10,14 +10,694 @@
   background-color: rgba(139, 92, 246, 0.06) !important;
 }
 
-@media (prefers-color-scheme: dark) {
-  .skill-quote {
-    border-inline-start-color: #a78bfa !important;
-    background-color: rgba(167, 139, 250, 0.1) !important;
+/* Dark mode keys off the `dark` CLASS on <html> — see the theme note in the
+   roadmap block below for how that was measured. Do NOT reintroduce a
+   `prefers-color-scheme` variant here: the site's theme toggle overrides the
+   OS preference and persists, so an OS-driven rule renders a dark quote on a
+   light page (this class previously had exactly that bug). */
+:root.dark .skill-quote {
+  border-inline-start-color: #a78bfa !important;
+  background-color: rgba(167, 139, 250, 0.1) !important;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   THE ROADMAP PAGE — docs/roadmap.md
+   ═══════════════════════════════════════════════════════════════════════════
+   Stages the page as a journey from solid ground into fog: a hero, a segmented
+   map, then four bands whose shared vertical rail loses its confidence as it
+   descends — solid navy for what shipped, flowing rust for what is in flight,
+   dashed slate for what is next, and a dotted grey that masks itself away.
+
+   Markup contract — every block is a `{div}` carrying a `:class:`:
+
+     .roadmap-hero      the opening panel (kicker / statement / tenets inside)
+     .roadmap-map       four segments; each links to a phase block below
+     .roadmap-band      one confidence horizon, + --shipped|motion|next|horizon
+       .roadmap-phase     what the band MEANS, + the matching --modifier
+       .roadmap-item      one milestone; add --minor for a one-line entry
+     .roadmap-end       the closing dissolve
+
+   Two authoring rules the CSS depends on:
+     · the FIRST paragraph of an item or phase block is its title/lead line
+     · issue chips need no markup — a plain link to /issues/ becomes a pill
+
+   Theme note — measured against the built site, not assumed. book-theme's
+   toggle swaps a `light`/`dark` CLASS on <html>; `data-theme` is never set,
+   so a `:root[data-theme="dark"]` rule is dead. That class is *seeded* from
+   the OS preference on a first visit, but the toggle overrides it and the
+   choice persists in localStorage — so as soon as a reader has toggled,
+   `prefers-color-scheme` no longer describes the page they are looking at.
+   A rule keyed on the OS then paints dark styling onto a light page, or the
+   reverse. Hence: these tokens key ONLY off `.dark`, with plain `:root` as
+   the light default — two rules, no media query, no specificity games.
+
+   book-theme is fetched per build and is NOT pinned by uv.lock, so nothing
+   below targets one of its internal class names.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+@property --roadmap-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+:root {
+  --roadmap-navy: #002e7a;
+  --roadmap-rust: #b05418;
+  --roadmap-slate: #5b7ba6;
+  --roadmap-grey: #94a0b0;
+
+  /* Band-shaped defaults, declared at the root on purpose. The theme's
+     hover-card previews re-render a `.roadmap-item` WITHOUT its `.roadmap-band`
+     wrapper, and a var() that resolves to nothing makes the whole declaration
+     invalid at computed-value time — which silently took out the card's
+     background and the issue chips' pills. These keep an out-of-context item
+     coherent. (The node itself is scoped to `.roadmap-band` instead; see below.) */
+  --roadmap-accent: #002e7a;
+  --roadmap-rail: 3px;
+  --roadmap-gutter: 2rem;
+
+  --roadmap-bg: #ffffff;
+  --roadmap-card: #ffffff;
+  --roadmap-card-2: #fafafa;
+  --roadmap-line: rgba(15, 23, 42, 0.11);
+  --roadmap-muted: #64748b;
+  --roadmap-shadow: rgba(15, 23, 42, 0.09);
+}
+
+:root.dark {
+  --roadmap-navy: #7aa2e3;
+  --roadmap-rust: #e08a52;
+  --roadmap-slate: #7f93ad;
+  --roadmap-grey: #6f7a87;
+  --roadmap-accent: #7aa2e3;
+  --roadmap-bg: #1c1917;
+  --roadmap-card: #262322;
+  --roadmap-card-2: #211e1d;
+  --roadmap-line: rgba(255, 255, 255, 0.13);
+  --roadmap-muted: #a8a29e;
+  --roadmap-shadow: rgba(0, 0, 0, 0.45);
+}
+
+/* ── The hero ───────────────────────────────────────────────────────────── */
+
+.roadmap-hero {
+  position: relative;
+  overflow: hidden;
+  margin-block: 1.75rem 2rem;
+  padding: clamp(1.4rem, 3.5vw, 2.4rem);
+  border: 1px solid var(--roadmap-line);
+  border-radius: 18px;
+  background:
+    radial-gradient(
+      120% 120% at 0% 0%,
+      color-mix(in srgb, var(--roadmap-rust) 13%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      120% 120% at 100% 100%,
+      color-mix(in srgb, var(--roadmap-navy) 15%, transparent),
+      transparent 55%
+    ),
+    var(--roadmap-card);
+}
+
+/* A very slow conic sheen. Purely atmospheric — the panel is complete without
+   it, and it never runs for a reader who asked for less motion. */
+.roadmap-hero::before {
+  content: "";
+  position: absolute;
+  inset: -60%;
+  z-index: 0;
+  opacity: 0.55;
+  background: conic-gradient(
+    from var(--roadmap-angle),
+    transparent 0deg,
+    color-mix(in srgb, var(--roadmap-rust) 16%, transparent) 60deg,
+    transparent 140deg,
+    color-mix(in srgb, var(--roadmap-navy) 18%, transparent) 240deg,
+    transparent 330deg
+  );
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .roadmap-hero::before {
+    animation: roadmap-sheen 24s linear infinite;
   }
 }
 
-:root[data-theme="dark"] .skill-quote {
-  border-inline-start-color: #a78bfa !important;
-  background-color: rgba(167, 139, 250, 0.1) !important;
+@keyframes roadmap-sheen {
+  to {
+    --roadmap-angle: 360deg;
+  }
+}
+
+.roadmap-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.roadmap-kicker {
+  margin-block-end: 0.75rem !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--roadmap-muted);
+}
+
+.roadmap-kicker::before {
+  content: "";
+  display: inline-block;
+  width: 1.6rem;
+  height: 2px;
+  margin-inline-end: 0.6rem;
+  vertical-align: 0.28em;
+  background: linear-gradient(to right, var(--roadmap-rust), var(--roadmap-navy));
+}
+
+.roadmap-statement > p {
+  margin: 0 !important;
+  font-size: clamp(1.25rem, 2.9vw, 1.85rem);
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+
+.roadmap-tenets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-block-start: 1.5rem;
+}
+
+.roadmap-tenets > p {
+  display: contents;
+}
+
+.roadmap-tenets code {
+  padding: 0.3em 0.75em !important;
+  border: 1px solid var(--roadmap-line);
+  border-radius: 999px;
+  background: var(--roadmap-card-2) !important;
+  font-size: 0.8rem !important;
+  font-weight: 500;
+  color: var(--roadmap-muted) !important;
+}
+
+/* ── The map: four segments, one per band, doubling as jump navigation ──── */
+
+.roadmap-map {
+  display: flex;
+  gap: 0.5rem;
+  margin-block: 0 2.75rem;
+}
+
+.roadmap-map > p {
+  display: contents;
+}
+
+/* The theme wraps cross-reference links in a hover-card <span>, so the anchor
+   is not necessarily the flex item. Style whatever the direct child is, and
+   let a nested anchor fill it — this works wrapped or bare. */
+.roadmap-map > p > * {
+  flex: 1 1 0;
+  border-top: 3px solid var(--seg, var(--roadmap-grey));
+  border-radius: 0 0 8px 8px;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--seg, var(--roadmap-grey)) 14%, transparent),
+    transparent 85%
+  );
+  color: var(--seg, var(--roadmap-grey));
+  transition: transform 0.16s ease;
+}
+
+.roadmap-map > p > *:hover {
+  transform: translateY(-2px);
+}
+
+.roadmap-map a {
+  display: block;
+  padding: 0.7rem 0.35rem 0.65rem !important;
+  background: none !important;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-align: center;
+  text-transform: uppercase;
+  text-decoration: none !important;
+  color: inherit !important;
+}
+
+/* Hovering a segment opens the phase description, so the segment has to look
+   like it holds something. The dot is the affordance. */
+.roadmap-map a::after {
+  content: "";
+  display: block;
+  width: 4px;
+  height: 4px;
+  margin: 0.4rem auto 0;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.35;
+  transition: opacity 0.16s ease;
+}
+
+.roadmap-map > p > *:hover a::after {
+  opacity: 1;
+}
+
+.roadmap-map > p > *:nth-child(1) {
+  --seg: var(--roadmap-navy);
+}
+.roadmap-map > p > *:nth-child(2) {
+  --seg: var(--roadmap-rust);
+}
+.roadmap-map > p > *:nth-child(3) {
+  --seg: var(--roadmap-slate);
+}
+.roadmap-map > p > *:nth-child(4) {
+  --seg: var(--roadmap-grey);
+}
+
+/* ── Bands ──────────────────────────────────────────────────────────────── */
+
+.roadmap-band {
+  --roadmap-accent: var(--roadmap-navy);
+  --roadmap-rail: 3px;
+  --roadmap-gutter: 2rem;
+
+  position: relative;
+  margin-block: 0 3.25rem;
+  padding-inline-start: var(--roadmap-gutter);
+}
+
+.roadmap-band--motion {
+  --roadmap-accent: var(--roadmap-rust);
+}
+.roadmap-band--next {
+  --roadmap-accent: var(--roadmap-slate);
+  --roadmap-rail: 2px;
+}
+.roadmap-band--horizon {
+  --roadmap-accent: var(--roadmap-grey);
+  --roadmap-rail: 2px;
+}
+
+/* The rail. Drawn as a pseudo-element so the horizon band can dissolve it
+   without touching its own prose. */
+.roadmap-band::before {
+  content: "";
+  position: absolute;
+  inset-block: 0.3rem 0;
+  inset-inline-start: 0;
+  z-index: 0;
+  width: var(--roadmap-rail);
+  border-radius: var(--roadmap-rail);
+  background: var(--roadmap-accent);
+  transform-origin: top;
+}
+
+/* The one band that is in flight is the one whose rail actually moves. */
+.roadmap-band--motion::before {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--roadmap-accent) 0 10px,
+    color-mix(in srgb, var(--roadmap-accent) 25%, transparent) 10px 20px
+  );
+  background-size: 100% 20px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .roadmap-band--motion::before {
+    animation: roadmap-flow 1.9s linear infinite;
+  }
+}
+
+@keyframes roadmap-flow {
+  to {
+    background-position-y: 20px;
+  }
+}
+
+.roadmap-band--next::before {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--roadmap-accent) 0 7px,
+    transparent 7px 15px
+  );
+}
+
+.roadmap-band--horizon::before {
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--roadmap-accent) 0 2px,
+    transparent 2px 10px
+  );
+  -webkit-mask-image: linear-gradient(to bottom, #000 35%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 35%, transparent 100%);
+}
+
+/* Deliberately NOT scroll-drawn. A `animation-timeline: view()` rail that
+   draws itself as the band enters was tried and removed: the spine is the one
+   element carrying the whole "confidence decays downward" argument, and any
+   state where it renders partially — a tall viewport, a deep link landing
+   mid-band, a print — breaks that argument instead of decorating it. The
+   motion that survived is the motion that means something: the in-motion
+   band's dashes flow, because that band is the one in flight.
+
+   The ghosted band ordinal. Decoration, but it gives each band a landmark you
+   can scroll to without reading. */
+.roadmap-band::after {
+  position: absolute;
+  z-index: 0;
+  top: -1.1rem;
+  inset-inline-end: 0.25rem;
+  font-size: clamp(4rem, 11vw, 7.5rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--roadmap-accent);
+  opacity: 0.07;
+  pointer-events: none;
+}
+
+.roadmap-band--shipped::after {
+  content: "01";
+}
+.roadmap-band--motion::after {
+  content: "02";
+}
+.roadmap-band--next::after {
+  content: "03";
+}
+.roadmap-band--horizon::after {
+  content: "04";
+}
+
+/* Sticky band header: scrolling deep into a band never loses which horizon
+   you are in. */
+.roadmap-band > h2 {
+  position: sticky;
+  z-index: 3;
+  top: 3.75rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-block: 0 1.5rem !important;
+  padding: 0.35rem 0.85rem 0.35rem 0.7rem !important;
+  border: 1px solid color-mix(in srgb, var(--roadmap-accent) 25%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--roadmap-card) 88%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  font-size: 0.85rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--roadmap-accent) !important;
+}
+
+.roadmap-band > h2::before {
+  content: "";
+  align-self: center;
+  width: 9px;
+  height: 9px;
+  margin-inline-end: 0.1rem;
+  border-radius: 50%;
+  background: var(--roadmap-accent);
+}
+
+.roadmap-ver {
+  padding: 0.1em 0.5em;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--roadmap-accent) 14%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* ── Phase blocks: one definition, two audiences ────────────────────────── */
+/*
+   Each band opens with a `.roadmap-phase` div that the map segment links to. A
+   cross-reference to a LABELLED DIV renders only that div in the theme's
+   hover card (verified against the build), which makes this block the one
+   place a phase is described — no duplicated blurb to drift.
+
+   It shows differently in each place, using the fact that the hover card
+   re-renders the block WITHOUT its `.roadmap-band` wrapper:
+
+     in the page   only the first paragraph — a one-line definition
+     in the popup  every paragraph — what the band means and what to do about it
+
+   So the rule below is deliberately ancestor-scoped. Un-scoping it would blank
+   the popup. Authoring contract: FIRST paragraph is the one-liner, the rest is
+   popup-only. */
+.roadmap-band .roadmap-phase > p ~ p {
+  display: none;
+}
+
+.roadmap-phase {
+  margin-block: -0.35rem 1.4rem;
+  scroll-margin-top: 7rem; /* clear the sticky band header when jumped to */
+}
+
+.roadmap-phase > p {
+  margin-block: 0 0.7rem;
+}
+
+.roadmap-phase > p:last-child {
+  margin-block-end: 0;
+}
+
+.roadmap-phase > p:first-child {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--roadmap-accent);
+}
+
+/* Phase accents are set OUTSIDE the band scope on purpose, so the popup keeps
+   its band's colour even though it renders with no band around it. */
+.roadmap-phase--shipped {
+  --roadmap-accent: var(--roadmap-navy);
+}
+.roadmap-phase--motion {
+  --roadmap-accent: var(--roadmap-rust);
+}
+.roadmap-phase--next {
+  --roadmap-accent: var(--roadmap-slate);
+}
+.roadmap-phase--horizon {
+  --roadmap-accent: var(--roadmap-grey);
+}
+
+/* Popup-only presentation: the block is on its own in a small card, so it gets
+   a little more room and a rule under the lead line. */
+.hover-card-content .roadmap-phase > p:first-child {
+  padding-block-end: 0.55rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--roadmap-accent) 30%, transparent);
+  font-size: 1.05rem;
+}
+
+.hover-card-content .roadmap-phase > p {
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+/* ── Milestones ─────────────────────────────────────────────────────────── */
+
+.roadmap-item {
+  --roadmap-node: 13px;
+  --roadmap-edge: 1px; /* own border width — see the node offset below */
+  position: relative;
+  z-index: 1;
+  margin-block: 1rem;
+  padding: 0.95rem 1.15rem;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  /* Gradient edge: the accent bleeds out of the top-left corner and fades. */
+  background:
+    linear-gradient(var(--roadmap-card), var(--roadmap-card)) padding-box,
+    linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--roadmap-accent) 55%, transparent),
+        var(--roadmap-line) 45%
+      )
+      border-box;
+  box-shadow: 0 1px 2px var(--roadmap-shadow);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.roadmap-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px var(--roadmap-shadow);
+}
+
+/* The node is an artifact OF the rail, so it only exists where the rail does.
+   Scoping it to `.roadmap-band` is what keeps it out of the theme's hover-card
+   previews, which render a bare `.roadmap-item`: there the offset below cannot
+   resolve, `inset-inline-start` falls back to `auto`, and the circle lands on
+   its static position — directly over the first letter of the title. */
+.roadmap-band .roadmap-item::before {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 1.15rem;
+  /* An absolutely positioned child is offset from the PADDING BOX, so only the
+     item's own border counts here — its padding must not be subtracted. */
+  inset-inline-start: calc(
+    var(--roadmap-rail) / 2 - var(--roadmap-gutter) - var(--roadmap-node) / 2 - var(--roadmap-edge)
+  );
+  width: var(--roadmap-node);
+  height: var(--roadmap-node);
+  border-radius: 50%;
+  background: var(--roadmap-accent);
+  box-shadow: 0 0 0 3px var(--roadmap-bg);
+}
+
+.roadmap-band--next .roadmap-item::before,
+.roadmap-band--horizon .roadmap-item::before {
+  background: var(--roadmap-bg);
+  border: 2px solid var(--roadmap-accent);
+}
+
+.roadmap-band--motion .roadmap-item:not(.roadmap-item--minor)::before {
+  box-shadow:
+    0 0 0 3px var(--roadmap-bg),
+    0 0 0 7px color-mix(in srgb, var(--roadmap-accent) 24%, transparent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .roadmap-band--motion .roadmap-item:not(.roadmap-item--minor)::before {
+    animation: roadmap-pulse 3.4s ease-in-out infinite;
+  }
+}
+
+@keyframes roadmap-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 3px var(--roadmap-bg),
+      0 0 0 6px color-mix(in srgb, var(--roadmap-accent) 26%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px var(--roadmap-bg),
+      0 0 0 12px color-mix(in srgb, var(--roadmap-accent) 0%, transparent);
+  }
+}
+
+.roadmap-item > p {
+  margin-block: 0 0.55rem;
+}
+
+.roadmap-item > p:last-child {
+  margin-block-end: 0;
+}
+
+/* The first paragraph of an item IS its title. Keep it first when editing. */
+.roadmap-item > p:first-child {
+  margin-block-end: 0.45rem;
+  font-size: 1.08rem;
+  font-weight: 650;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+
+/* Minor milestones drop the card entirely — a one-line row on the same rail,
+   so the size difference is structural rather than just smaller type. */
+.roadmap-item--minor {
+  --roadmap-node: 8px;
+  --roadmap-edge: 0px;
+  margin-block: 0.5rem;
+  padding: 0.15rem 0;
+  border: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.roadmap-item--minor::before {
+  top: 0.45rem;
+}
+
+.roadmap-item--minor:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.roadmap-item--minor > p:first-child {
+  font-size: 0.97rem;
+  font-weight: 500;
+  color: var(--roadmap-muted);
+}
+
+/* An issue chip still needs no markup: a plain link to the tracker becomes a
+   pill and inherits its band's accent. */
+.roadmap-item a[href*="/issues/"] {
+  display: inline-block;
+  margin-inline-end: 0.18rem;
+  padding: 0.05em 0.52em;
+  border: 1px solid color-mix(in srgb, var(--roadmap-accent) 34%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--roadmap-accent) 11%, transparent) !important;
+  color: var(--roadmap-accent) !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.76em;
+  font-weight: 600;
+  line-height: 1.7;
+  text-decoration: none !important;
+  transition: background 0.15s ease;
+}
+
+.roadmap-item a[href*="/issues/"]:hover {
+  background: color-mix(in srgb, var(--roadmap-accent) 24%, transparent) !important;
+}
+
+/* An item carrying a dropdown gets a hairline above it, so the disclosure
+   reads as a drawer on the card rather than a stray control. */
+.roadmap-item:has(details) details {
+  margin-block: 0.75rem 0 !important;
+  padding-block-start: 0.15rem;
+  border-top: 1px dashed var(--roadmap-line);
+  font-size: 0.93em;
+}
+
+/* ── The closing dissolve ───────────────────────────────────────────────── */
+
+.roadmap-end {
+  margin-block: -1.5rem 2.5rem;
+  padding: 2.5rem 1rem 3.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  font-style: italic;
+  color: var(--roadmap-muted);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, transparent 95%);
+  mask-image: linear-gradient(to bottom, #000 0%, transparent 95%);
+}
+
+.roadmap-end > p {
+  margin: 0 !important;
+}
+
+@media (max-width: 640px) {
+  .roadmap-band {
+    --roadmap-gutter: 1.35rem;
+  }
+  .roadmap-item {
+    --roadmap-node: 11px;
+    padding: 0.8rem 0.9rem;
+  }
+  .roadmap-map {
+    flex-wrap: wrap;
+  }
+  .roadmap-map a {
+    flex: 1 1 45%;
+  }
 }

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -216,7 +216,7 @@
   color: var(--roadmap-muted) !important;
 }
 
-/* ── The map: four segments, one per band, doubling as jump navigation ──── */
+/* ── The map: five segments, one per band, doubling as jump navigation ──── */
 
 .roadmap-map {
   display: flex;
@@ -804,7 +804,10 @@
   .roadmap-map {
     flex-wrap: wrap;
   }
-  .roadmap-map a {
+  /* Same selector as the desktop rule — the flex item is the theme's hover-card
+     wrapper, not the anchor, so `.roadmap-map a` would never override `flex: 1 1 0`
+     and the five segments would stay jammed in one row. */
+  .roadmap-map > p > * {
     flex: 1 1 45%;
   }
 }

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -477,6 +477,17 @@
   text-transform: none;
 }
 
+/* The chip links its GitHub milestone; theme link-blue would fight the band's
+   accent, so the anchor stays chip-colored and only the hover underline says
+   "clickable". */
+.roadmap-ver a {
+  color: inherit;
+  text-decoration: none;
+}
+.roadmap-ver a:hover {
+  text-decoration: underline;
+}
+
 /* ── Phase blocks: one definition, two audiences ────────────────────────── */
 /*
    Each band opens with a `.roadmap-phase` div that the map segment links to. A

--- a/docs/decisions/decision_02_attrs_lineage.md
+++ b/docs/decisions/decision_02_attrs_lineage.md
@@ -1,0 +1,449 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (xmris)
+  language: python
+  name: python3
+---
+
+(attrs-nb)=
+# The attrs decision — a design notebook
+
+:::{note} A frozen exploration record
+This notebook explored the option space for roadmap decision **02 — the lineage record**
+(tracker [#64](https://github.com/andrewendlinger/xmris/issues/64)) and froze when the
+decision landed on 2026-08-02: **option B, the physics/record split**. It is the record of
+*why*, not the spec of *what* — the aimed-solution notebook will be the spec, and the
+[decision board](#roadmap-decisions) carries the summary. The "Option B" cells run a
+**prototype defined inside this notebook**; nothing here is implemented in the library yet.
+:::
+
+The roadmap makes one hero promise: *the object they hand back can answer for every step that
+produced it*. This notebook holds every candidate attrs strategy against that sentence — first
+the problem, demonstrated live against today's `main`; then each option as code, the user
+experience and the contributor's side of the same coin.
+
+(attrs-nb-problem)=
+## The problem, live
+
+Today's law is Commandment 3: preserve inbound attrs, then append the parameter you applied —
+`apodization_lb = 5.0`, not `apodized = True`. A short chain looks well-recorded:
+
+```{code-cell} ipython3
+import numpy as np
+import xarray as xr
+
+import xmris
+
+fid = xmris.simulate_fid(
+    amplitudes=[1.0, 0.6],
+    chemical_shifts=[0.0, 5.2],
+    reference_frequency=120.66,  # MHz
+    n_points=1024,
+)
+
+spectrum = (
+    fid.xmr.zero_fill(target_points=2048)
+    .xmr.apodize_exp(lb=5.0)
+    .xmr.to_spectrum()
+    .xmr.phase(p0=20.0)
+)
+spectrum.attrs
+```
+
+Fifteen keys, physics and lineage shoulder to shoulder — already showing #64's second worry,
+sprawl. But the record *reads* complete: the line broadening, the zero-fill, the phase are all
+there. It stays complete exactly as long as no step happens twice.
+
+```{code-cell} ipython3
+twice = fid.xmr.apodize_exp(lb=5.0).xmr.apodize_exp(lb=5.0)
+
+print("the record claims lb =", twice.attrs["apodization_lb"])
+print("the data says lb = 10:", bool(np.allclose(twice, fid.xmr.apodize_exp(lb=10.0))))
+```
+
+The second application silently overwrote the first — no trace remains that this FID was
+apodized twice. With phasing, the record graduates from forgetting to lying:
+
+```{code-cell} ipython3
+spec = fid.xmr.to_spectrum()
+rephased = spec.xmr.phase(p0=20.0).xmr.phase(p0=-5.0)
+
+print("the record claims p0 =", rephased.attrs["phase_p0"])
+print("the data carries 15°:", bool(np.allclose(rephased, spec.xmr.phase(p0=15.0))))
+```
+
+Phases add: the object carries 15° of correction and its own record claims −5°. Anyone
+reproducing this result from the attrs reproduces the wrong spectrum.
+
+The library already feels this strain. `phase` hand-rolls a one-off cross-step consistency
+check — it remembers which coordinate space the last phase was applied in, and warns when the
+next one happens somewhere else:
+
+```{code-cell} ipython3
+spec_ppm = spec.xmr.phase(p0=20.0).xmr.to_ppm()
+_ = spec_ppm.xmr.phase(p0=5.0, dim="chemical_shift")  # ← warns
+```
+
+That warning is proto-history: one function keeping a private memory of the step before it,
+because the object has no shared one. And finally, one step *outside* xmris loses everything —
+xarray drops attrs on most operations by default
+([#21](https://github.com/andrewendlinger/xmris/issues/21)):
+
+```{code-cell} ipython3
+(spectrum * 2).attrs
+```
+
+So the question splits in two: **what shape should the record have** (Options A–C below), and
+**what preservation guarantee can the library honestly make** (its own
+[section](#attrs-nb-guarantee) — the answer is the same under every option).
+
+(attrs-nb-reframe)=
+## Two kinds of attrs
+
+Before comparing options, one observation that every option benefits from. Today's `ATTRS`
+vocabulary mixes two populations that behave nothing alike:
+
+| Class | Keys today | Who reads them |
+|---|---|---|
+| **Physics / calibration** — describe the data | `reference_frequency`, `carrier_ppm`, `b0_field`, `group_delay`, `spectral_width`, `dead_time`, `units` | Code: `to_ppm` and `fit_amares` gate and read them (`@requires_attrs`); [#22](https://github.com/andrewendlinger/xmris/issues/22)'s type/range validation targets them |
+| **Lineage / audit** — describe what was done | `phase_p0/p1/pivot/pivot_coord`, `apodization_lb/gb`, `zero_fill_target/position`, `baseline_*`, `group_delay_removed`, `amares_amplitude_scale`, `sim_*` | **Nobody.** A grep of `src/` finds one consumer: `phase`'s own advisory warning above. The record is write-only |
+
+Physics attrs are healthy: individually addressable, typed, gated at the door. Everything wrong
+in the previous section is confined to the lineage class. netCDF's CF conventions draw exactly
+this line — physical metadata that must stay valid, separate from an append-only `history`
+attribute of processing steps. Every option below leaves physics attrs untouched; the decision
+is only about the record.
+
+(attrs-nb-option-a)=
+## Option A — flat keys stay law
+
+Keep Commandment 3 as written. The overwrite becomes documented semantics — *last application
+wins* — and [#23](https://github.com/andrewendlinger/xmris/issues/23) (provenance tracking)
+closes as won't-do.
+
+**The user experience** is the one already shown live above: readable single keys
+(`apodization_lb: 5.0`) that answer "what was applied last?" and nothing else — not how many
+times, not in what order, not what the effective total is. The re-phasing cell stays a lie.
+
+**The contributor side** is today's hand-rolled pattern, repeated in every function
+(`src/xmris/processing/fid.py`):
+
+```python
+da_apodized = (da * weight).transpose(*da.dims).assign_attrs(da.attrs)
+
+# Record lineage
+da_apodized.attrs[ATTRS.apodization_lb] = lb
+
+return da_apodized
+```
+
+Twenty functions, twenty appends, and any new function's author must remember both halves —
+the `assign_attrs` copy *and* the append. Cheapest option by far: zero migration, no new
+machinery, `TestAttrsPreservation` untouched. Its price is that the hero sentence is false and
+stays false — the object answers for the *last* application of each step, unordered.
+
+(attrs-nb-option-b)=
+## Option B — one structured history
+
+Lineage moves into a single attr: `xmr_history`, one JSON string holding an append-only event
+log. Flat lineage keys are deleted from the vocabulary. One central decorator does all the
+bookkeeping — preservation *and* the event — so function bodies stop handling attrs entirely.
+
+To make this option feelable rather than imagined, the cell below prototypes that decorator and
+grafts it onto today's functions. These ~40 lines are also the honest size estimate of the
+central machinery:
+
+```{code-cell} ipython3
+import functools
+import inspect
+import json
+from importlib.metadata import version
+
+HISTORY_KEY = "xmr_history"  # would live in the vocabulary as ATTRS.history
+EMPTY = json.dumps({"schema": 1, "events": []})
+
+# Keys today's functions hand-append. Under option B the appends are deleted from
+# the source; the prototype strips them from wrapped outputs to emulate that.
+FLAT_LINEAGE = {
+    "phase_p0", "phase_p1", "phase_pivot", "phase_pivot_coord",
+    "apodization_lb", "apodization_gb", "zero_fill_target", "zero_fill_position",
+    "baseline_method", "baseline_lam", "baseline_p", "baseline_iter",
+    "group_delay_removed", "amares_amplitude_scale",
+    "sim_amplitudes", "sim_dampings", "sim_frequencies_hz", "sim_chemical_shifts_ppm",
+}
+
+
+def records_history(func):
+    """Prototype of the one central decorator: preserve attrs, append the event."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        bound = inspect.signature(func).bind(*args, **kwargs)
+        bound.apply_defaults()
+        data_args = [
+            v for v in bound.arguments.values() if isinstance(v, (xr.DataArray, xr.Dataset))
+        ]
+        params = {
+            k: v
+            for k, v in bound.arguments.items()
+            if not isinstance(v, (xr.DataArray, xr.Dataset))
+        }
+
+        result = func(*args, **kwargs)
+
+        inbound = dict(data_args[0].attrs) if data_args else {}
+        added = {k: v for k, v in result.attrs.items() if k not in FLAT_LINEAGE}
+        result.attrs = {**inbound, **added}  # preservation by construction
+
+        envelope = json.loads(result.attrs.get(HISTORY_KEY, EMPTY))
+        envelope["events"].append({"op": func.__name__, "params": params, "v": version("xmris")})
+        result.attrs[HISTORY_KEY] = json.dumps(envelope, default=str)
+        return result
+
+    return wrapper
+```
+
+```{code-cell} ipython3
+# Graft the prototype onto the live library, notebook-locally: the .xmr methods are
+# thin delegators to these module-level names (Commandment 9), so rebinding them
+# gives the real chained UX without touching src/.
+import xmris.core.accessor as _accessor
+
+for _name in ("zero_fill", "apodize_exp", "to_spectrum", "phase"):
+    setattr(_accessor, _name, records_history(getattr(_accessor, _name)))
+
+simulate_fid = records_history(xmris.simulate_fid)  # history starts at birth
+```
+
+(attrs-nb-option-b-ux)=
+### What the user sees
+
+The same chain as the opening — with the double apodization and the re-phasing left in
+deliberately:
+
+```{code-cell} ipython3
+fid_b = simulate_fid(
+    amplitudes=[1.0, 0.6],
+    chemical_shifts=[0.0, 5.2],
+    reference_frequency=120.66,
+    n_points=1024,
+)
+
+spectrum_b = (
+    fid_b.xmr.zero_fill(target_points=2048)
+    .xmr.apodize_exp(lb=5.0)
+    .xmr.apodize_exp(lb=5.0)  # the same step twice — now on the record
+    .xmr.to_spectrum()
+    .xmr.phase(p0=20.0)
+    .xmr.phase(p0=-5.0)  # re-phased — both calls visible, order kept
+)
+spectrum_b.attrs
+```
+
+The attrs dict collapses to its physics plus one record key. That `xmr_history` string is the
+honest cost of this option: at a glance it is a JSON blob. The reading surface would be a
+`da.xmr.history()` method — prototyped here as a function:
+
+```{code-cell} ipython3
+import pandas as pd
+
+
+def history(da: xr.DataArray) -> pd.DataFrame:
+    """What `da.xmr.history()` would return."""
+    events = json.loads(da.attrs[HISTORY_KEY])["events"]
+    return pd.DataFrame(
+        {
+            "op": [e["op"] for e in events],
+            "params": [
+                ", ".join(f"{k}={v!r}" for k, v in e["params"].items() if v is not None)
+                for e in events
+            ],
+            "xmris": [e["v"] for e in events],
+        }
+    )
+
+
+history(spectrum_b)
+```
+
+Every step, in order, with its parameters — including the repeated ones the flat record
+swallowed. The hero sentence, answered by a method call.
+
+(attrs-nb-option-b-file)=
+### What survives a file
+
+The record must travel with the data, so the shape is chosen for serialization: netCDF attrs
+cannot hold nested dicts, and a length-1 list-of-strings attr silently collapses to a scalar on
+an xarray round-trip — one JSON string is the engine-proof form.
+
+```{code-cell} ipython3
+import tempfile
+from pathlib import Path
+
+# netCDF holds no complex values natively (that is the component dim's business,
+# out of scope here) — the attrs are what we are round-tripping.
+magnitude = spectrum_b.copy(data=np.abs(spectrum_b.values))
+
+with tempfile.TemporaryDirectory() as tmp:
+    path = Path(tmp) / "spectrum.nc"
+    magnitude.to_netcdf(path)
+    loaded = xr.load_dataarray(path)
+
+assert loaded.attrs[HISTORY_KEY] == spectrum_b.attrs[HISTORY_KEY]
+history(loaded)
+```
+
+A colleague opening this file next year gets the full processing story out of the `.nc` itself.
+
+One deliberate absence: **no timestamps**. Events record `op`, `params` and the xmris version —
+nothing wall-clock. Identical inputs must produce identical objects, or every
+`assert_identical` in the executable docs (this project's differentiator) starts failing:
+
+```{code-cell} ipython3
+rerun = (
+    fid_b.xmr.zero_fill(target_points=2048)
+    .xmr.apodize_exp(lb=5.0)
+    .xmr.apodize_exp(lb=5.0)
+    .xmr.to_spectrum()
+    .xmr.phase(p0=20.0)
+    .xmr.phase(p0=-5.0)
+)
+xr.testing.assert_identical(spectrum_b, rerun)
+print("bit-identical rerun — the record is deterministic")
+```
+
+(attrs-nb-option-b-contrib)=
+### What the contributor writes
+
+Function bodies lose all attrs bookkeeping. Today's `apodize_exp` closes with three lines of
+hand-rolled lineage; under option B it becomes:
+
+```python
+@computes_in(TIME_DIMS)
+@records_history  # ← preservation + the event, centrally
+def apodize_exp(da: xr.DataArray, dim: str = DIMS.time, lb: float = 1.0) -> xr.DataArray:
+    _check_dims(da, dim, "apodize_exp")
+    weight = np.exp(-np.pi * lb * da.coords[dim])
+    return (da * weight).transpose(*da.dims)  # no attrs handling at all
+```
+
+The wider footprint of the change:
+
+- **Vocabulary**: the 14 flat lineage terms in `ATTRS` (plus `simulate_fid`'s literal `sim_*`
+  keys) are deleted; one term is added (`history = "xmr_history"` — namespaced, so it cannot
+  collide with user or CF attrs the way `baseline_method` can today).
+- **Commandment 3 rewrite** (draft): *Preserve inbound coordinates and attributes. Physics
+  attrs stay flat and typed. What the function did is one appended event in the history —
+  written by the decorator, never by hand. Banned: state flags, hand-appended lineage keys, and
+  any math that branches on the history.* The last clause makes the record write-only for
+  library logic; advisory reads stay legal — `phase`'s coordinate-space warning becomes a peek
+  at the history's tail instead of a private key.
+- **Tests**: `TestAttrsPreservation` survives unchanged (preservation is now structural, the
+  test becomes a regression guard); one new test pins the round trip and event order.
+- **`fit_amares`** appends a single `fit_amares` event to the Dataset — `amares_amplitude_scale`
+  becomes one of its params instead of a vocabulary term (dossier 05's side of this coin).
+
+:::{dropdown} Fine print — where the prototype cheats
+- **Applied vs. passed.** The decorator records arguments *as bound*. `phase(pivot=None)`
+  resolves the pivot internally, and `autophase` *finds* p0/p1 — today's flat keys record the
+  resolved values, which is genuinely better. The real decorator needs one opt-in channel for a
+  function to override its recorded params with what it actually applied; most functions need
+  nothing. This is the main piece of design work left inside option B.
+- **Functions that add physics attrs** (vendor loaders, `simulate_fid`) keep doing so — the
+  decorator preserves inbound attrs and function-added keys alike; only the event goes through
+  the append. The prototype emulates "deleted appends" by stripping `FLAT_LINEAGE`.
+- Params must be JSON-representable; the prototype falls back to `str`. The real rule: record
+  scalars, strings and small lists; data-shaped arguments are omitted.
+- The monkeypatch wraps four functions for the demo; the real change decorates all of them.
+:::
+
+(attrs-nb-option-c)=
+## Option C — hybrid: flat "latest" keys *plus* the history
+
+Keep the history from option B as the audit record, and additionally keep flat keys as a
+quick-glance surface for the *latest* application. The attrs would render like:
+
+```python
+>>> spectrum.attrs
+{'reference_frequency': 120.66,
+ 'carrier_ppm': 0.0,
+ 'apodization_lb': 5.0,        # ← latest application only
+ 'phase_p0': -5.0,             # ← still claims −5° while the data carries 15°
+ 'xmr_history': '{"schema": 1, "events": [...]}'}
+```
+
+The contributor delta over B is small — the decorator mirrors each event's params into flat
+keys. The problems are what the mirror *means*:
+
+- "Latest" is not "effective state": after two `lb=5` apodizations the mirror reads `5.0`; after
+  the re-phasing it reads `-5.0`. The quick-glance surface keeps the lie that motivated the
+  change, now beside the record that contradicts it.
+- The mirror duplicates the history's last event — redundant information that must be kept
+  consistent, and a second record format frozen at 1.0.
+- Its only justification would be readers — and today there are none (the
+  [grep above](#attrs-nb-reframe)). A consumer that appears later can be served by *adding* the
+  mirror back, a non-breaking change; removing it later is the breaking one.
+
+:::{note} Option D — provenance outside attrs
+A sidecar object (a ledger next to the DataArray) fails the first constraint: the record must
+travel with the data. Any plain xarray op or netCDF round trip orphans it. Not considered
+further.
+:::
+
+(attrs-nb-guarantee)=
+## The preservation guarantee — the same answer under every option
+
+Whatever the record's shape, what may a user actually rely on? Inside xmris the answer can be
+structural: the decorator restores inbound attrs onto every result, so even attrs-dropping
+operations *inside* a function body cannot lose them (this is
+[#21](https://github.com/andrewendlinger/xmris/issues/21)'s "systematic mechanism"). Outside
+xmris, the library cannot patch xarray, and pretending otherwise would be a false promise. The
+escape hatch already exists upstream:
+
+```{code-cell} ipython3
+with xr.set_options(keep_attrs=True):
+    doubled = spectrum_b * 2
+
+doubled.attrs == spectrum_b.attrs
+```
+
+:::{important} The honest guarantee, stated once
+Every public xmris function preserves inbound attrs and coordinates and appends its record —
+structurally, via the central decorator; `TestAttrsPreservation` stays as the regression guard.
+Outside xmris functions, xarray's rules apply: plain arithmetic, `concat`, `groupby` drop attrs
+unless you opt in with `xr.set_options(keep_attrs=True)`. xmris documents that boundary and
+never sets global options itself; histories of *combined* objects follow xarray's
+`combine_attrs`, and xmris invents no merge semantics. The history records xmris steps only —
+math done outside the library is invisible to it under every option.
+:::
+
+(attrs-nb-verdict)=
+## Side by side
+
+| Can the object answer… | A — flat | B — history | C — hybrid |
+|---|---|---|---|
+| what was applied last? | yes | yes (last event) | yes |
+| how many times, in what order? | no | yes | yes (history half) |
+| for the effective total (re-phasing)? | no — record lies | yes (sum of events) | history yes, mirror lies |
+| after a netCDF round trip? | yes | yes | yes |
+| at a glance, in the attrs repr? | yes — readable keys | JSON blob; `history()` is the surface | readable keys + blob |
+| Frozen surfaces at 1.0 | 14 flat keys | 1 envelope format | both |
+| Per-function cost | hand-rolled ×20 | one decorator | one decorator + mirror invariant |
+| Readers served today | 0 | 0 (writes a new surface) | 0 |
+
+:::{tip} Recommendation: option B
+The flat record fails the hero sentence in the first repeated step, and its keys have no
+readers to protect. One JSON-string history — envelope-versioned, timestamp-free, written by
+the same decorator that makes preservation structural — answers every row above except the
+glance, and the glance is a display problem (`history()`), not a storage problem. Revisit if a
+real programmatic consumer of "latest params" appears (re-add the mirror, additively), or if
+CF/NIfTI-MRS interop later wants a timestamped free-text `history` twin.
+
+Deciding this fixes half of dossier 03's schema (attrs = physics + record) and shapes dossier
+05's fit Dataset (one `fit_amares` event). On decision, the Resolution goes into
+`roadmap_issue_02_attrs_lineage.md` — this page then retires.
+:::

--- a/docs/decisions/decision_02_attrs_lineage.md
+++ b/docs/decisions/decision_02_attrs_lineage.md
@@ -21,8 +21,8 @@ decision landed on 2026-08-02: **option B, the physics/record split**. It is the
 **prototype defined inside this notebook**; nothing here is implemented in the library yet.
 :::
 
-The roadmap makes one hero promise: *the object they hand back can answer for every step that
-produced it*. This notebook holds every candidate attrs strategy against that sentence — first
+The roadmap promises that the object handed back *can answer for every step that produced it*.
+This notebook holds every candidate attrs strategy against that sentence — first
 the problem, demonstrated live against today's `main`; then each option as code, the user
 experience and the contributor's side of the same coin.
 

--- a/docs/decisions/decision_02_attrs_lineage.md
+++ b/docs/decisions/decision_02_attrs_lineage.md
@@ -345,7 +345,8 @@ The wider footprint of the change:
 - **Tests**: `TestAttrsPreservation` survives unchanged (preservation is now structural, the
   test becomes a regression guard); one new test pins the round trip and event order.
 - **`fit_amares`** appends a single `fit_amares` event to the Dataset — `amares_amplitude_scale`
-  becomes one of its params instead of a vocabulary term (dossier 05's side of this coin).
+  becomes one of its params instead of a vocabulary term (the fit-Dataset chapter of the
+  data-model schema, [#28](https://github.com/andrewendlinger/xmris/issues/28)).
 
 :::{dropdown} Fine print — where the prototype cheats
 - **Applied vs. passed.** The decorator records arguments *as bound*. `phase(pivot=None)`
@@ -443,7 +444,10 @@ glance, and the glance is a display problem (`history()`), not a storage problem
 real programmatic consumer of "latest params" appears (re-add the mirror, additively), or if
 CF/NIfTI-MRS interop later wants a timestamped free-text `history` twin.
 
-Deciding this fixes half of dossier 03's schema (attrs = physics + record) and shapes dossier
-05's fit Dataset (one `fit_amares` event). On decision, the Resolution goes into
-`roadmap_issue_02_attrs_lineage.md` — this page then retires.
+Deciding this fixes half of the data-model schema (attrs = physics + record,
+[#28](https://github.com/andrewendlinger/xmris/issues/28)) and shapes its fit-Dataset chapter
+(one `fit_amares` event). Decided 2026-08-02: the resolution is recorded on the
+[decision board](#roadmap-decisions) and in
+[#64](https://github.com/andrewendlinger/xmris/issues/64), which tracks the implementation.
+This page stays frozen as the record of *why*.
 :::

--- a/docs/decisions/decision_02b_physics_constants.md
+++ b/docs/decisions/decision_02b_physics_constants.md
@@ -28,7 +28,7 @@ Pass one compared boilerplate, an import-time global, and one-coordinate-per-con
 review rejected all three. Pass two elevated **repr readability to a first-class constraint**,
 prototyped the `keep_attrs` ergonomics (scoped sugar, notebook auto-detection), and added two
 structural options — the container coordinate won. This pass folds in the convergence round:
-the **history rides the container block too** (amending dossier 02's storage home, not its
+the **history rides the container block too** (amending decision 02's storage home, not its
 format), both containers are **pinned to the bottom** of the coordinate list with the
 enforcement measured, and the **names** are fixed (`xmr_acquisition`, `xmr_history`).
 :::
@@ -98,14 +98,14 @@ print(ATTRS.reference_frequency.description)
 (constants-nb-class)=
 ## What must travel — and what already does
 
-Not every key on today's objects is a constant this dossier must carry:
+Not every key on today's objects is a constant this decision must carry:
 
-| Key on today's objects | What it is | In this dossier's class? |
+| Key on today's objects | What it is | In this decision's class? |
 |---|---|---|
 | `reference_frequency`, `carrier_ppm`, `group_delay`, `b0_field` | Non-derivable acquisition constants — gates and converters need them | **Yes** |
 | `spectral_width`, `dead_time` | Derivable: the time coordinate's spacing and first sample — `fit_amares` already infers both from it | No — duplication to retire |
 | `units` | Describes the data values (CF-style variable attr) | No — stays an attr |
-| `sim_*`, `target_snr`, `apodization_lb`, … | Lineage — becomes `xmr_history` | No — dossier 02's law |
+| `sim_*`, `target_snr`, `apodization_lb`, … | Lineage — becomes `xmr_history` | No — decision 02's law |
 
 The second row is the thesis in miniature: `spectral_width` never had a travel problem,
 because it is not an annotation *about* the data — it **is structure**, the spacing of a
@@ -304,7 +304,7 @@ that pattern, twice — a two-line block that ends the coordinate list:
 - **`xmr_acquisition`** — attrs are the physical constants, flat and typed as 02's law
   demands; its **value** is a deterministic fingerprint of them, which buys back the honesty
   the attrs side of the matrix loses (xarray compares values, never attrs).
-- **`xmr_history`** — the record rides the same block: dossier 02's JSON envelope, format
+- **`xmr_history`** — the record rides the same block: decision 02's JSON envelope, format
   untouched, but its **home** moves from a droppable object attr into a coordinate whose
   *value is the envelope itself* — so identical histories travel and diverged histories drop
   honestly, by xarray's own rules.
@@ -350,7 +350,7 @@ def mint_containers(da: xr.DataArray) -> xr.DataArray:
 
 def reads_constants(func):
     """Prototype of the gate change: constants are found in the container, then attrs,
-    and the call appends its event to the record (dossier 02's decorator, one day)."""
+    and the call appends its event to the record (decision 02's decorator, one day)."""
 
     @functools.wraps(func)
     def wrapper(da, *args, **kwargs):
@@ -506,7 +506,7 @@ The blend keeps its constants (they still hold) and honestly loses its lineage (
 history describes it) — exactly the right answer in both columns, and nothing in the library
 invented merge semantics to get it. A drifting series promotes the fingerprint to a per-scan
 array — visibly non-uniform, so a gate meeting a non-scalar container can refuse with "this
-series is not uniformly calibrated" (the exact message is dossier 03's schema work):
+series is not uniformly calibrated" (the exact message is decision 03's schema work):
 
 ```{code-cell} ipython3
 drifted = xr.concat(
@@ -554,8 +554,8 @@ grid-mapping shape, self-describing under any tool's `ncdump`, no xmris required
 xmris call re-pins the block.)
 
 :::{dropdown} Fine print — costs and open ends, honestly
-- **The 02 amendment, stated precisely.** Dossier 02 closed the record's *format* (one JSON
-  envelope, versioned, timestamp-free) and named the key `xmr_history`; this dossier moves
+- **The 02 amendment, stated precisely.** Decision 02 closed the record's *format* (one JSON
+  envelope, versioned, timestamp-free) and named the key `xmr_history`; this decision moves
   its *home* from `da.attrs["xmr_history"]` to the coordinate's value — same name, same
   envelope, one line of 02's Resolution to amend at the harvest. Everything else 02 decided
   (write-only for library math, `da.xmr.history()` as the reading surface, no invented merge
@@ -566,7 +566,7 @@ xmris call re-pins the block.)
   makes this safe: a promoted container is *unreadable* until sliced back to one scan —
   `drifted.isel(repetition=0)` — which restores that scan's fingerprint.
 - **Contributor footprint.** Two writers (`simulate_fid`, the Bruker loader) mint the block
-  instead of `assign_attrs`; dossier 02's central decorator gains the re-pin (drop + assign
+  instead of `assign_attrs`; decision 02's central decorator gains the re-pin (drop + assign
   last) and the container read; one reader helper behind `requires_attrs` (and the direct
   `attrs.get` reads in `to_ppm`, `to_hz`, `fit_amares`, `remove_digital_filter`) looks
   container-first-then-attrs, with the attrs fallback kept indefinitely — data written under
@@ -700,7 +700,7 @@ instead of accumulating folklore.
 Two scalar coordinates, pinned as the last entries of every xmris return.
 **`xmr_acquisition`** holds the physical constants as its attrs — flat, typed, one click open
 in the repr — with a deterministic calibration fingerprint as its value, so disagreement is
-dropped honestly instead of first-wins lied about. **`xmr_history`** carries dossier 02's
+dropped honestly instead of first-wins lied about. **`xmr_history`** carries decision 02's
 JSON envelope, format untouched, as its value — the record now travels every plain operation
 the constants do, and diverged histories vanish honestly by xarray's own rules (an amendment
 to 02's storage home, folded at the harvest). Writers mint the block; gates read
@@ -713,14 +713,17 @@ the vocabulary's curation over all of it and audits what falls outside.
 Option P keeps the strictly strongest travel but fails the repr at exactly the scale the
 roadmap targets; option X is beautiful for axis constants and structurally partial;
 `keep_attrs` in every wrapper lies under combination and splits notebook from script. Feeds
-dossier 03 the schema sentence — *an xmris object carries its constants and record in the
+the data-model schema ([#28](https://github.com/andrewendlinger/xmris/issues/28)) the
+sentence — *an xmris object carries its constants and record in the
 pinned `xmr_*` block* — and re-scopes
 [#21](https://github.com/andrewendlinger/xmris/issues/21) (the outside-xmris half becomes
 structural) and [#22](https://github.com/andrewendlinger/xmris/issues/22) (validation targets
 one dict, in one reader). Revisit if xarray flips its default attrs propagation or fixes
 `xr.where`'s coordinate-attrs strip, or if per-scan constants become a first-class workflow
-(a promoted container then wants reading semantics, not a refusal). The Resolution lives in
-`roadmap_issue_02b_physics_attrs.md`; this page retires at the harvest.
+(a promoted container then wants reading semantics, not a refusal). Decided 2026-08-03: the
+resolution is recorded on the [decision board](#roadmap-decisions) and in
+[#21](https://github.com/andrewendlinger/xmris/issues/21), which tracks the implementation.
+This page stays frozen as the record of *why*.
 :::
 
 ```{code-cell} ipython3

--- a/docs/decisions/decision_02b_physics_constants.md
+++ b/docs/decisions/decision_02b_physics_constants.md
@@ -1,0 +1,796 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3 (xmris)
+  language: python
+  name: python3
+---
+
+(constants-nb)=
+# The constants decision — a design notebook
+
+:::{note} A frozen exploration record
+This notebook explored the option space for roadmap decision **02b — the physical constants**
+(tracker [#21](https://github.com/andrewendlinger/xmris/issues/21)) and froze when the
+decision landed on 2026-08-03: **the container coordinates, `xmr_acquisition` +
+`xmr_history`**. It is the record of *why*, not the spec of *what* — the aimed-solution
+notebook will be the spec, and the [decision board](#roadmap-decisions) carries the summary.
+Every option below runs a **prototype defined inside this notebook**; nothing here is
+implemented in the library yet. Sibling to [the attrs exploration](#attrs-nb), whose decision
+is settled law underneath this page.
+:::
+
+:::{note} What changed across review rounds
+Pass one compared boilerplate, an import-time global, and one-coordinate-per-constant storage;
+review rejected all three. Pass two elevated **repr readability to a first-class constraint**,
+prototyped the `keep_attrs` ergonomics (scoped sugar, notebook auto-detection), and added two
+structural options — the container coordinate won. This pass folds in the convergence round:
+the **history rides the container block too** (amending dossier 02's storage home, not its
+format), both containers are **pinned to the bottom** of the coordinate list with the
+enforcement measured, and the **names** are fixed (`xmr_acquisition`, `xmr_history`).
+:::
+
+The [attrs decision](#attrs-nb) split the metadata world in two: lineage became the
+`xmr_history` record, and the **physical constants** — the numbers a measurement cannot be
+interpreted without — stayed flat, typed, individually addressable. Two promises about those
+constants are still broken or unmade: they do not reliably **travel** (one ordinary xarray
+operation strips them, and the failure surfaces steps later), and they are not
+**discoverable** (every constant carries curated prose and a unit in the vocabulary, yet
+nothing on the object surfaces it). This notebook's thesis, reached the long way round: the
+library should stop trying to patch xarray's metadata rules and instead stop keeping physics
+*as* metadata — the options differ in **where in the object's structure** the constants live,
+and what each home costs in the repr, at the gates, and in a file.
+
+(constants-nb-problem)=
+## The problem, live
+
+`simulate_fid` stamps its output with the calibration the physics needs — the same keys a
+vendor loader writes. Inside `.xmr` chains they are safe; a notebook is not an `.xmr` chain:
+
+```{code-cell} ipython3
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+import xmris
+
+fid = xmris.simulate_fid(
+    amplitudes=[1.0, 0.6],
+    chemical_shifts=[0.0, 5.2],
+    reference_frequency=120.66,  # MHz
+    n_points=1024,
+)
+spectrum = fid.xmr.apodize_exp(lb=5.0).xmr.to_spectrum()
+
+scaled = spectrum * 2  # any plain xarray operation
+scaled.attrs
+```
+
+Everything is gone — including `reference_frequency` and `carrier_ppm`, without which a ppm
+axis cannot exist. Nothing says so; the failure arrives later, in a different cell, possibly a
+different day:
+
+```{code-cell} ipython3
+normalized = scaled / scaled.size  # ...a few innocent steps later...
+try:
+    normalized.xmr.to_ppm()
+except ValueError as err:
+    print(err)
+```
+
+The error is honest but names the *symptom*: the user is told to re-enter a value they already
+provided, with no hint which upstream line dropped it —
+[#21](https://github.com/andrewendlinger/xmris/issues/21)'s insidious half. And the second
+promise breaks silently in the first cell's output: to a scientist arriving from any vendor,
+`'reference_frequency': 120.66` is a bare float, while the curation written for exactly that
+reader is reachable only by importing library internals:
+
+```{code-cell} ipython3
+from xmris.core.config import ATTRS  # a user never types this line
+
+print("unit:", ATTRS.reference_frequency.unit)
+print(ATTRS.reference_frequency.description)
+```
+
+(constants-nb-class)=
+## What must travel — and what already does
+
+Not every key on today's objects is a constant this dossier must carry:
+
+| Key on today's objects | What it is | In this dossier's class? |
+|---|---|---|
+| `reference_frequency`, `carrier_ppm`, `group_delay`, `b0_field` | Non-derivable acquisition constants — gates and converters need them | **Yes** |
+| `spectral_width`, `dead_time` | Derivable: the time coordinate's spacing and first sample — `fit_amares` already infers both from it | No — duplication to retire |
+| `units` | Describes the data values (CF-style variable attr) | No — stays an attr |
+| `sim_*`, `target_snr`, `apodization_lb`, … | Lineage — becomes `xmr_history` | No — dossier 02's law |
+
+The second row is the thesis in miniature: `spectral_width` never had a travel problem,
+because it is not an annotation *about* the data — it **is structure**, the spacing of a
+coordinate, and xarray protects structure with everything it has. Four constants need a home
+today; the MRSI horizon multiplies the family (echo/repetition timing, flip angle, voxel
+geometry), so the mechanism must stay readable at, say, ten constants on a four-dimensional
+object. That object is this page's measuring stick:
+
+```{code-cell} ipython3
+HORIZON = {  # the four real constants of today + a plausible MRSI-era family
+    "reference_frequency": 120.66, "carrier_ppm": 4.7, "group_delay": 68.0, "b0_field": 7.0,
+    "echo_time": 0.012, "repetition_time": 2.0, "flip_angle": 90.0,
+    "voxel_dx": 2.5, "voxel_dy": 2.5, "voxel_dz": 8.0,
+}
+
+mrsi = xr.DataArray(
+    np.zeros((8, 8, 256, 4), dtype=complex),
+    dims=["kx", "ky", "time", "coil"],
+    coords={
+        "kx": np.arange(8), "ky": np.arange(8), "coil": np.arange(4),
+        "time": ("time", np.arange(256) * 1e-4, {"units": "s"}),
+    },
+    name="mrsi",
+)
+```
+
+(constants-nb-keepattrs)=
+## The `keep_attrs` family — ergonomics for the flag
+
+The constants could stay attrs if the flag that protects attrs stopped being ceremony. Two
+ergonomic forms, prototyped. First, scoped sugar — `with xmris.keep():`
+
+```{code-cell} ipython3
+import contextlib
+
+
+@contextlib.contextmanager
+def keep():
+    """What `xmris.keep()` would be: three lines of sugar over xarray's option."""
+    with xr.set_options(keep_attrs=True):
+        yield
+
+
+with keep():
+    doubled = spectrum * 2
+
+doubled.attrs == spectrum.attrs
+```
+
+It works, and the name is friendlier — but count the ceremony. Scoped honestly, *every* cell
+that touches the data needs the wrapper, which is more ritual than the line it replaced;
+hoisted to one call at the top of the notebook, it *is* the anti-goal line wearing a nicer
+name. Sugar relocates the ceremony; it cannot remove it.
+
+Second form: the library detects a notebook and sets the flag there, leaving scripts alone.
+Detection is real — `get_ipython()` exists exactly when running under Jupyter/IPython (it does
+right now, in this page's kernel). But watch what the *same three lines* then do in the two
+environments:
+
+```{code-cell} ipython3
+import subprocess
+import sys
+
+xr.set_options(keep_attrs=True)  # what auto-detecting xmris would have done at import — here
+
+lines = (
+    "import numpy as np, xarray as xr\n"
+    "da = xr.DataArray(np.ones(4), dims='t', attrs={'reference_frequency': 120.66})\n"
+    "print('as a script:  ', (da * 2).attrs)\n"
+)
+da = xr.DataArray(np.ones(4), dims="t", attrs={"reference_frequency": 120.66})
+print("in the notebook:", (da * 2).attrs)
+print(subprocess.run([sys.executable, "-c", lines], capture_output=True, text=True).stdout, end="")
+```
+
+The pipeline that worked all week in Jupyter loses its constants the day it is promoted to a
+script — the failure mode moves to exactly the moment nobody is watching. And in the notebook,
+the flag is a **session global**: every other library's objects in the same kernel now behave
+differently because xmris was imported — the third tenet inverted, and a direct contradiction
+of the [attrs Resolution's guarantee](#attrs-nb-guarantee) that xmris never sets global
+options. Worse, the whole family shares one deeper flaw — under the flag, attrs of *combined*
+objects are first-wins:
+
+```{code-cell} ipython3
+colleague = spectrum.copy(deep=True)
+colleague.attrs["reference_frequency"] = 500.13  # same molecule, different spectrometer
+
+merged = spectrum + colleague  # flag still on, from the cell above
+print(merged.attrs["reference_frequency"], "— first operand wins, silently")
+
+xr.set_options(keep_attrs="default")  # undo: this notebook must not own the session either
+```
+
+A later `to_ppm` draws an axis that is wrong for half the signal, without a murmur. Whatever
+the ergonomics, `keep_attrs` converts silent loss into silent lies. The family is not the
+answer at any level of sugar.
+
+(constants-nb-structure)=
+## The structural turn
+
+xarray drops *annotations*; it protects *structure* — coordinates survive because science
+depends on them. So measure exactly what a coordinate-borne constant can rely on. The probe: a
+scalar (dimensionless) coordinate whose **value** is the constant and whose own attrs carry
+its unit — pushed through the operations a real analysis performs:
+
+```{code-cell} ipython3
+probe = xr.DataArray(
+    np.linspace(-1, 1, 8),
+    dims=["frequency"],
+    coords={
+        "frequency": ("frequency", np.arange(8.0), {"units": "Hz"}),
+        "reference_frequency": xr.Variable((), 120.66, attrs={"units": "MHz"}),
+    },
+)
+
+ops = {
+    "da * 2": lambda d: d * 2,
+    "np.abs(da)": lambda d: np.abs(d),
+    "da - da.mean()": lambda d: d - d.mean(),
+    "da.mean('frequency')": lambda d: d.mean("frequency"),
+    "da.isel(frequency=slice(2, 6))": lambda d: d.isel(frequency=slice(2, 6)),
+    "da.where(da > 0)": lambda d: d.where(d > 0),
+    "xr.where(da > 0, da, 0)": lambda d: xr.where(d > 0, d, 0),
+    "da.groupby('band').mean()": lambda d: d.assign_coords(
+        band=("frequency", [0, 0, 0, 0, 1, 1, 1, 1])
+    ).groupby("band").mean(),
+    "xr.concat([da, da], 'rep')": lambda d: xr.concat([d, d], dim="rep"),
+}
+
+matrix = {}
+for label, op in ops.items():
+    out = op(probe)
+    coord = out.coords.get("reference_frequency")
+    matrix[label] = {
+        "object attrs survive": bool(out.attrs),
+        "coord value survives": coord is not None and 120.66 in np.atleast_1d(coord.values),
+        "coord attrs survive": coord is not None and coord.attrs.get("units") == "MHz",
+    }
+pd.DataFrame(matrix).T
+```
+
+Three facts, and they shape everything below. Object attrs survive almost nothing — the
+problem section, quantified. A coordinate's **value** survives *everything on this list*,
+including the reduction that removes the spectral axis. A coordinate's **attrs** survive
+everything except one function — `xr.where` (the function form; the everyday method
+`da.where` is safe), which rebuilds coordinates bare. So a constant stored as a coordinate
+*value* is bulletproof; a constant stored in a coordinate's *attrs* has exactly one known
+leak. Three homes follow from this table — they differ in which side of it they sit on, and
+in what they do to the repr.
+
+(constants-nb-perconstant)=
+## Option P — one coordinate per constant
+
+The maximal-robustness corner: every constant is its own scalar coordinate (value = the
+constant, attrs = its unit via `as_variable`, Commandment 7's machinery). Travel is the
+"value" column above — no leak at all — and disagreement gets the best semantics on this
+page:
+
+```{code-cell} ipython3
+ge = probe.copy(deep=True)
+siemens = probe.copy(deep=True).assign_coords(reference_frequency=500.13)
+
+summed = ge + siemens
+drifting = xr.concat([ge, ge.assign_coords(reference_frequency=120.68)], dim="repetition")
+
+print("cross-field sum:  constant kept?", "reference_frequency" in summed.coords)
+print("drifting series: ", drifting.reference_frequency.values, drifting.reference_frequency.dims)
+```
+
+Conflicting values are *dropped* — the combined object honestly has no single reference
+frequency, and the next gate refuses loudly. A drifting series is *promoted* to a per-scan
+array — the truth, recorded. This option fails somewhere else entirely. Put the horizon
+family on the measuring stick:
+
+```{code-cell} ipython3
+mrsi_per = mrsi.assign_coords({k: xr.Variable((), v) for k, v in HORIZON.items()})
+mrsi_per
+```
+
+Ten constants shoulder-to-shoulder with four real axes, indistinguishable from data
+coordinates at a glance. This is the review objection, on screen: at MRSI scale the repr —
+the single most-read surface in a notebook — becomes a wall. Mitigations were considered and
+don't rescue it: insertion order *is* preserved through operations (the constants stay
+grouped at the end), but ten lines are ten lines; an `xmr_` name prefix makes the grouping
+visible at the cost of uglier names everywhere (`da.xmr_reference_frequency`), and xarray
+offers no per-object way to fold coordinates away. Right physics, unreadable at scale.
+
+(constants-nb-container)=
+## Option C — the container coordinates
+
+The geoscience stacks hit this exact wall and left a pattern: rioxarray carries an entire
+coordinate-reference system as **one** scalar coordinate (`spatial_ref`) whose attrs hold the
+fields — CF's grid-mapping design, netCDF-native, proven at survey scale. The xmris shape is
+that pattern, twice — a two-line block that ends the coordinate list:
+
+- **`xmr_acquisition`** — attrs are the physical constants, flat and typed as 02's law
+  demands; its **value** is a deterministic fingerprint of them, which buys back the honesty
+  the attrs side of the matrix loses (xarray compares values, never attrs).
+- **`xmr_history`** — the record rides the same block: dossier 02's JSON envelope, format
+  untouched, but its **home** moves from a droppable object attr into a coordinate whose
+  *value is the envelope itself* — so identical histories travel and diverged histories drop
+  honestly, by xarray's own rules.
+
+```{code-cell} ipython3
+import functools
+import hashlib
+import json
+
+PHYSICS = (ATTRS.reference_frequency, ATTRS.carrier_ppm, ATTRS.group_delay, ATTRS.b0_field)
+CONTAINERS = ["xmr_acquisition", "xmr_history"]
+EMPTY_HISTORY = json.dumps({"schema": 1, "events": []})
+
+
+def fingerprint(constants: dict) -> str:
+    """Deterministic identity of a calibration (no timestamps — reruns stay identical)."""
+    return hashlib.sha256(json.dumps(constants, sort_keys=True).encode()).hexdigest()[:8]
+
+
+def mint_containers(da: xr.DataArray) -> xr.DataArray:
+    """Prototype of the central bookkeeping: home the constants and the record,
+    and pin the block to the bottom of the coordinate list."""
+    carried = (
+        dict(da.coords["xmr_acquisition"].attrs) if "xmr_acquisition" in da.coords else {}
+    )
+    loose = {str(t): da.attrs[t] for t in PHYSICS if t in da.attrs}
+    constants = {**carried, **loose}
+    history = (
+        str(da.coords["xmr_history"].values) if "xmr_history" in da.coords else EMPTY_HISTORY
+    )
+
+    # assign_coords on an existing key updates in place (measured) — dropping
+    # first and re-assigning is what moves the block to the end.
+    out = da.drop_vars([c for c in CONTAINERS if c in da.coords])
+    if constants:
+        out = out.assign_coords(
+            xmr_acquisition=xr.Variable((), fingerprint(constants), constants)
+        )
+    out = out.assign_coords(xmr_history=xr.Variable((), history))
+    out.attrs = {k: v for k, v in out.attrs.items() if k not in loose}
+    return out
+
+
+def reads_constants(func):
+    """Prototype of the gate change: constants are found in the container, then attrs,
+    and the call appends its event to the record (dossier 02's decorator, one day)."""
+
+    @functools.wraps(func)
+    def wrapper(da, *args, **kwargs):
+        found = {}
+        if "xmr_acquisition" in da.coords and da.coords["xmr_acquisition"].ndim == 0:
+            found = {
+                k: v for k, v in da.coords["xmr_acquisition"].attrs.items() if k in PHYSICS
+            }
+        result = func(da.assign_attrs(found), *args, **kwargs)
+        result.attrs = {k: v for k, v in result.attrs.items() if k not in found}
+        result = mint_containers(result)
+        envelope = json.loads(str(result.coords["xmr_history"].values))
+        envelope["events"].append({"op": func.__name__})
+        return result.assign_coords(xmr_history=xr.Variable((), json.dumps(envelope)))
+
+    return wrapper
+
+
+# Graft onto the live library, notebook-locally: the .xmr methods are thin
+# delegators to these module-level names, so rebinding gives the real chained
+# UX without touching src/.
+import xmris.core.accessor as _accessor
+
+for _name in ("to_ppm", "to_hz", "to_spectrum", "apodize_exp"):
+    setattr(_accessor, _name, reads_constants(getattr(_accessor, _name)))
+```
+
+(constants-nb-container-ux)=
+### The measuring stick, again
+
+```{code-cell} ipython3
+mrsi_one = mrsi.assign_coords(
+    xmr_acquisition=xr.Variable((), fingerprint(HORIZON), attrs=HORIZON),
+    xmr_history=xr.Variable((), EMPTY_HISTORY),
+)
+mrsi_one
+```
+
+Ten constants — and the processing record beside them — in a **two-line block** that stays
+two lines whether the family grows to fifteen or fifty. In a Jupyter repr the
+`xmr_acquisition` entry expands to the full constants dict on one click; programmatically it
+is a plain mapping, one hop away, with `explain()` ([below](#constants-nb-explain)) as the
+curated view:
+
+```{code-cell} ipython3
+dict(mrsi_one.xmr_acquisition.attrs)
+```
+
+Travel is the matrix's "attrs" column — everything except `xr.where` — plus the block itself
+surviving axis-dropping reductions (it outlives `mean("time")`, where axis-carried constants
+below die). The opening section's failure, replayed end-to-end:
+
+```{code-cell} ipython3
+spectrum_c = mint_containers(fid).xmr.apodize_exp(lb=5.0).xmr.to_spectrum()
+detour = np.abs(spectrum_c * 2) / spectrum_c.size  # plain xarray, twice over
+detour.xmr.to_ppm().coords["chemical_shift"]
+```
+
+No flag, no ceremony, no failure. Entry for an outsider is today's documented plain-string
+path, unchanged — the first gate re-homes loose attrs into the container, and from then on
+they travel:
+
+```{code-cell} ipython3
+outsider = xr.DataArray(
+    np.random.default_rng(0).normal(size=128),
+    dims=["frequency"],
+    coords={"frequency": np.linspace(-500, 500, 128)},
+    attrs={"reference_frequency": 120.66, "carrier_ppm": 4.7},  # plain strings, as today
+)
+referenced = outsider.xmr.to_ppm()
+print("re-homed:", dict(referenced.xmr_acquisition.attrs))
+print("recorded:", str(referenced.xmr_history.values))
+print("survives the next plain op?", "xmr_acquisition" in (referenced * 2).coords)
+```
+
+(constants-nb-container-pinned)=
+### Pinned to the bottom, named as a block
+
+The review asked for a guarantee: these must not read as data coordinates, and they must sit
+at the end of the list. Both are enforceable, and the enforcement was measured. xarray
+displays coordinates in **insertion order** — there is no auto-sorting — so `mint_containers`
+pins the block by dropping and re-assigning it last on every xmris return (a plain
+re-assignment updates in place and would *not* move it). Ordinary operations then preserve
+that order:
+
+```{code-cell} ipython3
+after = {
+    "spectrum_c * 2": spectrum_c * 2,
+    "np.abs(spectrum_c)": np.abs(spectrum_c),
+    "spectrum_c + spectrum_c": spectrum_c + spectrum_c,
+    "spectrum_c.where(|s| > 0.1)": spectrum_c.where(np.abs(spectrum_c) > 0.1),
+    "spectrum_c.isel(slice)": spectrum_c.isel(frequency=slice(0, 512)),
+    "xr.concat([...], 'rep')": xr.concat([spectrum_c, spectrum_c], dim="rep"),
+}
+pd.DataFrame(
+    {"xmr_* block is still last": {k: list(v.coords)[-2:] == CONTAINERS for k, v in after.items()}}
+)
+```
+
+Three cases can push the block off the bottom — a user's own later `assign_coords`, `groupby`
+re-appending the grouped coordinate, and netCDF reload order (engine-determined). None of
+them is silent damage, and every one self-heals at the next xmris touch:
+
+```{code-cell} ipython3
+slipped = spectrum_c.assign_coords(mask=("frequency", np.ones(spectrum_c.sizes["frequency"])))
+print("after a user assign_coords:", list(slipped.coords))
+print("after the next xmris call: ", list(slipped.xmr.to_ppm().coords))
+```
+
+The names do the other half of the review's ask. The `xmr_` prefix marks ownership at a
+glance — it is the accessor's own name, so the mental link "`xmr_*` belongs to `.xmr`" is
+free — it renders the pair as one visual block above the Attributes section, and it cannot
+collide with any vendor's axis names. The words after the prefix are the domain's own:
+
+| Coordinate | Value (what xarray compares) | Attrs | Read surface |
+|---|---|---|---|
+| `xmr_acquisition` | calibration fingerprint | the constants, flat + typed | one click in the repr · `explain()` · `da.xmr_acquisition.attrs` |
+| `xmr_history` | the JSON envelope — 02's format, verbatim | — | `da.xmr.history()` |
+
+(constants-nb-container-conflict)=
+### When calibrations — or histories — disagree
+
+The fingerprint value is what xarray compares, so conflicts behave like Option P's — honest,
+and each container answers independently:
+
+```{code-cell} ipython3
+other_cal = mint_containers(
+    fid.assign_attrs(reference_frequency=500.13)
+).xmr.apodize_exp(lb=5.0).xmr.to_spectrum()
+
+mixed = spectrum_c + other_cal
+print("calibration kept?", "xmr_acquisition" in mixed.coords,
+      "| record kept?", "xmr_history" in mixed.coords)
+try:
+    mixed.xmr.to_ppm()
+except ValueError as err:
+    print(str(err).splitlines()[0])
+```
+
+Different constants → different fingerprints → the calibration is dropped whole and the next
+gate refuses loudly, instead of `keep_attrs`' confidently wrong axis — while the record
+survives, because both operands carry the *same* history. The mirror case: same calibration,
+diverged processing —
+
+```{code-cell} ipython3
+blend = spectrum_c + spectrum_c.xmr.apodize_exp(lb=0.5)  # one more recorded step on one side
+
+print("calibration kept?", "xmr_acquisition" in blend.coords,
+      "| record kept?", "xmr_history" in blend.coords)
+```
+
+The blend keeps its constants (they still hold) and honestly loses its lineage (no single
+history describes it) — exactly the right answer in both columns, and nothing in the library
+invented merge semantics to get it. A drifting series promotes the fingerprint to a per-scan
+array — visibly non-uniform, so a gate meeting a non-scalar container can refuse with "this
+series is not uniformly calibrated" (the exact message is dossier 03's schema work):
+
+```{code-cell} ipython3
+drifted = xr.concat(
+    [mint_containers(fid), mint_containers(fid.assign_attrs(reference_frequency=120.68))],
+    dim="repetition",
+)
+drifted.xmr_acquisition.values
+```
+
+One honest cost, from the matrix's one leak: `xr.where` (function form) strips the
+container's attrs — but keeps its value, so the damage is *detectable*, not silent:
+
+```{code-cell} ipython3
+holed = xr.where(np.abs(spectrum_c) > 0.1, spectrum_c, 0)
+print("container present:", "xmr_acquisition" in holed.coords,
+      "| constants left:", dict(holed.xmr_acquisition.attrs))
+```
+
+A gate that finds the container present but empty can say precisely what happened and how to
+fix it — a named, loud, one-function edge case (today `xr.where` already strips the
+`units` metadata Commandment 7 puts on every ppm axis, so this is an upstream wart worth an
+xarray issue regardless of this decision).
+
+(constants-nb-container-file)=
+### What survives a file
+
+```{code-cell} ipython3
+import tempfile
+from pathlib import Path
+
+magnitude = spectrum_c.copy(data=np.abs(spectrum_c.values))  # netCDF holds no complex values
+
+with tempfile.TemporaryDirectory() as tmp:
+    path = Path(tmp) / "spectrum.nc"
+    magnitude.rename("spectrum").to_netcdf(path)
+    loaded = xr.load_dataarray(path)
+
+print("coordinate order after reload:", list(loaded.coords))
+loaded.xmr_acquisition
+```
+
+The container is a real netCDF variable carrying the constants as its attributes — the CF
+grid-mapping shape, self-describing under any tool's `ncdump`, no xmris required to read it.
+(Reload order is the netCDF engine's choice — one of the three slip cases above; the first
+xmris call re-pins the block.)
+
+:::{dropdown} Fine print — costs and open ends, honestly
+- **The 02 amendment, stated precisely.** Dossier 02 closed the record's *format* (one JSON
+  envelope, versioned, timestamp-free) and named the key `xmr_history`; this dossier moves
+  its *home* from `da.attrs["xmr_history"]` to the coordinate's value — same name, same
+  envelope, one line of 02's Resolution to amend at the harvest. Everything else 02 decided
+  (write-only for library math, `da.xmr.history()` as the reading surface, no invented merge
+  semantics) carries over unchanged.
+- **Stale attrs on a promoted container.** After the drift `concat`, the per-scan
+  fingerprints are truthful but the container's attrs still show scan 1's constants
+  (first-wins on attrs is unfixable from library code). The gate's non-scalar check is what
+  makes this safe: a promoted container is *unreadable* until sliced back to one scan —
+  `drifted.isel(repetition=0)` — which restores that scan's fingerprint.
+- **Contributor footprint.** Two writers (`simulate_fid`, the Bruker loader) mint the block
+  instead of `assign_attrs`; dossier 02's central decorator gains the re-pin (drop + assign
+  last) and the container read; one reader helper behind `requires_attrs` (and the direct
+  `attrs.get` reads in `to_ppm`, `to_hz`, `fit_amares`, `remove_digital_filter`) looks
+  container-first-then-attrs, with the attrs fallback kept indefinitely — data written under
+  today's law keeps working, and outsider entry stays plain `assign_attrs` (the lazy
+  re-homing makes the existing fix-lines correct). `TestAttrsPreservation` is untouched; one
+  new parametrized test pins "the block is the last two coordinates" across the public API.
+- **Prototype cheats.** Only four functions are wrapped here (the real change is the central
+  decorator, so every function records and re-pins); events carry just `op` (the real
+  envelope carries params and version, per 02); `mint_containers` runs at the chain head
+  (real writers mint at the source).
+:::
+
+(constants-nb-axis)=
+## Option X — constants ride the axis they calibrate
+
+The zero-repr-cost corner: `reference_frequency` and `carrier_ppm` calibrate the spectral
+axis, `group_delay` the time axis — so store each constant in the attrs of the dimension
+coordinate it belongs to. No new repr line at all, and a certain semantic beauty: the
+calibration lives on the thing it calibrates.
+
+```{code-cell} ipython3
+axis_da = xr.DataArray(
+    np.linspace(-1, 1, 8),
+    dims=["frequency"],
+    coords={
+        "frequency": (
+            "frequency",
+            np.arange(8.0),
+            {"units": "Hz", "reference_frequency": 120.66, "carrier_ppm": 4.7},
+        )
+    },
+)
+print("survives da*2:", (axis_da * 2).frequency.attrs.get("reference_frequency"))
+print("survives mean('frequency'):",
+      "frequency" in axis_da.mean("frequency").coords)
+```
+
+Both edges cut against it. The constants die whenever their axis does — and an axis dies in
+legitimate workflows (integrating a peak, collapsing a spectral region into a map: exactly
+the fit-derived amplitude maps MRSI produces, which still deserve their acquisition context).
+It shares `xr.where`'s attrs leak *without* a surviving value to detect it by, and binary-op
+conflicts are first-wins (measured — the axis values agree, so xarray keeps the first
+operand's attrs wholesale). And the class has members with no axis at all: `b0_field` today,
+echo/repetition timing tomorrow — which forces a second home and makes the whole design
+two mechanisms instead of one. The converters would also need to hand-carry constants across
+every axis swap (`to_spectrum` builds its output axis from scratch). Elegant for the axis
+constants it fits, structurally partial for the family.
+
+(constants-nb-explain)=
+## Discoverability — `explain()`
+
+Whatever the home, discoverability is one accessor method: walk the object, match every name
+against the vocabulary, surface the curation. Under the container it reads one level deeper —
+and the native repr already carries the constants one click away:
+
+```{code-cell} ipython3
+from xmris.core.config import COORDS, DIMS
+
+
+def _term_for(key: str):
+    for vocab in (ATTRS, COORDS, DIMS):
+        for term in vocab._get_terms().values():
+            if term == key:
+                return term
+    return None
+
+
+def explain(da: xr.DataArray) -> pd.DataFrame:
+    """What `da.xmr.explain()` would return."""
+    rows = []
+    if "xmr_acquisition" in da.coords:
+        for key, value in da.coords["xmr_acquisition"].attrs.items():
+            rows.append((str(key), "constant", value, _term_for(key), None))
+    if "xmr_history" in da.coords:
+        events = json.loads(str(da.coords["xmr_history"].values))["events"]
+        rows.append((
+            "xmr_history", "record", f"{len(events)} events", None,
+            "The append-only processing record — read it with da.xmr.history().",
+        ))
+    for name, coord in da.coords.items():
+        if coord.ndim == 0:
+            continue
+        span = f"{coord.size} points, {coord.values.min():g} … {coord.values.max():g}"
+        rows.append((str(name), "coordinate", span, _term_for(name), None))
+    for key, value in da.attrs.items():
+        rows.append((str(key), "attr", value, _term_for(key), None))
+
+    def describe(term, override):
+        if override:
+            return override
+        if term is None:
+            return "⚠ not in the xmris vocabulary"
+        return term.description if len(term.description) <= 110 else term.description[:110] + "…"
+
+    return pd.DataFrame(
+        {
+            "lives as": [r[1] for r in rows],
+            "value": [r[2] for r in rows],
+            "unit": [r[3].unit if r[3] else "" for r in rows],
+            "description": [describe(r[3], r[4]) for r in rows],
+        },
+        index=pd.Index([r[0] for r in rows], name="name"),
+    )
+
+
+explain(spectrum_c.xmr.to_ppm())
+```
+
+Every recognized name answers for itself — readable wording, unit, inline — and the table
+doubles as an audit: the literal keys `simulate_fid` leaks past the vocabulary today light up
+as *not in the xmris vocabulary*, which is how a growing constants family stays curated
+instead of accumulating folklore.
+
+(constants-nb-verdict)=
+## Side by side
+
+| | `keep_attrs` family | P — per-constant coords | C — container block | X — axis-carried |
+|---|---|---|---|---|
+| Survives plain ops | only under the flag | everything measured | everything but `xr.where` | dies with its axis |
+| Cross-calibration sum | first wins — silent lie | dropped → loud gate | dropped → loud gate | first wins — silent lie |
+| Drifting series (`concat`) | first scan's values | per-scan truth | per-scan fingerprints, gate-detectable | first scan's values |
+| Repr cost at MRSI scale | none | **+10 lines and growing** | +2 pinned lines, constant | none |
+| The record can share the home | no | no — needs its own coord anyway | yes — sibling coordinate | no |
+| Ceremony / session | per-notebook or owns session | none | none | none |
+| Covers axis-less constants | yes | yes | yes | no — needs a second home |
+| netCDF shape | header attrs | 10 scalar variables | one CF grid-mapping-style block | axis attrs |
+| Script ≡ notebook | not under auto-detect | yes | yes | yes |
+| Migration | docs only | writers + gates | writers + gates + decorator re-pin | writers + gates + converters |
+
+:::{tip} The decision — converged 2026-08-03: the container block, plus `xmr.explain()`
+Two scalar coordinates, pinned as the last entries of every xmris return.
+**`xmr_acquisition`** holds the physical constants as its attrs — flat, typed, one click open
+in the repr — with a deterministic calibration fingerprint as its value, so disagreement is
+dropped honestly instead of first-wins lied about. **`xmr_history`** carries dossier 02's
+JSON envelope, format untouched, as its value — the record now travels every plain operation
+the constants do, and diverged histories vanish honestly by xarray's own rules (an amendment
+to 02's storage home, folded at the harvest). Writers mint the block; gates read
+container-first with an indefinite plain-attrs fallback and lazily re-home outsider entry;
+the central decorator re-pins the block last on every return, and the measured ordering rules
+(insertion order displayed, preserved by ordinary ops, three self-healing slips) make
+"always at the bottom" an enforceable contract rather than a hope. `xmr.explain()` surfaces
+the vocabulary's curation over all of it and audits what falls outside.
+
+Option P keeps the strictly strongest travel but fails the repr at exactly the scale the
+roadmap targets; option X is beautiful for axis constants and structurally partial;
+`keep_attrs` in every wrapper lies under combination and splits notebook from script. Feeds
+dossier 03 the schema sentence — *an xmris object carries its constants and record in the
+pinned `xmr_*` block* — and re-scopes
+[#21](https://github.com/andrewendlinger/xmris/issues/21) (the outside-xmris half becomes
+structural) and [#22](https://github.com/andrewendlinger/xmris/issues/22) (validation targets
+one dict, in one reader). Revisit if xarray flips its default attrs propagation or fixes
+`xr.where`'s coordinate-attrs strip, or if per-scan constants become a first-class workflow
+(a promoted container then wants reading semantics, not a refusal). The Resolution lives in
+`roadmap_issue_02b_physics_attrs.md`; this page retires at the harvest.
+:::
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+# Pin the load-bearing claims so this page fails loudly if behavior shifts.
+
+# The problem, and the undone session flag.
+assert scaled.attrs == {}
+assert xr.get_options()["keep_attrs"] == "default"
+
+# keep_attrs family: first-wins lie under the flag.
+assert merged.attrs["reference_frequency"] == 120.66
+
+# The matrix rows everything builds on.
+assert matrix["da * 2"]["coord value survives"] and matrix["da * 2"]["coord attrs survive"]
+assert matrix["np.abs(da)"]["coord attrs survive"]
+assert matrix["da.where(da > 0)"]["coord attrs survive"]
+assert matrix["da.mean('frequency')"]["coord value survives"]
+assert not matrix["xr.where(da > 0, da, 0)"]["coord attrs survive"]
+assert matrix["xr.where(da > 0, da, 0)"]["coord value survives"]
+assert not any(row["object attrs survive"] for row in matrix.values())
+
+# Option P: honest conflicts, per-scan truth, and the repr sprawl being objected to.
+assert "reference_frequency" not in summed.coords
+assert list(drifting.reference_frequency.values) == [120.66, 120.68]
+assert sum(1 for c in mrsi_per.coords.values() if c.ndim == 0) == len(HORIZON)
+
+# Option C: travel, re-homing, and the record riding along.
+assert dict(mrsi_one.xmr_acquisition.attrs) == HORIZON
+assert (np.abs(spectrum_c * 2)).xmr_acquisition.attrs["reference_frequency"] == 120.66
+assert referenced.xmr_acquisition.attrs["reference_frequency"] == 120.66
+assert "reference_frequency" not in referenced.attrs
+assert "xmr_acquisition" in (referenced * 2).coords
+assert json.loads(str(referenced.xmr_history.values))["events"] == [{"op": "to_ppm"}]
+assert [e["op"] for e in json.loads(str(spectrum_c.xmr_history.values))["events"]] == [
+    "apodize_exp", "to_spectrum",
+]
+
+# Pinned to the bottom: preserved by plain ops, healed after a slip.
+assert all(list(v.coords)[-2:] == CONTAINERS for v in after.values())
+assert list(slipped.coords)[-2:] != CONTAINERS  # the slip is real...
+assert list(slipped.xmr.to_ppm().coords)[-2:] == CONTAINERS  # ...and heals
+
+# Conflicts: each container answers independently.
+assert "xmr_acquisition" not in mixed.coords and "xmr_history" in mixed.coords
+assert "xmr_acquisition" in blend.coords and "xmr_history" not in blend.coords
+assert drifted.xmr_acquisition.dims == ("repetition",)
+assert len(set(drifted.xmr_acquisition.values)) == 2
+
+# The xr.where residue is detectable, and the file keeps everything.
+assert "xmr_acquisition" in holed.coords and dict(holed.xmr_acquisition.attrs) == {}
+assert loaded.xmr_acquisition.attrs["reference_frequency"] == 120.66
+assert str(loaded.xmr_acquisition.values) == str(spectrum_c.xmr_acquisition.values)
+assert str(loaded.xmr_history.values) == str(spectrum_c.xmr_history.values)
+
+# Determinism (02's assert_identical law): identical pipelines, identical objects.
+rerun = mint_containers(fid).xmr.apodize_exp(lb=5.0).xmr.to_spectrum()
+xr.testing.assert_identical(spectrum_c, rerun)
+
+# Option X: dies with its axis; conflict is first-wins (the measured flaw).
+assert "frequency" not in axis_da.mean("frequency").coords
+_xa, _xb = axis_da, axis_da.copy(deep=True)
+_xb.coords["frequency"].attrs["reference_frequency"] = 500.13
+assert (_xa + _xb).frequency.attrs["reference_frequency"] == 120.66
+
+# explain(): curated, container-aware, and auditing the leaks.
+table = explain(spectrum_c.xmr.to_ppm())
+assert table.loc["reference_frequency", "unit"] == "MHz"
+assert table.loc["reference_frequency", "lives as"] == "constant"
+assert table.loc["xmr_history", "value"] == "3 events"
+assert (table["description"] == "⚠ not in the xmris vocabulary").any()
+```

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -17,8 +17,16 @@ project:
     - myst.doi.bib
   toc:
     - file: index.md
+    # The roadmap's decision board links one exploration notebook (frozen at
+    # decision time) and later one aimed-solution notebook per decision — they
+    # live in decisions/ and nest under the Roadmap sidebar entry.
     - file: roadmap.md
       title: Roadmap
+      children:
+        - file: decisions/decision_02_attrs_lineage.md
+          title: 02 · Attrs — exploration
+        - file: decisions/decision_02b_physics_constants.md
+          title: 02b · Constants — exploration
 
     # 1. GROUP: Core concepts and basic usage
     - title: Basics

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -17,6 +17,8 @@ project:
     - myst.doi.bib
   toc:
     - file: index.md
+    - file: roadmap.md
+      title: Roadmap
 
     # 1. GROUP: Core concepts and basic usage
     - title: Basics
@@ -209,6 +211,8 @@ site:
   nav:
     - title: Home
       url: /index
+    - title: Roadmap
+      url: /roadmap
     - title: API
       url: /index-1
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -439,10 +439,10 @@ wording of that refusal, and the fate of the unused k-space vocabulary, is decis
 (roadmap-landscape)=
 ## The issue landscape
 
-<span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-08-03 · the
+<span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-08-05 · the
 [milestones](https://github.com/andrewendlinger/xmris/milestones) are the live source</span>
 
-Forty-four issues are open, and their distribution is the argument for the release line above: the
+Forty-seven issues are open, and their distribution is the argument for the release line above: the
 largest cluster is not missing features — it is unmade decisions, plus the work standing behind
 them. Two of those decisions are now made (02 and 02b on the board); their tracker issues stay
 open until the implementations land, with
@@ -451,12 +451,12 @@ open until the implementations land, with
 
 | Cluster | Issues | Lands in |
 |---|---|---|
-| Design decisions — the board above | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) | v0.8 |
-| Blocked behind them | [#21](https://github.com/andrewendlinger/xmris/issues/21) [#22](https://github.com/andrewendlinger/xmris/issues/22) [#23](https://github.com/andrewendlinger/xmris/issues/23) [#28](https://github.com/andrewendlinger/xmris/issues/28) [#34](https://github.com/andrewendlinger/xmris/issues/34) [#71](https://github.com/andrewendlinger/xmris/issues/71) [#102](https://github.com/andrewendlinger/xmris/issues/102) [#107](https://github.com/andrewendlinger/xmris/issues/107) | v0.8 · the schema #28 in v0.9 |
-| The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) [#131](https://github.com/andrewendlinger/xmris/issues/131) | v0.7 |
+| Design decisions — the board above | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) [#136](https://github.com/andrewendlinger/xmris/issues/136) | v0.8 |
+| Blocked behind them | [#21](https://github.com/andrewendlinger/xmris/issues/21) [#22](https://github.com/andrewendlinger/xmris/issues/22) [#23](https://github.com/andrewendlinger/xmris/issues/23) [#28](https://github.com/andrewendlinger/xmris/issues/28) [#34](https://github.com/andrewendlinger/xmris/issues/34) [#71](https://github.com/andrewendlinger/xmris/issues/71) [#102](https://github.com/andrewendlinger/xmris/issues/102) [#107](https://github.com/andrewendlinger/xmris/issues/107) | v0.8 |
+| The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) [#131](https://github.com/andrewendlinger/xmris/issues/131) [#137](https://github.com/andrewendlinger/xmris/issues/137) [#138](https://github.com/andrewendlinger/xmris/issues/138) | v0.7 |
 | Quality & tooling | [#87](https://github.com/andrewendlinger/xmris/issues/87) [#108](https://github.com/andrewendlinger/xmris/issues/108) [#111](https://github.com/andrewendlinger/xmris/issues/111) [#117](https://github.com/andrewendlinger/xmris/issues/117) [#127](https://github.com/andrewendlinger/xmris/issues/127) [#133](https://github.com/andrewendlinger/xmris/issues/133) | v0.8 – v0.9 |
 | The front door | [#27](https://github.com/andrewendlinger/xmris/issues/27) [#46](https://github.com/andrewendlinger/xmris/issues/46) [#67](https://github.com/andrewendlinger/xmris/issues/67) [#119](https://github.com/andrewendlinger/xmris/issues/119) [#120](https://github.com/andrewendlinger/xmris/issues/120) [#121](https://github.com/andrewendlinger/xmris/issues/121) [#126](https://github.com/andrewendlinger/xmris/issues/126) | v0.9 |
-| Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#128](https://github.com/andrewendlinger/xmris/issues/128) [#132](https://github.com/andrewendlinger/xmris/issues/132) | v0.9 |
+| Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#128](https://github.com/andrewendlinger/xmris/issues/128) [#132](https://github.com/andrewendlinger/xmris/issues/132) | v0.9 |
 | Space & scale | [#4](https://github.com/andrewendlinger/xmris/issues/4) [#25](https://github.com/andrewendlinger/xmris/issues/25) | Horizon |
 
 The decisions are not a flat list. The spine below is the board's dependency order — the decided

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 (roadmap)=
 # Where xmris is going
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-26 · v0.6.1 · visual draft — content not final</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-26</span>
 
 ::::{div}
 :class: roadmap-hero
@@ -27,28 +27,34 @@ needs.
 :::
 ::::
 
-Today the package is honest about what it is. The processing chain genuinely broadcasts: zero-fill,
-apodize, Fourier, phase and reference all run across a coil axis, a repetition axis or a voxel grid
-without knowing they exist. The fitting does not — `fit_amares` is one-dimensional, and five
-documentation pages hand-roll the same `xr.concat` stack to work around it. That gap between the
-two halves is the shape of most of the near-term work.
+That sentence is closer to true than it looks. Your data stays an `xarray.DataArray` — `.xmr` is an
+accessor, not a container — so the processing chain broadcasts by construction: zero-fill, apodize,
+Fourier, phase and reference run across a coil axis, a repetition series or a voxel grid without
+being told they exist. The fitting keeps up: `fit_amares` takes whatever dimensions you hand it,
+fits every spectrum in parallel, and folds the results back into your layout. The honest remainder
+is small and specific — the simulator builds one FID at a time, automatic phasing picks a single
+phase for the whole array, a fit across a grid still normalises and initialises globally rather
+than per voxel, and past a certain size, memory. That remainder is the far end of this page.
 
-The destination is that the dimension you did not think about is the one that costs nothing. And
-that the record travels with the data: the reference frequency, the phase that was applied, the
-prior knowledge a fit was given, the residual it produced — all attached to the object you already
-hold, so a figure and the methods section describing it come out of the same file.
+The near end is less glamorous and more important. Roughly a third of the open tracker sits behind
+five unmade architecture decisions, and the version on PyPI does not install the package this
+documentation describes. So the next two releases are not feature releases: one makes the install
+honest, and one makes the ground stop moving. Features come after the promises hold.
 
-The last thing on this page is a promise rather than a feature. `v1.0` is the point at which the
-[architecture contract](contributing/contract.md) stops moving and the API you wrote against stays
-where it is.
+The last thing on this page is a promise rather than a feature. `v1.0` is not a milestone with an
+item list; it is the point at which the [architecture contract](contributing/contract.md) stops
+moving and the API you wrote against stays where it is. What has to be true first is written in
+the [horizon band](#roadmap-horizon).
 
 :::{note} How to read this page
 Four bands, from what already works to what is still an intention — and the spine beside them loses
-its confidence as it descends. There are deliberately **no dates**. A milestone moves up a band when
-the work is real, not when a quarter ends. Version numbers are the release a milestone is aimed at,
-not a commitment to ship it there.
+its confidence as it descends. There are deliberately **no dates**: this is a one-maintainer
+project beside a PhD, so order is real information and a schedule would be fiction. A milestone
+moves up a band when the work is real, not when a quarter ends.
 
-The issue tracker holds the detail; this page holds the argument.
+The [tracker's milestones](https://github.com/andrewendlinger/xmris/milestones) hold the item
+lists and move faster; this page holds the argument. Version numbers are the release a milestone is
+aimed at, not a commitment to ship it there.
 :::
 
 :::{div}
@@ -61,7 +67,7 @@ The issue tracker holds the detail; this page holds the argument.
 :class: roadmap-band roadmap-band--shipped
 
 (roadmap-shipped)=
-## Shipped <span class="roadmap-ver">v0.1 – v0.6</span>
+## Shipped <span class="roadmap-ver">on `main` today</span>
 
 ::::{div}
 :class: roadmap-phase roadmap-phase--shipped
@@ -69,11 +75,13 @@ The issue tracker holds the detail; this page holds the argument.
 
 What you can use today.
 
-Released to PyPI, documented, and exercised by the test suite — the claims on these cards are live
-notebook cells, so a broken one fails the build rather than quietly ageing.
+Real on `main`, documented, and exercised on every pull request — the claims on these cards are
+live notebook cells, so a broken one fails the build rather than quietly ageing.
 
-Nothing here is a plan. If something in this band does not work, that is a bug worth reporting, not
-a roadmap item waiting its turn.
+One honesty note: `main` is ahead of PyPI, and the wheel PyPI serves carries the old, broken
+packaging — closing that gap is the entire point of the band below. Nothing here is a plan. If
+something in this band does not work, that is a bug worth reporting, not a roadmap item waiting
+its turn.
 ::::
 
 ::::{div}
@@ -84,7 +92,7 @@ An architecture you can hold in your head
 Eleven numbered rules — xarray in, xarray out; never mutate the input; the vocabulary is law — are
 written down as [the architecture contract](contributing/contract.md) and *executed* against the
 source on every build. The page quotes the live code it governs, so the contract cannot drift away
-from it. [#72](https://github.com/andrewendlinger/xmris/issues/72)
+from it.
 ::::
 
 ::::{div}
@@ -95,16 +103,19 @@ A processing chain that reads like the physics
 `zero_fill` → `apodize_exp` → `to_spectrum` → `autophase` → `baseline_als` → `to_ppm`, each a pure
 function and an `.xmr` method, each preserving the coordinates it was given and appending exactly
 the parameter it applied. Domain mistakes are caught at the door by `@computes_in` and
-`@ensures_domain` rather than in your results.
+`@ensures_domain`: a function handed data in the wrong domain refuses, instead of computing
+something plausible and wrong.
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-Fitting, through pyAMARES
+Fitting that broadcasts
 
-`fit_amares` returns a Dataset with the data, the model and the residual aligned on the same axes,
-so the fit is an object you can keep processing rather than a table you have to reassemble.
+`fit_amares` meets your data in either domain, stacks whatever extra dimensions it finds, fits
+every spectrum in parallel, and hands back a Dataset with the data, the model and the residual
+aligned on the same axes — with per-parameter uncertainties, and a per-voxel `fit_status` instead
+of a silent zero where a fit fails.
 ::::
 
 ::::{div}
@@ -117,7 +128,7 @@ Interactive widgets for phasing, apodization and scrolling through spectra
 :class: roadmap-item roadmap-item--minor
 
 Documentation that executes itself — every claim is a live cell, every page previewed per pull
-request [#104](https://github.com/andrewendlinger/xmris/issues/104)
+request
 ::::
 
 :::::
@@ -132,14 +143,14 @@ request [#104](https://github.com/andrewendlinger/xmris/issues/104)
 :class: roadmap-phase roadmap-phase--motion
 :label: roadmap-phase-motion
 
-Being built right now.
+Being released right now.
 
-The linked issues are open and have commits against them. This is the last point at which the shape
-of an API is still cheap to change.
+Everything in this band is merged and working on `main`; what is in motion is the release itself.
+v0.7 is the tag that makes the shipped band installable — months of fitting, contract and
+documentation work that PyPI has not seen yet.
 
-So it is the band worth arguing with. If you have a view on how a failed fit should announce itself,
-or what a result Dataset ought to be called, saying so now costs nothing — saying so after v1.0
-costs a deprecation cycle.
+It is deliberately small. The only code it waits for is the install fix below, because tagging a
+release whose bare `pip install` cannot even be imported would defeat the point of tagging at all.
 ::::
 
 ::::{div}
@@ -147,46 +158,29 @@ costs a deprecation cycle.
 
 Fitting you can trust
 
-A fit that fails to converge can currently return quietly, and the Dataset it produces uses literal
-keys instead of the controlled vocabulary. This is the work that makes fitting say *why* it stopped,
-validate prior knowledge before it reaches the solver, and come back speaking the same language as
-everything else.
-[#80](https://github.com/andrewendlinger/xmris/issues/80)
-[#81](https://github.com/andrewendlinger/xmris/issues/81)
-[#82](https://github.com/andrewendlinger/xmris/issues/82)
-[#69](https://github.com/andrewendlinger/xmris/issues/69)
-
-:::{dropdown} What each piece covers
-- **[#80](https://github.com/andrewendlinger/xmris/issues/80)** — silent-failure and convergence
-  hardening: a fit reports its exit condition instead of returning a plausible-looking result.
-- **[#81](https://github.com/andrewendlinger/xmris/issues/81)** — the API and docstring rough edges
-  around `fit_amares`.
-- **[#82](https://github.com/andrewendlinger/xmris/issues/82)** — the prior-knowledge file format
-  has traps that are currently discovered at runtime; validate and document them.
-- **[#69](https://github.com/andrewendlinger/xmris/issues/69)** — the result Dataset ignores
-  `VARS`/`DIMS`, which breaks the one-vocabulary rule at exactly the point users look hardest.
-:::
+The rework that headlines this release. Amplitude scale is normalised before fitting, killing a
+failure mode where a fit could "converge" on its own prior and look completely fine; a failed
+voxel comes back as `NaN` plus a `fit_status` that says why, never a plausible number; prior
+knowledge is validated before it reaches the solver instead of failing inside it.
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-One canonical API
+An install that tells the truth
 
-A free function and its `.xmr` method should never disagree — but today only the `dim` defaults are
-pinned by a test, and the accessor is registered as an import side-effect nobody chose. This is the
-audit, the enforcement, and the decision underneath both.
-[#71](https://github.com/andrewendlinger/xmris/issues/71)
-[#102](https://github.com/andrewendlinger/xmris/issues/102)
-[#62](https://github.com/andrewendlinger/xmris/issues/62)
+The wheel on PyPI cannot install on Apple Silicon, and today's `main` fixed that while leaving a
+bare `pip install xmris` unimportable — a missing core dependency that CI never caught, because no
+job installs the package the way a user does. v0.7 ships an install that works everywhere, AMARES
+as the optional `xmris[fitting]` extra, and a CI job that installs like a stranger so this class
+of bug cannot return. [#122](https://github.com/andrewendlinger/xmris/issues/122)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-Install without a git fork — pyAMARES becomes an optional extra
-[#70](https://github.com/andrewendlinger/xmris/issues/70)
-[#115](https://github.com/andrewendlinger/xmris/issues/115)
+A changelog begins — its first entry is this release
+[#10](https://github.com/andrewendlinger/xmris/issues/10)
 ::::
 
 :::::
@@ -201,27 +195,60 @@ Install without a git fork — pyAMARES becomes an optional extra
 :class: roadmap-phase roadmap-phase--next
 :label: roadmap-phase-next
 
-Decided, but not yet built.
+Committed, but not built.
 
-Each of these has a design behind it — usually an open `design-decision` issue that has been argued
-through — and no implementation. The version stamp is where it is aimed, not where it is promised.
+v0.8 is one thing said five ways: the architecture settles. Five design decisions are open, each
+an issue where the choice is argued before any code follows, and roughly a third of the tracker is
+blocked behind them. v0.8 is the last release allowed to move the ground under a user — and saying
+that publicly is most of the value of having a roadmap at all.
 
-A milestone leaves this band by being built, or by being dropped when the decision underneath it
-turns out to be wrong. Both happen, and the second is not a failure.
+v0.9 then turns outward: everything a stranger needs that today requires reading the source, or
+knowing the author. Its exit criterion is the JOSS submission.
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-Provenance that survives a chain
+Five decisions, then the code that follows
 
-The applied parameter is the record — `phase_p0=15.0`, never `phase_applied=True` — but attributes
-survive a long chain by convention rather than by guarantee. The open decision is whether lineage
-stays flat per-parameter keys or becomes a structured history log; what it unlocks is a spectrum
-that can reconstruct its own methods section.
-[#64](https://github.com/andrewendlinger/xmris/issues/64)
-[#21](https://github.com/andrewendlinger/xmris/issues/21)
-[#23](https://github.com/andrewendlinger/xmris/issues/23)
+The questions are argued in their issues, not here — what this page fixes is the order, and that
+they resolve together in one release rather than leaking across several.
+
+:::{dropdown} The five, in dependency order
+- **[#65](https://github.com/andrewendlinger/xmris/issues/65)** — what a vocabulary term *is*
+  (today: a `str` subclass carrying metadata), then
+  **[#88](https://github.com/andrewendlinger/xmris/issues/88)** — where diagnostic and
+  algorithm-output axes live. The cheapest pair, so it goes first.
+- **[#64](https://github.com/andrewendlinger/xmris/issues/64)** — the attrs strategy: does lineage
+  stay flat applied-parameter keys, or become a structured history? The highest-leverage decision
+  on the board — four issues wait on it, Commandment 3 is rewritten by whatever it decides, and it
+  is what turns "the record travels with the data" from a convention into a guarantee: a spectrum
+  that can reconstruct its own methods section.
+- **[#62](https://github.com/andrewendlinger/xmris/issues/62)** — accessor auto-registration and
+  which API is canonical, so a free function and its `.xmr` method cannot drift apart again.
+- **[#66](https://github.com/andrewendlinger/xmris/issues/66)** — the boundary between pytest and
+  notebook tests, which decides how the architecture suite gets rebuilt to discover functions
+  instead of trusting hand-maintained lists.
+:::
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+`simulate_fid` learns to stack — the `xr.concat` boilerplate five pages currently teach becomes
+one argument [#113](https://github.com/andrewendlinger/xmris/issues/113)
+::::
+
+::::{div}
+:class: roadmap-item
+
+Ready for a stranger
+
+The first hour of a new user, made survivable without reading the source: a documented path from
+raw vendor data or a bare numpy array into an xmris-ready object
+[#46](https://github.com/andrewendlinger/xmris/issues/46), a README whose quick start actually
+runs, a public API surface with no unreachable corners, and the correctness backlog in fitting and
+plotting paid down.
 ::::
 
 ::::{div}
@@ -229,34 +256,23 @@ that can reconstruct its own methods section.
 
 A data model written down
 
-The vocabulary is law, but the *schema* it forms has never been stated: which dimensions and
-attributes an object must carry to be an xmris FID, and what a function may assume about one it is
-handed. Writing that down is what lets other packages target xmris rather than guess at it.
+The vocabulary is law inside the library, but the *schema* it forms has never been stated: which
+dimensions and attributes an object must carry to count as an xmris FID or spectrum, and what a
+function may assume about one it is handed. Writing that down — after the attrs decision fixes
+what the record looks like — is what lets other packages target xmris rather than guess at it.
 [#28](https://github.com/andrewendlinger/xmris/issues/28)
-[#65](https://github.com/andrewendlinger/xmris/issues/65)
-[#88](https://github.com/andrewendlinger/xmris/issues/88)
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-Lazy and chunked
+A JOSS paper
 
-dask support, so a dataset larger than memory is still the same three chained lines.
-[#25](https://github.com/andrewendlinger/xmris/issues/25)
-::::
-
-::::{div}
-:class: roadmap-item roadmap-item--minor
-
-Fitting beyond one dimension — the `xr.concat` workaround becomes the library's job
-[#113](https://github.com/andrewendlinger/xmris/issues/113)
-::::
-
-::::{div}
-:class: roadmap-item roadmap-item--minor
-
-A changelog [#10](https://github.com/andrewendlinger/xmris/issues/10)
+The submission is v0.9's definition of done — a deadline chosen, not imposed. The epic that gates
+it is public-release readiness: a citation file, community files, a typing gate, fitting coverage
+worth the name, and a State of the Field against FSL-MRS, Osprey, suspect and spant. JOSS happily
+cites 0.x software, so *citable* does not wait for *frozen*.
+[#67](https://github.com/andrewendlinger/xmris/issues/67)
 ::::
 
 :::::
@@ -286,34 +302,38 @@ something moves up a band.
 
 `v1.0` — the point the contract stops moving
 
-Not a feature: a promise. The epic that gates it is public-release readiness — a JOSS paper with a
-State of the Field against FSL-MRS, Osprey, suspect and spant; a citation file; a typing gate;
-fitting coverage worth the name; a clean install from PyPI with no git sources. After it, the API
-you wrote against stays where it is.
-[#67](https://github.com/andrewendlinger/xmris/issues/67)
+Not a feature: a promise — and deliberately not a milestone in the tracker yet, because creating
+one now would fake a certainty nobody has. What has to be true first: the five decisions shipped
+and the contract stable across two consecutive releases; the stranger's first hour solved; a
+written deprecation policy. When those hold, calling it 1.0 is a formality; until then, calling it
+1.0 would be a lie with a version number.
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-The visualization ecosystem: `.plot`, `.widget`, `.ui`
+MRSI: space and scale
 
-Three lazily-loaded pillars, of which two exist in part. The third does not: a napari bridge for
-scrolling a four-dimensional spectral volume and overlaying fitted metabolite maps on the anatomy
-they came from.
-[#4](https://github.com/andrewendlinger/xmris/issues/4)
+The vocabulary already declares `x`, `y`, `z` and their k-space twins, and nothing uses them yet —
+a placed bet, not dead weight. Cashing it in, in order: CSI-shaped data, spatial plus spectral,
+through the same three lines that process one FID; per-voxel initialisation and normalisation for
+fits across a grid; lazy, chunked processing for volumes that outgrow memory
+[#25](https://github.com/andrewendlinger/xmris/issues/25); and image coordinates, so a fitted
+metabolite map can sit on the anatomical image it came from
+[#4](https://github.com/andrewendlinger/xmris/issues/4).
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-More vendors than Bruker [#46](https://github.com/andrewendlinger/xmris/issues/46)
+More vendors than Bruker — Siemens, GE, Philips, NIfTI-MRS
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-Imaging, and not only spectroscopy — the `I` in the name is still aspirational
+What xmris is *not*: image reconstruction and quantitative-MRI parameter mapping stay out of
+scope — the *i* in the name is the spectroscopic imaging above, not an MRI toolbox
 ::::
 
 :::::
@@ -327,9 +347,10 @@ and then it is someone else's turn to say what comes next
 (roadmap-changing)=
 ## How this page changes
 
-This page is written by hand, and it is the argument rather than the record: the issue tracker holds
-what is actually being worked on, and it moves faster. A milestone here earns its band from the
-state of the work, so if the two disagree, the tracker is right and this page is stale — say so by
+This page is written by hand, and it is the argument rather than the record: the
+[milestones](https://github.com/andrewendlinger/xmris/milestones) hold what is actually in each
+release, and they move faster. A milestone here earns its band from the state of the work, so if
+the two disagree, the tracker is right and this page is stale — say so by
 [opening an issue](https://github.com/andrewendlinger/xmris/issues/new).
 
 :::{seealso}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 (roadmap)=
 # Where xmris is going
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-26</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-03</span>
 
 ::::{div}
 :class: roadmap-hero
@@ -9,58 +9,39 @@
 :::{div}
 :class: roadmap-kicker
 
-The vision
+The direction
 :::
 
 :::{div}
 :class: roadmap-statement
 
-xmris is finished when the three lines you write to process a single spectrum are the same three
-lines that process a whole spectroscopic-imaging dataset — and when the object they hand back can
-answer for every step that produced it.
+The same lines that process one spectrum will process a whole spectroscopic-imaging dataset —
+and the result can answer for every step that produced it.
 :::
 
 :::{div}
 :class: roadmap-tenets
 
-`xarray in, xarray out` `docs before code` `worry only about your data`
+`xarray in, xarray out` `docs before code` `the physics travels with the data`
 :::
 ::::
 
-Three commitments shape everything below. Your data stays an `xarray.DataArray` — `.xmr` adds the
-physics and nothing owns you, so the whole xarray ecosystem keeps working. The documentation comes
-before the code and honestly gets more of the work: every page executes on every pull request, and
-it is written to be *read* — educational, opinionated, occasionally fun — not consulted in defeat.
-And once your data is in, the bookkeeping stops being yours: coordinates, frequency axes, the
-metadata tags scanners breed — xmris carries them, so the focus goes back to the one thing that is
-actually yours.
-
-Where does it stand? Closer to the vision than you might guess: the processing chain broadcasts
-across whatever dimensions you bring, and the fitting keeps up — `fit_amares`, for example, folds
-a grid of spectra through the same call as a single FID. The 1-D holdouts that remain (the
-simulator, per-spectrum autophasing) are tracked as ordinary work items below. The next two
-releases deliberately ship no features at all: first an install that tells the truth, then the
-architecture decisions that let the ground stop moving. Features come after the promises hold.
-
-The last thing on this page is a promise rather than a feature. `v1.0` is the point at which the
-[architecture contract](contributing/contract.md) stops moving and the API you wrote against stays
-where it is. What has to be true first is written in the [horizon band](#roadmap-horizon).
+Three commitments shape everything below. Your data stays an `xarray.DataArray` — `.xmr` adds
+the physics, and the whole xarray ecosystem keeps working. The docs come before the code: every
+page executes on every pull request. And the bookkeeping — coordinates, frequency axes, scanner
+metadata — travels with the data.
 
 :::{note} How to read this page
-Four bands, from what already works to what is still an intention — and the spine beside them loses
-its confidence as it descends. There are deliberately **no dates**: this is a one-maintainer
-project beside a PhD, so order is real information and a schedule would be fiction. A milestone
-moves up a band when the work is real, not when a quarter ends.
+Five bands, descending in confidence: from what already works, through the decision board we
+would defend today, to a far end that is more a direction.
 
-The [tracker's milestones](https://github.com/andrewendlinger/xmris/milestones) hold the item
-lists and move faster; this page holds the argument. Version numbers are the release a milestone is
-aimed at, not a commitment to ship it there.
+The page is aligned with the [tracker's milestones](https://github.com/andrewendlinger/xmris/milestones) and is supposed to give a clearer picture of what's ahead / planned for xmris.
 :::
 
 :::{div}
 :class: roadmap-map
 
-[Shipped](#roadmap-phase-shipped) [In motion](#roadmap-phase-motion) [Next](#roadmap-phase-next) [Horizon](#roadmap-phase-horizon)
+[Shipped](#roadmap-phase-shipped) [In motion](#roadmap-phase-motion) [Decisions](#roadmap-phase-decisions) [Outward](#roadmap-phase-outward) [Horizon](#roadmap-phase-horizon)
 :::
 
 :::::{div}
@@ -75,13 +56,40 @@ aimed at, not a commitment to ship it there.
 
 What you can use today.
 
-Real on `main`, documented, and exercised on every pull request — the claims on these cards are
-live notebook cells, so a broken one fails the build rather than quietly ageing.
+Real on `main` and exercised on every pull request — every claim on these cards is a live
+notebook cell, so a broken one fails the build. (`main` runs ahead of PyPI; closing that gap is
+the band below.)
+::::
 
-One honesty note: `main` is ahead of PyPI, and the wheel PyPI serves carries the old, broken
-packaging — closing that gap is the entire point of the band below. Nothing here is a plan. If
-something in this band does not work, that is a bug worth reporting, not a roadmap item waiting
-its turn.
+::::{div}
+:class: roadmap-item
+
+Spectrum processing that reads like the physics
+
+[`zero_fill`](#zero-fill) → [`apodize_exp`](#apodization) → [`autophase`](#autophase-intro) →
+[`baseline_als`](#baseline) → [`to_ppm`](#hz-ppm): each a pure function and an `.xmr` method,
+and the FID-to-spectrum conversion [happens automatically](#domain-contracts) where the chain
+needs it.
+::::
+
+::::{div}
+:class: roadmap-item
+
+Plotting, some of it interactive
+
+Config-based [plotting](#plot-basics) from [waterfall](#waterfall) to [carpet](#carpet) plots,
+plus live widgets for [phasing](#widget-phase), [apodization](#widget-apodization) and
+[scrolling through spectra](#widget-scroller).
+::::
+
+::::{div}
+:class: roadmap-item
+
+pyAMARES fitting that broadcasts
+
+`fit_amares` fits every spectrum across whatever dimensions you bring — data, model, residual
+and per-parameter uncertainties come back aligned on the same axes
+([quick start](#fitting-quickstart), [deep dive](#pyamares)).
 ::::
 
 ::::{div}
@@ -89,46 +97,9 @@ its turn.
 
 An architecture you can hold in your head
 
-Eleven numbered rules — xarray in, xarray out; never mutate the input; the vocabulary is law — are
-written down as [the architecture contract](contributing/contract.md) and *executed* against the
-source on every build. The page quotes the live code it governs, so the contract cannot drift away
-from it.
-::::
-
-::::{div}
-:class: roadmap-item
-
-A processing chain that reads like the physics
-
-`zero_fill` → `apodize_exp` → `to_spectrum` → `autophase` → `baseline_als` → `to_ppm`, each a pure
-function and an `.xmr` method, each preserving the coordinates it was given and appending exactly
-the parameter it applied. Domain mistakes are caught at the door by `@computes_in` and
-`@ensures_domain`: a function handed data in the wrong domain refuses, instead of computing
-something plausible and wrong.
-::::
-
-::::{div}
-:class: roadmap-item
-
-Fitting that broadcasts
-
-`fit_amares` meets your data in either domain, stacks whatever extra dimensions it finds, fits
-every spectrum in parallel, and hands back a Dataset with the data, the model and the residual
-aligned on the same axes — with per-parameter uncertainties, and a per-voxel `fit_status` instead
-of a silent zero where a fit fails.
-::::
-
-::::{div}
-:class: roadmap-item roadmap-item--minor
-
-Interactive widgets for phasing, apodization and scrolling through spectra
-::::
-
-::::{div}
-:class: roadmap-item roadmap-item--minor
-
-Documentation that executes itself — every claim is a live cell, every page previewed per pull
-request
+Eleven rules — xarray in, xarray out; never mutate the input; the vocabulary is law — written
+down as [the contract](contributing/contract.md) and executed against the source on every
+build. The why is the [architecture tour](#architecture).
 ::::
 
 :::::
@@ -186,65 +157,216 @@ A changelog begins — its first entry is this release
 :::::
 
 :::::{div}
-:class: roadmap-band roadmap-band--next
+:class: roadmap-band roadmap-band--decisions
 
-(roadmap-next)=
-## Next <span class="roadmap-ver">v0.8 – v0.9</span>
+(roadmap-decisions)=
+## The decisions <span class="roadmap-ver">v0.8</span>
 
 ::::{div}
-:class: roadmap-phase roadmap-phase--next
-:label: roadmap-phase-next
+:class: roadmap-phase roadmap-phase--decisions
+:label: roadmap-phase-decisions
 
-Committed, but not built.
+The near horizon: the architecture settles, one argued decision at a time.
 
-v0.8 is one thing said several ways: the architecture settles. The open design decisions — what a
-vocabulary term is, what the record looks like, what is core and what is an extra, who registers
-what, where the tests live — each get argued in an issue before any code follows, and roughly a
-third of the tracker is blocked behind them. v0.8 is the last release allowed to move the ground
-under a user, and saying that publicly is most of the value of having a roadmap at all.
+Roughly a third of the tracker is blocked behind the questions on this board, and v0.8 is the
+last release allowed to move the ground under a user — so each question is decided before its
+code is written. The board is ordered by how irreversible each decision is and how soon it
+blocks: the full cards are load-bearing, the one-line rows can wait.
 
-v0.9 then turns outward: everything a stranger needs that today requires reading the source, or
-knowing the author. Its exit criterion is the JOSS submission.
+Every decision leaves a paper trail. It starts as an *exploration notebook* that demonstrates the
+problem live and runs every serious option as code. When one option wins, that notebook freezes
+as the record of *why*, an *aimed-solution notebook* details the *what*, and only then does the
+implementation follow. A decided card links its trail.
 ::::
 
 ::::{div}
 :class: roadmap-item
 
-The decisions, then the code that follows
+01 · The license <span class="roadmap-status roadmap-status--arguing">in discussion</span>
 
-The questions are argued in their issues, not here — what this page fixes is the order, and that
-they resolve together in one release rather than leaking across several.
+xmris is AGPL-3.0-only — the strongest copyleft on PyPI, the quietest gate on who may adopt it,
+and a contradiction of the extension ecosystem this page promises further down. Whether that is a
+value to state and keep, or an accident to fix while there is exactly one copyright holder, is
+under argument now.
+::::
 
-:::{dropdown} In dependency order
-- **[#65](https://github.com/andrewendlinger/xmris/issues/65)** — what a vocabulary term *is*
-  (today: a `str` subclass carrying metadata), then
-  **[#88](https://github.com/andrewendlinger/xmris/issues/88)** — where diagnostic and
-  algorithm-output axes live. The cheapest pair, so it goes first.
-- **[#124](https://github.com/andrewendlinger/xmris/issues/124)** — what is core xmris: the
-  extras boundary (`[fitting]` exists; `[plotting]`? vendors?) and the plug-in mechanism that
-  lets a lab in another MR domain add functions *and vocabulary* without forking core. Packaging
-  is a one-way door, so it closes while the ground is still allowed to move.
-- **[#125](https://github.com/andrewendlinger/xmris/issues/125)** — vendor IO: how much xmris
-  owns, and whether NIfTI-MRS becomes the on-ramp instead of N bespoke loaders. Downstream of
-  #124.
-- **[#64](https://github.com/andrewendlinger/xmris/issues/64)** — the attrs strategy: flat
-  applied-parameter keys, or a structured history? The highest-leverage decision on the board —
-  four issues wait on it, Commandment 3 is rewritten by whatever it decides, and it is what turns
-  "the record travels with the data" from a convention into a guarantee.
-- **[#62](https://github.com/andrewendlinger/xmris/issues/62)** — accessor auto-registration and
-  which API is canonical, so a free function and its `.xmr` method cannot drift apart again.
-  Resolves together with #124's registration question.
-- **[#66](https://github.com/andrewendlinger/xmris/issues/66)** — the boundary between pytest and
-  notebook tests, which decides how the architecture suite gets rebuilt to discover functions
-  instead of trusting hand-maintained lists.
-:::
+::::{div}
+:class: roadmap-item roadmap-item--decided
+
+02 · The lineage record <span class="roadmap-status roadmap-status--decided">decided 2026-08-02</span>
+
+Processing lineage leaves flat attrs keys entirely: every operation appends to one `xmr_history`
+record — the parameters actually applied, in order, written by one central decorator and read
+back as `history()`. Physics and calibration attrs stay flat, typed and individually addressable.
+The repeat-application lie — the data carrying one apodization while the record claims another —
+dies with the flat keys.
+
+The exploration that got here is frozen as [a design notebook](#attrs-nb); the aimed-solution
+notebook comes next, then the implementation.
+[#64](https://github.com/andrewendlinger/xmris/issues/64)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--decided
+
+02b · The physical constants <span class="roadmap-status roadmap-status--decided">decided 2026-08-03</span>
+
+The constants a measurement cannot be interpreted without — reference frequency, carrier, group
+delay — move out of droppable attrs into one scalar coordinate, `xmr_acquisition`, with the
+history riding beside it as `xmr_history`. Surviving plain xarray operations becomes structural
+rather than boilerplate; mixed calibrations drop the container whole and fail loudly at the next
+gate; and `explain()` renders every constant with its unit and curated description.
+
+Frozen exploration: [the constants design notebook](#constants-nb); the aimed-solution notebook
+comes next. [#21](https://github.com/andrewendlinger/xmris/issues/21)
+[#22](https://github.com/andrewendlinger/xmris/issues/22)
+::::
+
+::::{div}
+:class: roadmap-item
+
+03 · A data model written down
+
+Which dimensions, coordinates and attributes make an object an xmris FID or spectrum — and what a
+function may assume about one it is handed. The schema is what lets other packages target xmris
+rather than guess at it; with 02 and 02b fixing what the record and the constants look like, it
+is unblocked and next in line.
+[#28](https://github.com/andrewendlinger/xmris/issues/28)
+::::
+
+::::{div}
+:class: roadmap-item
+
+04 · Core and extras
+
+`[fitting]` exists — does `[plotting]`? do vendors? Install lines are a one-way door: the extras
+boundary closes while the ground is still allowed to move, not after.
+[#124](https://github.com/andrewendlinger/xmris/issues/124)
+::::
+
+::::{div}
+:class: roadmap-item
+
+05 · The fit schema, and the fork beneath it
+
+The fit result — one Dataset carrying data, model, residual, parameters and uncertainties — is
+the contract a second fitter would slot into, so it gets frozen deliberately rather than by
+accident. And the liability underneath gets named: today's fitter rides `pyamares-xmris`, a
+self-maintained fork on the critical path, whose exit strategy — upstream, maintain, or replace —
+has never been written down.
+::::
+
+::::{div}
+:class: roadmap-item
+
+06 · The preprocessing middle
+
+The vocabulary declares `average` and `coil`, the Bruker loader emits them, and no function
+consumes them: averaging, coil combination and frequency-drift alignment are the unclaimed gap
+between load and fit. Does xmris own that middle — the physics-aware, lineage-recording versions,
+not the one-line mean — or say honestly that it does not?
+::::
+
+::::{div}
+:class: roadmap-item
+
+07 · The auto-convert default
+
+Today a domain-mismatched call is converted silently by default, while the option's own docstring
+recommends strict mode for quantitative work. Flipping a default after 1.0 is a breaking change,
+so it gets decided now, while it is cheap.
+::::
+
+::::{div}
+:class: roadmap-item
+
+08 · Accessor parity
+
+A free function and its `.xmr` method can drift apart today — signatures, defaults, docstrings.
+The fix is mechanical (an introspection test, a registration decorator, or codegen); the decision
+is which mechanism, and it retires a whole class of bug at once.
+[#62](https://github.com/andrewendlinger/xmris/issues/62)
+[#102](https://github.com/andrewendlinger/xmris/issues/102)
+::::
+
+::::{div}
+:class: roadmap-item
+
+09 · Vendor IO
+
+How much loading xmris owns — "array plus params in, labeled DataArray out", or real file
+readers — and whether NIfTI-MRS becomes the common on-ramp instead of N bespoke loaders.
+[#125](https://github.com/andrewendlinger/xmris/issues/125)
+[#46](https://github.com/andrewendlinger/xmris/issues/46)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-A full review-and-simplify pass opens v0.8 — run before the decisions are argued, so its findings
-feed them [#127](https://github.com/andrewendlinger/xmris/issues/127)
+10 · What a vocabulary term *is* — the representation behind the strings
+[#65](https://github.com/andrewendlinger/xmris/issues/65)
+[#88](https://github.com/andrewendlinger/xmris/issues/88)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+11 · Where tests live — the pytest/notebook boundary, and coverage that discovers instead of
+listing [#66](https://github.com/andrewendlinger/xmris/issues/66)
+[#107](https://github.com/andrewendlinger/xmris/issues/107)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+12 · The plug-in promise — a platform, or extensibility by documented convention?
+[#124](https://github.com/andrewendlinger/xmris/issues/124)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+13 · The Python ceiling — ≤3.13 for everyone, for the sake of an optional extra
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+14 · The typing promise — `py.typed` ships with no checker behind it
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+15 · The MRI non-goal, said exactly — MRSI yes; reconstruction, where is the line?
+::::
+
+:::::
+
+:::::{div}
+:class: roadmap-band roadmap-band--outward
+
+(roadmap-outward)=
+## Then outward <span class="roadmap-ver">v0.8 – v0.9</span>
+
+::::{div}
+:class: roadmap-phase roadmap-phase--outward
+:label: roadmap-phase-outward
+
+Committed, but not built.
+
+v0.8 lands the code the decision board unblocks — roughly a third of the tracker waits there —
+and the decisions resolve together in one release rather than leaking across several.
+
+v0.9 then turns to everything a stranger needs that today requires reading the source, or knowing
+the author. Its exit criterion is the JOSS submission.
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+A full review-and-simplify pass runs first, so its findings feed the decisions still open above
+[#127](https://github.com/andrewendlinger/xmris/issues/127)
 ::::
 
 ::::{div}
@@ -265,18 +387,6 @@ raw vendor data or a bare numpy array into an xmris-ready object
 tutorials from concept explainers [#126](https://github.com/andrewendlinger/xmris/issues/126), a
 README whose quick start actually runs, a public API surface with no unreachable corners, and the
 correctness backlog in fitting and plotting paid down.
-::::
-
-::::{div}
-:class: roadmap-item
-
-A data model written down
-
-The vocabulary is law inside the library, but the *schema* it forms has never been stated: which
-dimensions and attributes an object must carry to count as an xmris FID or spectrum, and what a
-function may assume about one it is handed. Writing that down — after the attrs decision fixes
-what the record looks like — is what lets other packages target xmris rather than guess at it.
-[#28](https://github.com/andrewendlinger/xmris/issues/28)
 ::::
 
 ::::{div}
@@ -305,12 +415,13 @@ cites 0.x software, so *citable* does not wait for *frozen*.
 
 Direction, not commitment.
 
-This is what xmris is being built *toward*. These may arrive in a different form, in a different
-order, or not at all — the rail fades here because the confidence does.
+This is what xmris is being built *toward* — held loosely on purpose. These may arrive in a
+different form, in a different order, or not at all; the rail fades here because the confidence
+does, and the decision board above is allowed to rewrite any of it.
 
 They are on the page anyway, because a roadmap that only lists the safe things is not telling you
-where it is going. If your work depends on one of them, say so in the tracker: that is the main way
-something moves up a band.
+where it is going. If your work depends on one of them, say so in the tracker: that is the main
+way something moves up a band.
 ::::
 
 ::::{div}
@@ -319,10 +430,10 @@ something moves up a band.
 `v1.0` — the point the contract stops moving
 
 Not a feature: a promise — and deliberately not a milestone in the tracker yet, because creating
-one now would fake a certainty nobody has. What has to be true first: the design decisions shipped
-and the contract stable across two consecutive releases; the stranger's first hour solved; a
-written deprecation policy. When those hold, calling it 1.0 is a formality; until then, calling it
-1.0 would be a lie with a version number.
+one now would fake a certainty nobody has. What has to be true first: the decision board above
+emptied, the contract stable across two consecutive releases, the stranger's first hour solved,
+and a written deprecation policy. When those hold, calling it 1.0 is a formality; until then,
+calling it 1.0 would be a lie with a version number.
 ::::
 
 ::::{div}
@@ -344,25 +455,27 @@ metabolite map can sit on the anatomical image it came from
 
 An xmris someone else can extend
 
-The plug-in mechanism is a v0.8 decision
-([#124](https://github.com/andrewendlinger/xmris/issues/124)); what it enables is horizon work: a
-lab in another MR domain — multi-echo bSSFP, say — publishing its own functions and vocabulary as
-an extension, vendor loaders that ship on their own cadence, and heavy capabilities that never
-weigh down the core install.
+Whether this is promised at all is decision 12 on the board: a plug-in platform is a
+compatibility contract with parties who do not exist yet, and a written data model (decision 03)
+plus documented conventions may serve an outside lab better than an API. If the promise survives,
+it looks like a lab in another MR domain publishing its own functions and vocabulary as an
+extension, vendor loaders that ship on their own cadence, and heavy capabilities that never weigh
+down the core install.
+[#124](https://github.com/andrewendlinger/xmris/issues/124)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-More vendors than Bruker — Siemens, GE, Philips, NIfTI-MRS; how much xmris owns is
-[#125](https://github.com/andrewendlinger/xmris/issues/125)'s decision
+More vendors than Bruker — Siemens, GE, Philips, NIfTI-MRS; how much xmris owns is decision 09
+[#125](https://github.com/andrewendlinger/xmris/issues/125)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-Core xmris will not do image reconstruction or quantitative-MRI parameter mapping — the door is
-modular rather than closed: if they come, they come as extensions
+Core xmris will not do image reconstruction or quantitative-MRI parameter mapping — the exact
+wording of that refusal, and the fate of the unused k-space vocabulary, is decision 15
 ::::
 
 :::::
@@ -370,16 +483,19 @@ modular rather than closed: if they come, they come as extensions
 (roadmap-landscape)=
 ## The issue landscape
 
-<span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-07-26 · the
+<span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-08-03 · the
 [milestones](https://github.com/andrewendlinger/xmris/milestones) are the live source</span>
 
 Forty-one issues are open, and their distribution is the argument for the release line above: the
 largest cluster is not missing features — it is unmade decisions, plus the work standing behind
-them.
+them. Two of those decisions are now made (02 and 02b on the board); their tracker issues stay
+open until the implementations land, with
+[#21](https://github.com/andrewendlinger/xmris/issues/21) and
+[#22](https://github.com/andrewendlinger/xmris/issues/22) re-scoped by what was decided.
 
 | Cluster | Issues | Lands in |
 |---|---|---|
-| Unmade design decisions | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) | v0.8 |
+| Design decisions — the board above | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) | v0.8 |
 | Blocked behind them | [#21](https://github.com/andrewendlinger/xmris/issues/21) [#22](https://github.com/andrewendlinger/xmris/issues/22) [#23](https://github.com/andrewendlinger/xmris/issues/23) [#28](https://github.com/andrewendlinger/xmris/issues/28) [#34](https://github.com/andrewendlinger/xmris/issues/34) [#71](https://github.com/andrewendlinger/xmris/issues/71) [#102](https://github.com/andrewendlinger/xmris/issues/102) [#107](https://github.com/andrewendlinger/xmris/issues/107) | v0.8 · the schema #28 in v0.9 |
 | The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) | v0.7 |
 | Quality & tooling | [#87](https://github.com/andrewendlinger/xmris/issues/87) [#108](https://github.com/andrewendlinger/xmris/issues/108) [#111](https://github.com/andrewendlinger/xmris/issues/111) [#117](https://github.com/andrewendlinger/xmris/issues/117) [#127](https://github.com/andrewendlinger/xmris/issues/127) | v0.8 – v0.9 |
@@ -387,20 +503,20 @@ them.
 | Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#128](https://github.com/andrewendlinger/xmris/issues/128) | v0.9 |
 | Space & scale | [#4](https://github.com/andrewendlinger/xmris/issues/4) [#25](https://github.com/andrewendlinger/xmris/issues/25) | Horizon |
 
-The decisions are not a flat list. The spine below is v0.8's execution order — it is why the
-vocabulary question goes first and the attrs strategy matters most:
+The decisions are not a flat list. The spine below is the board's dependency order — the decided
+pair feeds the data model first, and the license decision quietly gates the plug-in promise:
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart TD
-    n65["#65 what is a vocabulary term?"] --> n88["#88 diagnostic axes"]
-    n65 --> n124["#124 what is core xmris?"]
-    n124 --> n125["#125 vendor IO"]
-    n124 <--> n62["#62 accessor registration"]
-    n62 --> n62d["#34 · parts of #71 #102"]
-    n64["#64 attrs strategy"] --> n64d["#21 #22 #23 · then #28"]
-    n66["#66 pytest vs notebook"] --> n102["#102 test auto-discovery"]
-    n102 --> n107["#107 test restructure"]
+    d02["02 lineage record ✓"] --> d03["03 data model"]
+    d02b["02b constants ✓"] --> d03
+    d06["06 preprocessing middle"] --> d03
+    d06 --> d15["15 MRI non-goal"]
+    d01["01 license"] --> d12["12 plug-in promise"]
+    d04["04 core & extras"] <--> d12
+    d04 --> d09["09 vendor IO"]
+    d08["08 accessor parity"] --> d11["11 test architecture"]
 ```
 
 :::{div}
@@ -418,7 +534,11 @@ release, and they move faster. A milestone here earns its band from the state of
 the two disagree, the tracker is right and this page is stale — say so by
 [opening an issue](https://github.com/andrewendlinger/xmris/issues/new).
 
+The decision board keeps its paper on this site: each decided card links an exploration notebook,
+frozen the day the decision lands, and an aimed-solution notebook that becomes the spec the
+implementation is checked against. Both live in the sidebar beneath this page.
+
 :::{seealso}
-The [dev diary](diary/about.md) is this page's backward-looking twin: one entry per decision already
-taken, rewritten in place as that decision evolves.
+The [dev diary](diary/about.md) is this page's backward-looking twin: one entry per decision
+already taken, rewritten in place as that decision evolves.
 :::

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ build. The why is the [architecture tour](#architecture).
 :class: roadmap-band roadmap-band--motion
 
 (roadmap-in-motion)=
-## In motion <span class="roadmap-ver">v0.7</span>
+## In motion <span class="roadmap-ver"><a href="https://github.com/andrewendlinger/xmris/milestone/1">v0.7</a></span>
 
 ::::{div}
 :class: roadmap-phase roadmap-phase--motion
@@ -160,7 +160,7 @@ even be imported [#122](https://github.com/andrewendlinger/xmris/issues/122)
 :class: roadmap-band roadmap-band--decisions
 
 (roadmap-decisions)=
-## The decisions <span class="roadmap-ver">v0.8</span>
+## The decisions <span class="roadmap-ver"><a href="https://github.com/andrewendlinger/xmris/milestone/2">v0.8</a></span>
 
 ::::{div}
 :class: roadmap-phase roadmap-phase--decisions
@@ -268,18 +268,21 @@ listing [#66](https://github.com/andrewendlinger/xmris/issues/66)
 :class: roadmap-item roadmap-item--minor
 
 13 · The Python ceiling — ≤3.13 for everyone, for the sake of an optional extra
+[#133](https://github.com/andrewendlinger/xmris/issues/133)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
 14 · The typing promise — `py.typed` ships with no checker behind it
+[#67](https://github.com/andrewendlinger/xmris/issues/67)
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
 15 · The MRI non-goal, said exactly — MRSI yes; reconstruction, where is the line?
+[#136](https://github.com/andrewendlinger/xmris/issues/136)
 ::::
 
 :::::
@@ -288,7 +291,7 @@ listing [#66](https://github.com/andrewendlinger/xmris/issues/66)
 :class: roadmap-band roadmap-band--outward
 
 (roadmap-outward)=
-## Then outward <span class="roadmap-ver">v0.8 – v0.9</span>
+## Then outward <span class="roadmap-ver"><a href="https://github.com/andrewendlinger/xmris/milestone/2">v0.8</a> – <a href="https://github.com/andrewendlinger/xmris/milestone/3">v0.9</a></span>
 
 ::::{div}
 :class: roadmap-phase roadmap-phase--outward

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,338 @@
+(roadmap)=
+# Where xmris is going
+
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-26 · v0.6.1 · visual draft — content not final</span>
+
+::::{div}
+:class: roadmap-hero
+
+:::{div}
+:class: roadmap-kicker
+
+The vision
+:::
+
+:::{div}
+:class: roadmap-statement
+
+xmris is finished when the three lines you write to process a single FID are the same three lines
+that process a whole volume — and when the object they hand back already carries everything a paper
+needs.
+:::
+
+:::{div}
+:class: roadmap-tenets
+
+`xarray in, xarray out` `the notebook is the test` `the record travels with the data`
+:::
+::::
+
+Today the package is honest about what it is. The processing chain genuinely broadcasts: zero-fill,
+apodize, Fourier, phase and reference all run across a coil axis, a repetition axis or a voxel grid
+without knowing they exist. The fitting does not — `fit_amares` is one-dimensional, and five
+documentation pages hand-roll the same `xr.concat` stack to work around it. That gap between the
+two halves is the shape of most of the near-term work.
+
+The destination is that the dimension you did not think about is the one that costs nothing. And
+that the record travels with the data: the reference frequency, the phase that was applied, the
+prior knowledge a fit was given, the residual it produced — all attached to the object you already
+hold, so a figure and the methods section describing it come out of the same file.
+
+The last thing on this page is a promise rather than a feature. `v1.0` is the point at which the
+[architecture contract](contributing/contract.md) stops moving and the API you wrote against stays
+where it is.
+
+:::{note} How to read this page
+Four bands, from what already works to what is still an intention — and the spine beside them loses
+its confidence as it descends. There are deliberately **no dates**. A milestone moves up a band when
+the work is real, not when a quarter ends. Version numbers are the release a milestone is aimed at,
+not a commitment to ship it there.
+
+The issue tracker holds the detail; this page holds the argument.
+:::
+
+:::{div}
+:class: roadmap-map
+
+[Shipped](#roadmap-phase-shipped) [In motion](#roadmap-phase-motion) [Next](#roadmap-phase-next) [Horizon](#roadmap-phase-horizon)
+:::
+
+:::::{div}
+:class: roadmap-band roadmap-band--shipped
+
+(roadmap-shipped)=
+## Shipped <span class="roadmap-ver">v0.1 – v0.6</span>
+
+::::{div}
+:class: roadmap-phase roadmap-phase--shipped
+:label: roadmap-phase-shipped
+
+What you can use today.
+
+Released to PyPI, documented, and exercised by the test suite — the claims on these cards are live
+notebook cells, so a broken one fails the build rather than quietly ageing.
+
+Nothing here is a plan. If something in this band does not work, that is a bug worth reporting, not
+a roadmap item waiting its turn.
+::::
+
+::::{div}
+:class: roadmap-item
+
+An architecture you can hold in your head
+
+Eleven numbered rules — xarray in, xarray out; never mutate the input; the vocabulary is law — are
+written down as [the architecture contract](contributing/contract.md) and *executed* against the
+source on every build. The page quotes the live code it governs, so the contract cannot drift away
+from it. [#72](https://github.com/andrewendlinger/xmris/issues/72)
+::::
+
+::::{div}
+:class: roadmap-item
+
+A processing chain that reads like the physics
+
+`zero_fill` → `apodize_exp` → `to_spectrum` → `autophase` → `baseline_als` → `to_ppm`, each a pure
+function and an `.xmr` method, each preserving the coordinates it was given and appending exactly
+the parameter it applied. Domain mistakes are caught at the door by `@computes_in` and
+`@ensures_domain` rather than in your results.
+::::
+
+::::{div}
+:class: roadmap-item
+
+Fitting, through pyAMARES
+
+`fit_amares` returns a Dataset with the data, the model and the residual aligned on the same axes,
+so the fit is an object you can keep processing rather than a table you have to reassemble.
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Interactive widgets for phasing, apodization and scrolling through spectra
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Documentation that executes itself — every claim is a live cell, every page previewed per pull
+request [#104](https://github.com/andrewendlinger/xmris/issues/104)
+::::
+
+:::::
+
+:::::{div}
+:class: roadmap-band roadmap-band--motion
+
+(roadmap-in-motion)=
+## In motion <span class="roadmap-ver">v0.7</span>
+
+::::{div}
+:class: roadmap-phase roadmap-phase--motion
+:label: roadmap-phase-motion
+
+Being built right now.
+
+The linked issues are open and have commits against them. This is the last point at which the shape
+of an API is still cheap to change.
+
+So it is the band worth arguing with. If you have a view on how a failed fit should announce itself,
+or what a result Dataset ought to be called, saying so now costs nothing — saying so after v1.0
+costs a deprecation cycle.
+::::
+
+::::{div}
+:class: roadmap-item
+
+Fitting you can trust
+
+A fit that fails to converge can currently return quietly, and the Dataset it produces uses literal
+keys instead of the controlled vocabulary. This is the work that makes fitting say *why* it stopped,
+validate prior knowledge before it reaches the solver, and come back speaking the same language as
+everything else.
+[#80](https://github.com/andrewendlinger/xmris/issues/80)
+[#81](https://github.com/andrewendlinger/xmris/issues/81)
+[#82](https://github.com/andrewendlinger/xmris/issues/82)
+[#69](https://github.com/andrewendlinger/xmris/issues/69)
+
+:::{dropdown} What each piece covers
+- **[#80](https://github.com/andrewendlinger/xmris/issues/80)** — silent-failure and convergence
+  hardening: a fit reports its exit condition instead of returning a plausible-looking result.
+- **[#81](https://github.com/andrewendlinger/xmris/issues/81)** — the API and docstring rough edges
+  around `fit_amares`.
+- **[#82](https://github.com/andrewendlinger/xmris/issues/82)** — the prior-knowledge file format
+  has traps that are currently discovered at runtime; validate and document them.
+- **[#69](https://github.com/andrewendlinger/xmris/issues/69)** — the result Dataset ignores
+  `VARS`/`DIMS`, which breaks the one-vocabulary rule at exactly the point users look hardest.
+:::
+::::
+
+::::{div}
+:class: roadmap-item
+
+One canonical API
+
+A free function and its `.xmr` method should never disagree — but today only the `dim` defaults are
+pinned by a test, and the accessor is registered as an import side-effect nobody chose. This is the
+audit, the enforcement, and the decision underneath both.
+[#71](https://github.com/andrewendlinger/xmris/issues/71)
+[#102](https://github.com/andrewendlinger/xmris/issues/102)
+[#62](https://github.com/andrewendlinger/xmris/issues/62)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Install without a git fork — pyAMARES becomes an optional extra
+[#70](https://github.com/andrewendlinger/xmris/issues/70)
+[#115](https://github.com/andrewendlinger/xmris/issues/115)
+::::
+
+:::::
+
+:::::{div}
+:class: roadmap-band roadmap-band--next
+
+(roadmap-next)=
+## Next <span class="roadmap-ver">v0.8 – v0.9</span>
+
+::::{div}
+:class: roadmap-phase roadmap-phase--next
+:label: roadmap-phase-next
+
+Decided, but not yet built.
+
+Each of these has a design behind it — usually an open `design-decision` issue that has been argued
+through — and no implementation. The version stamp is where it is aimed, not where it is promised.
+
+A milestone leaves this band by being built, or by being dropped when the decision underneath it
+turns out to be wrong. Both happen, and the second is not a failure.
+::::
+
+::::{div}
+:class: roadmap-item
+
+Provenance that survives a chain
+
+The applied parameter is the record — `phase_p0=15.0`, never `phase_applied=True` — but attributes
+survive a long chain by convention rather than by guarantee. The open decision is whether lineage
+stays flat per-parameter keys or becomes a structured history log; what it unlocks is a spectrum
+that can reconstruct its own methods section.
+[#64](https://github.com/andrewendlinger/xmris/issues/64)
+[#21](https://github.com/andrewendlinger/xmris/issues/21)
+[#23](https://github.com/andrewendlinger/xmris/issues/23)
+::::
+
+::::{div}
+:class: roadmap-item
+
+A data model written down
+
+The vocabulary is law, but the *schema* it forms has never been stated: which dimensions and
+attributes an object must carry to be an xmris FID, and what a function may assume about one it is
+handed. Writing that down is what lets other packages target xmris rather than guess at it.
+[#28](https://github.com/andrewendlinger/xmris/issues/28)
+[#65](https://github.com/andrewendlinger/xmris/issues/65)
+[#88](https://github.com/andrewendlinger/xmris/issues/88)
+::::
+
+::::{div}
+:class: roadmap-item
+
+Lazy and chunked
+
+dask support, so a dataset larger than memory is still the same three chained lines.
+[#25](https://github.com/andrewendlinger/xmris/issues/25)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Fitting beyond one dimension — the `xr.concat` workaround becomes the library's job
+[#113](https://github.com/andrewendlinger/xmris/issues/113)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+A changelog [#10](https://github.com/andrewendlinger/xmris/issues/10)
+::::
+
+:::::
+
+:::::{div}
+:class: roadmap-band roadmap-band--horizon
+
+(roadmap-horizon)=
+## Horizon <span class="roadmap-ver">v1.0 and past it</span>
+
+::::{div}
+:class: roadmap-phase roadmap-phase--horizon
+:label: roadmap-phase-horizon
+
+Direction, not commitment.
+
+This is what xmris is being built *toward*. These may arrive in a different form, in a different
+order, or not at all — the rail fades here because the confidence does.
+
+They are on the page anyway, because a roadmap that only lists the safe things is not telling you
+where it is going. If your work depends on one of them, say so in the tracker: that is the main way
+something moves up a band.
+::::
+
+::::{div}
+:class: roadmap-item
+
+`v1.0` — the point the contract stops moving
+
+Not a feature: a promise. The epic that gates it is public-release readiness — a JOSS paper with a
+State of the Field against FSL-MRS, Osprey, suspect and spant; a citation file; a typing gate;
+fitting coverage worth the name; a clean install from PyPI with no git sources. After it, the API
+you wrote against stays where it is.
+[#67](https://github.com/andrewendlinger/xmris/issues/67)
+::::
+
+::::{div}
+:class: roadmap-item
+
+The visualization ecosystem: `.plot`, `.widget`, `.ui`
+
+Three lazily-loaded pillars, of which two exist in part. The third does not: a napari bridge for
+scrolling a four-dimensional spectral volume and overlaying fitted metabolite maps on the anatomy
+they came from.
+[#4](https://github.com/andrewendlinger/xmris/issues/4)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+More vendors than Bruker [#46](https://github.com/andrewendlinger/xmris/issues/46)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Imaging, and not only spectroscopy — the `I` in the name is still aspirational
+::::
+
+:::::
+
+:::{div}
+:class: roadmap-end
+
+and then it is someone else's turn to say what comes next
+:::
+
+(roadmap-changing)=
+## How this page changes
+
+This page is written by hand, and it is the argument rather than the record: the issue tracker holds
+what is actually being worked on, and it moves faster. A milestone here earns its band from the
+state of the work, so if the two disagree, the tracker is right and this page is stale — say so by
+[opening an issue](https://github.com/andrewendlinger/xmris/issues/new).
+
+:::{seealso}
+The [dev diary](diary/about.md) is this page's backward-looking twin: one entry per decision already
+taken, rewritten in place as that decision evolves.
+:::

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,6 +120,14 @@ v0.7 is the tag that finally makes the band above installable.
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
+Next in line: the docs get a floor plan — a sidebar you can scan, concepts apart from tutorials,
+and a landing page that says where everything lives
+[#137](https://github.com/andrewendlinger/xmris/issues/137)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
 This very page — the roadmap you are reading is being written and argued right now
 [#116](https://github.com/andrewendlinger/xmris/issues/116)
 ::::

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,36 +15,36 @@ The vision
 :::{div}
 :class: roadmap-statement
 
-xmris is finished when the three lines you write to process a single FID are the same three lines
-that process a whole volume — and when the object they hand back already carries everything a paper
-needs.
+xmris is finished when the three lines you write to process a single spectrum are the same three
+lines that process a whole spectroscopic-imaging dataset — and when the object they hand back can
+answer for every step that produced it.
 :::
 
 :::{div}
 :class: roadmap-tenets
 
-`xarray in, xarray out` `the notebook is the test` `the record travels with the data`
+`xarray in, xarray out` `docs before code` `worry only about your data`
 :::
 ::::
 
-That sentence is closer to true than it looks. Your data stays an `xarray.DataArray` — `.xmr` is an
-accessor, not a container — so the processing chain broadcasts by construction: zero-fill, apodize,
-Fourier, phase and reference run across a coil axis, a repetition series or a voxel grid without
-being told they exist. The fitting keeps up: `fit_amares` takes whatever dimensions you hand it,
-fits every spectrum in parallel, and folds the results back into your layout. The honest remainder
-is small and specific — the simulator builds one FID at a time, automatic phasing picks a single
-phase for the whole array, a fit across a grid still normalises and initialises globally rather
-than per voxel, and past a certain size, memory. That remainder is the far end of this page.
+Three commitments shape everything below. Your data stays an `xarray.DataArray` — `.xmr` adds the
+physics and nothing owns you, so the whole xarray ecosystem keeps working. The documentation comes
+before the code and honestly gets more of the work: every page executes on every pull request, and
+it is written to be *read* — educational, opinionated, occasionally fun — not consulted in defeat.
+And once your data is in, the bookkeeping stops being yours: coordinates, frequency axes, the
+metadata tags scanners breed — xmris carries them, so the focus goes back to the one thing that is
+actually yours.
 
-The near end is less glamorous and more important. Roughly a third of the open tracker sits behind
-five unmade architecture decisions, and the version on PyPI does not install the package this
-documentation describes. So the next two releases are not feature releases: one makes the install
-honest, and one makes the ground stop moving. Features come after the promises hold.
+Where does it stand? Closer to the vision than you might guess: the processing chain broadcasts
+across whatever dimensions you bring, and the fitting keeps up — `fit_amares`, for example, folds
+a grid of spectra through the same call as a single FID. The 1-D holdouts that remain (the
+simulator, per-spectrum autophasing) are tracked as ordinary work items below. The next two
+releases deliberately ship no features at all: first an install that tells the truth, then the
+architecture decisions that let the ground stop moving. Features come after the promises hold.
 
-The last thing on this page is a promise rather than a feature. `v1.0` is not a milestone with an
-item list; it is the point at which the [architecture contract](contributing/contract.md) stops
-moving and the API you wrote against stays where it is. What has to be true first is written in
-the [horizon band](#roadmap-horizon).
+The last thing on this page is a promise rather than a feature. `v1.0` is the point at which the
+[architecture contract](contributing/contract.md) stops moving and the API you wrote against stays
+where it is. What has to be true first is written in the [horizon band](#roadmap-horizon).
 
 :::{note} How to read this page
 Four bands, from what already works to what is still an intention — and the spine beside them loses
@@ -197,10 +197,11 @@ A changelog begins — its first entry is this release
 
 Committed, but not built.
 
-v0.8 is one thing said five ways: the architecture settles. Five design decisions are open, each
-an issue where the choice is argued before any code follows, and roughly a third of the tracker is
-blocked behind them. v0.8 is the last release allowed to move the ground under a user — and saying
-that publicly is most of the value of having a roadmap at all.
+v0.8 is one thing said several ways: the architecture settles. The open design decisions — what a
+vocabulary term is, what the record looks like, what is core and what is an extra, who registers
+what, where the tests live — each get argued in an issue before any code follows, and roughly a
+third of the tracker is blocked behind them. v0.8 is the last release allowed to move the ground
+under a user, and saying that publicly is most of the value of having a roadmap at all.
 
 v0.9 then turns outward: everything a stranger needs that today requires reading the source, or
 knowing the author. Its exit criterion is the JOSS submission.
@@ -209,27 +210,41 @@ knowing the author. Its exit criterion is the JOSS submission.
 ::::{div}
 :class: roadmap-item
 
-Five decisions, then the code that follows
+The decisions, then the code that follows
 
 The questions are argued in their issues, not here — what this page fixes is the order, and that
 they resolve together in one release rather than leaking across several.
 
-:::{dropdown} The five, in dependency order
+:::{dropdown} In dependency order
 - **[#65](https://github.com/andrewendlinger/xmris/issues/65)** — what a vocabulary term *is*
   (today: a `str` subclass carrying metadata), then
   **[#88](https://github.com/andrewendlinger/xmris/issues/88)** — where diagnostic and
   algorithm-output axes live. The cheapest pair, so it goes first.
-- **[#64](https://github.com/andrewendlinger/xmris/issues/64)** — the attrs strategy: does lineage
-  stay flat applied-parameter keys, or become a structured history? The highest-leverage decision
-  on the board — four issues wait on it, Commandment 3 is rewritten by whatever it decides, and it
-  is what turns "the record travels with the data" from a convention into a guarantee: a spectrum
-  that can reconstruct its own methods section.
+- **[#124](https://github.com/andrewendlinger/xmris/issues/124)** — what is core xmris: the
+  extras boundary (`[fitting]` exists; `[plotting]`? vendors?) and the plug-in mechanism that
+  lets a lab in another MR domain add functions *and vocabulary* without forking core. Packaging
+  is a one-way door, so it closes while the ground is still allowed to move.
+- **[#125](https://github.com/andrewendlinger/xmris/issues/125)** — vendor IO: how much xmris
+  owns, and whether NIfTI-MRS becomes the on-ramp instead of N bespoke loaders. Downstream of
+  #124.
+- **[#64](https://github.com/andrewendlinger/xmris/issues/64)** — the attrs strategy: flat
+  applied-parameter keys, or a structured history? The highest-leverage decision on the board —
+  four issues wait on it, Commandment 3 is rewritten by whatever it decides, and it is what turns
+  "the record travels with the data" from a convention into a guarantee.
 - **[#62](https://github.com/andrewendlinger/xmris/issues/62)** — accessor auto-registration and
   which API is canonical, so a free function and its `.xmr` method cannot drift apart again.
+  Resolves together with #124's registration question.
 - **[#66](https://github.com/andrewendlinger/xmris/issues/66)** — the boundary between pytest and
   notebook tests, which decides how the architecture suite gets rebuilt to discover functions
   instead of trusting hand-maintained lists.
 :::
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+A full review-and-simplify pass opens v0.8 — run before the decisions are argued, so its findings
+feed them [#127](https://github.com/andrewendlinger/xmris/issues/127)
 ::::
 
 ::::{div}
@@ -246,9 +261,10 @@ Ready for a stranger
 
 The first hour of a new user, made survivable without reading the source: a documented path from
 raw vendor data or a bare numpy array into an xmris-ready object
-[#46](https://github.com/andrewendlinger/xmris/issues/46), a README whose quick start actually
-runs, a public API surface with no unreachable corners, and the correctness backlog in fitting and
-plotting paid down.
+[#46](https://github.com/andrewendlinger/xmris/issues/46), a sidebar that separates hands-on
+tutorials from concept explainers [#126](https://github.com/andrewendlinger/xmris/issues/126), a
+README whose quick start actually runs, a public API surface with no unreachable corners, and the
+correctness backlog in fitting and plotting paid down.
 ::::
 
 ::::{div}
@@ -303,7 +319,7 @@ something moves up a band.
 `v1.0` — the point the contract stops moving
 
 Not a feature: a promise — and deliberately not a milestone in the tracker yet, because creating
-one now would fake a certainty nobody has. What has to be true first: the five decisions shipped
+one now would fake a certainty nobody has. What has to be true first: the design decisions shipped
 and the contract stable across two consecutive releases; the stranger's first hour solved; a
 written deprecation policy. When those hold, calling it 1.0 is a formality; until then, calling it
 1.0 would be a lie with a version number.
@@ -316,27 +332,76 @@ MRSI: space and scale
 
 The vocabulary already declares `x`, `y`, `z` and their k-space twins, and nothing uses them yet —
 a placed bet, not dead weight. Cashing it in, in order: CSI-shaped data, spatial plus spectral,
-through the same three lines that process one FID; per-voxel initialisation and normalisation for
-fits across a grid; lazy, chunked processing for volumes that outgrow memory
+through the same three lines that process one FID; per-voxel initialisation for fits across a
+grid; lazy, chunked processing for volumes that outgrow memory
 [#25](https://github.com/andrewendlinger/xmris/issues/25); and image coordinates, so a fitted
 metabolite map can sit on the anatomical image it came from
 [#4](https://github.com/andrewendlinger/xmris/issues/4).
 ::::
 
 ::::{div}
-:class: roadmap-item roadmap-item--minor
+:class: roadmap-item
 
-More vendors than Bruker — Siemens, GE, Philips, NIfTI-MRS
+An xmris someone else can extend
+
+The plug-in mechanism is a v0.8 decision
+([#124](https://github.com/andrewendlinger/xmris/issues/124)); what it enables is horizon work: a
+lab in another MR domain — multi-echo bSSFP, say — publishing its own functions and vocabulary as
+an extension, vendor loaders that ship on their own cadence, and heavy capabilities that never
+weigh down the core install.
 ::::
 
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-What xmris is *not*: image reconstruction and quantitative-MRI parameter mapping stay out of
-scope — the *i* in the name is the spectroscopic imaging above, not an MRI toolbox
+More vendors than Bruker — Siemens, GE, Philips, NIfTI-MRS; how much xmris owns is
+[#125](https://github.com/andrewendlinger/xmris/issues/125)'s decision
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Core xmris will not do image reconstruction or quantitative-MRI parameter mapping — the door is
+modular rather than closed: if they come, they come as extensions
 ::::
 
 :::::
+
+(roadmap-landscape)=
+## The issue landscape
+
+<span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-07-26 · the
+[milestones](https://github.com/andrewendlinger/xmris/milestones) are the live source</span>
+
+Forty-one issues are open, and their distribution is the argument for the release line above: the
+largest cluster is not missing features — it is unmade decisions, plus the work standing behind
+them.
+
+| Cluster | Issues | Lands in |
+|---|---|---|
+| Unmade design decisions | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) | v0.8 |
+| Blocked behind them | [#21](https://github.com/andrewendlinger/xmris/issues/21) [#22](https://github.com/andrewendlinger/xmris/issues/22) [#23](https://github.com/andrewendlinger/xmris/issues/23) [#28](https://github.com/andrewendlinger/xmris/issues/28) [#34](https://github.com/andrewendlinger/xmris/issues/34) [#71](https://github.com/andrewendlinger/xmris/issues/71) [#102](https://github.com/andrewendlinger/xmris/issues/102) [#107](https://github.com/andrewendlinger/xmris/issues/107) | v0.8 · the schema #28 in v0.9 |
+| The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) | v0.7 |
+| Quality & tooling | [#87](https://github.com/andrewendlinger/xmris/issues/87) [#108](https://github.com/andrewendlinger/xmris/issues/108) [#111](https://github.com/andrewendlinger/xmris/issues/111) [#117](https://github.com/andrewendlinger/xmris/issues/117) [#127](https://github.com/andrewendlinger/xmris/issues/127) | v0.8 – v0.9 |
+| The front door | [#27](https://github.com/andrewendlinger/xmris/issues/27) [#46](https://github.com/andrewendlinger/xmris/issues/46) [#67](https://github.com/andrewendlinger/xmris/issues/67) [#119](https://github.com/andrewendlinger/xmris/issues/119) [#120](https://github.com/andrewendlinger/xmris/issues/120) [#121](https://github.com/andrewendlinger/xmris/issues/121) [#126](https://github.com/andrewendlinger/xmris/issues/126) | v0.9 |
+| Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#128](https://github.com/andrewendlinger/xmris/issues/128) | v0.9 |
+| Space & scale | [#4](https://github.com/andrewendlinger/xmris/issues/4) [#25](https://github.com/andrewendlinger/xmris/issues/25) | Horizon |
+
+The decisions are not a flat list. The spine below is v0.8's execution order — it is why the
+vocabulary question goes first and the attrs strategy matters most:
+
+```{mermaid}
+%%{init: {'flowchart': {'htmlLabels': false}}}%%
+flowchart TD
+    n65["#65 what is a vocabulary term?"] --> n88["#88 diagnostic axes"]
+    n65 --> n124["#124 what is core xmris?"]
+    n124 --> n125["#125 vendor IO"]
+    n124 <--> n62["#62 accessor registration"]
+    n62 --> n62d["#34 · parts of #71 #102"]
+    n64["#64 attrs strategy"] --> n64d["#21 #22 #23 · then #28"]
+    n66["#66 pytest vs notebook"] --> n102["#102 test auto-discovery"]
+    n102 --> n107["#107 test restructure"]
+```
 
 :::{div}
 :class: roadmap-end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 (roadmap)=
 # Where xmris is going
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-04</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-05</span>
 
 ::::{div}
 :class: roadmap-hero
@@ -15,21 +15,21 @@ The direction
 :::{div}
 :class: roadmap-statement
 
-Metadata neatly tucked away, the same lines that process a single FID process an N-D volume of
-them.
+The physics used to live in headers, protocols, and someone's memory. Here it lives in the
+array.
 :::
 
 :::{div}
 :class: roadmap-tenets
 
-`xarray in, xarray out` `docs before code` `the physics travels with the data`
+`xarray in, xarray out` `one FID or a volume, the same lines` `docs before code`
 :::
 ::::
 
-Three commitments shape everything below. Your data stays an `xarray.DataArray` — `.xmr` adds
-the physics, and the whole xarray ecosystem keeps working. The docs come before the code: every
-page executes on every pull request. And the bookkeeping — coordinates, frequency axes, scanner
-metadata — travels with the data.
+Three commitments shape everything below. Your data stays an `xarray.DataArray` — the physics
+comes to it, never your data into a framework, and the whole xarray ecosystem keeps working. The
+same pure lines process one FID or an N-D volume of them. And the docs come before the code:
+every page executes on every pull request.
 
 :::{note} How to read this page
 Five bands: from what already works, through the upcoming architecture decisions, to the near

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,10 +32,10 @@ page executes on every pull request. And the bookkeeping — coordinates, freque
 metadata — travels with the data.
 
 :::{note} How to read this page
-Five bands, descending in confidence: from what already works, through the decision board we
-would defend today, to a far end that is more a direction.
-
-The page is aligned with the [tracker's milestones](https://github.com/andrewendlinger/xmris/milestones) and is supposed to give a clearer picture of what's ahead / planned for xmris.
+Five bands: from what already works, through the upcoming architecture decisions, to the near
+and far future — kept in sync with the
+[issues and milestones](https://github.com/andrewendlinger/xmris/milestones). Like any plan, it
+will probably change when it meets reality.
 :::
 
 :::{div}
@@ -56,9 +56,7 @@ The page is aligned with the [tracker's milestones](https://github.com/andrewend
 
 What you can use today.
 
-Real on `main` and exercised on every pull request — every claim on these cards is a live
-notebook cell, so a broken one fails the build. (`main` runs ahead of PyPI; closing that gap is
-the band below.)
+Real on `main` and exercised on every pull request — though `main` still runs ahead of PyPI.
 ::::
 
 ::::{div}
@@ -114,37 +112,16 @@ build. The why is the [architecture tour](#architecture).
 :class: roadmap-phase roadmap-phase--motion
 :label: roadmap-phase-motion
 
-Being released right now.
+Moving right now.
 
-Everything in this band is merged and working on `main`; what is in motion is the release itself.
-v0.7 is the tag that makes the shipped band installable — months of fitting, contract and
-documentation work that PyPI has not seen yet.
-
-It is deliberately small. The only code it waits for is the install fix below, because tagging a
-release whose bare `pip install` cannot even be imported would defeat the point of tagging at all.
+v0.7 is the tag that finally makes the band above installable.
 ::::
 
 ::::{div}
-:class: roadmap-item
+:class: roadmap-item roadmap-item--minor
 
-Fitting you can trust
-
-The rework that headlines this release. Amplitude scale is normalised before fitting, killing a
-failure mode where a fit could "converge" on its own prior and look completely fine; a failed
-voxel comes back as `NaN` plus a `fit_status` that says why, never a plausible number; prior
-knowledge is validated before it reaches the solver instead of failing inside it.
-::::
-
-::::{div}
-:class: roadmap-item
-
-An install that tells the truth
-
-The wheel on PyPI cannot install on Apple Silicon, and today's `main` fixed that while leaving a
-bare `pip install xmris` unimportable — a missing core dependency that CI never caught, because no
-job installs the package the way a user does. v0.7 ships an install that works everywhere, AMARES
-as the optional `xmris[fitting]` extra, and a CI job that installs like a stranger so this class
-of bug cannot return. [#122](https://github.com/andrewendlinger/xmris/issues/122)
+This very page — the roadmap you are reading is being written and argued right now
+[#116](https://github.com/andrewendlinger/xmris/issues/116)
 ::::
 
 ::::{div}
@@ -152,6 +129,29 @@ of bug cannot return. [#122](https://github.com/andrewendlinger/xmris/issues/122
 
 A changelog begins — its first entry is this release
 [#10](https://github.com/andrewendlinger/xmris/issues/10)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+The docs stop recommending strict mode — automatic domain conversion is the default, deliberately
+and permanently [#131](https://github.com/andrewendlinger/xmris/issues/131)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Bug fix: a fit could silently return the prior it was given and look completely fine — the rework
+that kills it is merged; the last guards are tracked
+[#80](https://github.com/andrewendlinger/xmris/issues/80)
+[#82](https://github.com/andrewendlinger/xmris/issues/82)
+::::
+
+::::{div}
+:class: roadmap-item roadmap-item--minor
+
+Bug fix: the wheel on PyPI cannot install on Apple Silicon, and a bare `pip install xmris` cannot
+even be imported [#122](https://github.com/andrewendlinger/xmris/issues/122)
 ::::
 
 :::::
@@ -168,26 +168,8 @@ A changelog begins — its first entry is this release
 
 The near horizon: the architecture settles, one argued decision at a time.
 
-Roughly a third of the tracker is blocked behind the questions on this board, and v0.8 is the
-last release allowed to move the ground under a user — so each question is decided before its
-code is written. The board is ordered by how irreversible each decision is and how soon it
-blocks: the full cards are load-bearing, the one-line rows can wait.
-
-Every decision leaves a paper trail. It starts as an *exploration notebook* that demonstrates the
-problem live and runs every serious option as code. When one option wins, that notebook freezes
-as the record of *why*, an *aimed-solution notebook* details the *what*, and only then does the
-implementation follow. A decided card links its trail.
-::::
-
-::::{div}
-:class: roadmap-item
-
-01 · The license <span class="roadmap-status roadmap-status--arguing">in discussion</span>
-
-xmris is AGPL-3.0-only — the strongest copyleft on PyPI, the quietest gate on who may adopt it,
-and a contradiction of the extension ecosystem this page promises further down. Whether that is a
-value to state and keep, or an accident to fix while there is exactly one copyright holder, is
-under argument now.
+v0.8 is the last release allowed to move the ground under a user, so every question here is
+decided in writing before its code is written.
 ::::
 
 ::::{div}
@@ -195,14 +177,10 @@ under argument now.
 
 02 · The lineage record <span class="roadmap-status roadmap-status--decided">decided 2026-08-02</span>
 
-Processing lineage leaves flat attrs keys entirely: every operation appends to one `xmr_history`
-record — the parameters actually applied, in order, written by one central decorator and read
-back as `history()`. Physics and calibration attrs stay flat, typed and individually addressable.
-The repeat-application lie — the data carrying one apodization while the record claims another —
-dies with the flat keys.
+Processing history becomes one `xmr_history` record — what each operation actually applied, in
+order. Physics attrs stay flat and typed.
 
-The exploration that got here is frozen as [a design notebook](#attrs-nb); the aimed-solution
-notebook comes next, then the implementation.
+<span class="roadmap-progress">[explored](#attrs-nb) ✓ → decided ✓ → <strong>next: solution spec</strong> → implementation</span>
 [#64](https://github.com/andrewendlinger/xmris/issues/64)
 ::::
 
@@ -211,14 +189,11 @@ notebook comes next, then the implementation.
 
 02b · The physical constants <span class="roadmap-status roadmap-status--decided">decided 2026-08-03</span>
 
-The constants a measurement cannot be interpreted without — reference frequency, carrier, group
-delay — move out of droppable attrs into one scalar coordinate, `xmr_acquisition`, with the
-history riding beside it as `xmr_history`. Surviving plain xarray operations becomes structural
-rather than boilerplate; mixed calibrations drop the container whole and fail loudly at the next
-gate; and `explain()` renders every constant with its unit and curated description.
+The constants a measurement cannot be interpreted without travel as one container coordinate,
+`xmr_acquisition` — they survive plain xarray operations structurally, not by boilerplate.
 
-Frozen exploration: [the constants design notebook](#constants-nb); the aimed-solution notebook
-comes next. [#21](https://github.com/andrewendlinger/xmris/issues/21)
+<span class="roadmap-progress">[explored](#constants-nb) ✓ → decided ✓ → <strong>next: solution spec</strong> → implementation</span>
+[#21](https://github.com/andrewendlinger/xmris/issues/21)
 [#22](https://github.com/andrewendlinger/xmris/issues/22)
 ::::
 
@@ -227,10 +202,9 @@ comes next. [#21](https://github.com/andrewendlinger/xmris/issues/21)
 
 03 · A data model written down
 
-Which dimensions, coordinates and attributes make an object an xmris FID or spectrum — and what a
-function may assume about one it is handed. The schema is what lets other packages target xmris
-rather than guess at it; with 02 and 02b fixing what the record and the constants look like, it
-is unblocked and next in line.
+Which dimensions, coordinates and attributes make an object an xmris FID or spectrum — the
+schema other packages target instead of guessing at. Chapter two is the fit-result Dataset.
+Unblocked by 02 and 02b, next in line.
 [#28](https://github.com/andrewendlinger/xmris/issues/28)
 ::::
 
@@ -239,42 +213,9 @@ is unblocked and next in line.
 
 04 · Core and extras
 
-`[fitting]` exists — does `[plotting]`? do vendors? Install lines are a one-way door: the extras
-boundary closes while the ground is still allowed to move, not after.
+`[fitting]` exists — does `[plotting]`? do vendors? Install lines are a one-way door: the
+boundary closes while the ground is still allowed to move.
 [#124](https://github.com/andrewendlinger/xmris/issues/124)
-::::
-
-::::{div}
-:class: roadmap-item
-
-05 · The fit schema, and the fork beneath it
-
-The fit result — one Dataset carrying data, model, residual, parameters and uncertainties — is
-the contract a second fitter would slot into, so it gets frozen deliberately rather than by
-accident. And the liability underneath gets named: today's fitter rides `pyamares-xmris`, a
-self-maintained fork on the critical path, whose exit strategy — upstream, maintain, or replace —
-has never been written down.
-::::
-
-::::{div}
-:class: roadmap-item
-
-06 · The preprocessing middle
-
-The vocabulary declares `average` and `coil`, the Bruker loader emits them, and no function
-consumes them: averaging, coil combination and frequency-drift alignment are the unclaimed gap
-between load and fit. Does xmris own that middle — the physics-aware, lineage-recording versions,
-not the one-line mean — or say honestly that it does not?
-::::
-
-::::{div}
-:class: roadmap-item
-
-07 · The auto-convert default
-
-Today a domain-mismatched call is converted silently by default, while the option's own docstring
-recommends strict mode for quantitative work. Flipping a default after 1.0 is a breaking change,
-so it gets decided now, while it is cheap.
 ::::
 
 ::::{div}
@@ -282,9 +223,8 @@ so it gets decided now, while it is cheap.
 
 08 · Accessor parity
 
-A free function and its `.xmr` method can drift apart today — signatures, defaults, docstrings.
-The fix is mechanical (an introspection test, a registration decorator, or codegen); the decision
-is which mechanism, and it retires a whole class of bug at once.
+A free function and its `.xmr` method can drift apart — signatures, defaults, docstrings. The
+decision is the mechanism that makes drift impossible.
 [#62](https://github.com/andrewendlinger/xmris/issues/62)
 [#102](https://github.com/andrewendlinger/xmris/issues/102)
 ::::
@@ -294,8 +234,8 @@ is which mechanism, and it retires a whole class of bug at once.
 
 09 · Vendor IO
 
-How much loading xmris owns — "array plus params in, labeled DataArray out", or real file
-readers — and whether NIfTI-MRS becomes the common on-ramp instead of N bespoke loaders.
+How much loading xmris owns — and whether NIfTI-MRS becomes the common on-ramp instead of N
+bespoke loaders.
 [#125](https://github.com/andrewendlinger/xmris/issues/125)
 [#46](https://github.com/andrewendlinger/xmris/issues/46)
 ::::
@@ -355,11 +295,8 @@ listing [#66](https://github.com/andrewendlinger/xmris/issues/66)
 
 Committed, but not built.
 
-v0.8 lands the code the decision board unblocks — roughly a third of the tracker waits there —
-and the decisions resolve together in one release rather than leaking across several.
-
-v0.9 then turns to everything a stranger needs that today requires reading the source, or knowing
-the author. Its exit criterion is the JOSS submission.
+v0.8 lands the code the decision board unblocks; v0.9 turns to what a stranger needs, and the
+JOSS submission is its definition of done.
 ::::
 
 ::::{div}
@@ -374,6 +311,18 @@ A full review-and-simplify pass runs first, so its findings feed the decisions s
 
 `simulate_fid` learns to stack — the `xr.concat` boilerplate five pages currently teach becomes
 one argument [#113](https://github.com/andrewendlinger/xmris/issues/113)
+::::
+
+::::{div}
+:class: roadmap-item
+
+The preprocessing middle gets claimed
+
+The gap between load and fit — averaging that aligns before it means, coil combination,
+frequency-drift correction — becomes xmris code: the physics-aware, lineage-recording versions,
+not the one-line mean. The vocabulary's `average` and `coil` dimensions finally get their
+consumers; drafts exist and will be ported.
+[#132](https://github.com/andrewendlinger/xmris/issues/132)
 ::::
 
 ::::{div}
@@ -415,13 +364,8 @@ cites 0.x software, so *citable* does not wait for *frozen*.
 
 Direction, not commitment.
 
-This is what xmris is being built *toward* — held loosely on purpose. These may arrive in a
-different form, in a different order, or not at all; the rail fades here because the confidence
-does, and the decision board above is allowed to rewrite any of it.
-
-They are on the page anyway, because a roadmap that only lists the safe things is not telling you
-where it is going. If your work depends on one of them, say so in the tracker: that is the main
-way something moves up a band.
+Where xmris is headed, held loosely — these may arrive in a different form, in a different order,
+or not at all.
 ::::
 
 ::::{div}
@@ -486,7 +430,7 @@ wording of that refusal, and the fate of the unused k-space vocabulary, is decis
 <span style="color: gray; font-size: 0.9em;">A snapshot taken 2026-08-03 · the
 [milestones](https://github.com/andrewendlinger/xmris/milestones) are the live source</span>
 
-Forty-one issues are open, and their distribution is the argument for the release line above: the
+Forty-four issues are open, and their distribution is the argument for the release line above: the
 largest cluster is not missing features — it is unmade decisions, plus the work standing behind
 them. Two of those decisions are now made (02 and 02b on the board); their tracker issues stay
 open until the implementations land, with
@@ -497,24 +441,22 @@ open until the implementations land, with
 |---|---|---|
 | Design decisions — the board above | [#62](https://github.com/andrewendlinger/xmris/issues/62) [#64](https://github.com/andrewendlinger/xmris/issues/64) [#65](https://github.com/andrewendlinger/xmris/issues/65) [#66](https://github.com/andrewendlinger/xmris/issues/66) [#88](https://github.com/andrewendlinger/xmris/issues/88) [#113](https://github.com/andrewendlinger/xmris/issues/113) [#124](https://github.com/andrewendlinger/xmris/issues/124) [#125](https://github.com/andrewendlinger/xmris/issues/125) | v0.8 |
 | Blocked behind them | [#21](https://github.com/andrewendlinger/xmris/issues/21) [#22](https://github.com/andrewendlinger/xmris/issues/22) [#23](https://github.com/andrewendlinger/xmris/issues/23) [#28](https://github.com/andrewendlinger/xmris/issues/28) [#34](https://github.com/andrewendlinger/xmris/issues/34) [#71](https://github.com/andrewendlinger/xmris/issues/71) [#102](https://github.com/andrewendlinger/xmris/issues/102) [#107](https://github.com/andrewendlinger/xmris/issues/107) | v0.8 · the schema #28 in v0.9 |
-| The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) | v0.7 |
-| Quality & tooling | [#87](https://github.com/andrewendlinger/xmris/issues/87) [#108](https://github.com/andrewendlinger/xmris/issues/108) [#111](https://github.com/andrewendlinger/xmris/issues/111) [#117](https://github.com/andrewendlinger/xmris/issues/117) [#127](https://github.com/andrewendlinger/xmris/issues/127) | v0.8 – v0.9 |
+| The tag itself | [#10](https://github.com/andrewendlinger/xmris/issues/10) [#115](https://github.com/andrewendlinger/xmris/issues/115) [#116](https://github.com/andrewendlinger/xmris/issues/116) [#122](https://github.com/andrewendlinger/xmris/issues/122) [#131](https://github.com/andrewendlinger/xmris/issues/131) | v0.7 |
+| Quality & tooling | [#87](https://github.com/andrewendlinger/xmris/issues/87) [#108](https://github.com/andrewendlinger/xmris/issues/108) [#111](https://github.com/andrewendlinger/xmris/issues/111) [#117](https://github.com/andrewendlinger/xmris/issues/117) [#127](https://github.com/andrewendlinger/xmris/issues/127) [#133](https://github.com/andrewendlinger/xmris/issues/133) | v0.8 – v0.9 |
 | The front door | [#27](https://github.com/andrewendlinger/xmris/issues/27) [#46](https://github.com/andrewendlinger/xmris/issues/46) [#67](https://github.com/andrewendlinger/xmris/issues/67) [#119](https://github.com/andrewendlinger/xmris/issues/119) [#120](https://github.com/andrewendlinger/xmris/issues/120) [#121](https://github.com/andrewendlinger/xmris/issues/121) [#126](https://github.com/andrewendlinger/xmris/issues/126) | v0.9 |
-| Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#128](https://github.com/andrewendlinger/xmris/issues/128) | v0.9 |
+| Correctness & capability | [#29](https://github.com/andrewendlinger/xmris/issues/29) [#31](https://github.com/andrewendlinger/xmris/issues/31) [#80](https://github.com/andrewendlinger/xmris/issues/80) [#82](https://github.com/andrewendlinger/xmris/issues/82) [#83](https://github.com/andrewendlinger/xmris/issues/83) [#84](https://github.com/andrewendlinger/xmris/issues/84) [#128](https://github.com/andrewendlinger/xmris/issues/128) [#132](https://github.com/andrewendlinger/xmris/issues/132) | v0.9 |
 | Space & scale | [#4](https://github.com/andrewendlinger/xmris/issues/4) [#25](https://github.com/andrewendlinger/xmris/issues/25) | Horizon |
 
 The decisions are not a flat list. The spine below is the board's dependency order — the decided
-pair feeds the data model first, and the license decision quietly gates the plug-in promise:
+pair feeds the data model first, and the core/extras boundary and the plug-in promise decide each
+other:
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart TD
     d02["02 lineage record ✓"] --> d03["03 data model"]
     d02b["02b constants ✓"] --> d03
-    d06["06 preprocessing middle"] --> d03
-    d06 --> d15["15 MRI non-goal"]
-    d01["01 license"] --> d12["12 plug-in promise"]
-    d04["04 core & extras"] <--> d12
+    d04["04 core & extras"] <--> d12["12 plug-in promise"]
     d04 --> d09["09 vendor IO"]
     d08["08 accessor parity"] --> d11["11 test architecture"]
 ```
@@ -532,7 +474,9 @@ This page is written by hand, and it is the argument rather than the record: the
 [milestones](https://github.com/andrewendlinger/xmris/milestones) hold what is actually in each
 release, and they move faster. A milestone here earns its band from the state of the work, so if
 the two disagree, the tracker is right and this page is stale — say so by
-[opening an issue](https://github.com/andrewendlinger/xmris/issues/new).
+[opening an issue](https://github.com/andrewendlinger/xmris/issues/new). The same route works
+forward: if your work depends on something sitting in the horizon band, say so there too, because
+that is the main way something moves up a band.
 
 The decision board keeps its paper on this site: each decided card links an exploration notebook,
 frozen the day the decision lands, and an aimed-solution notebook that becomes the spec the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 (roadmap)=
 # Where xmris is going
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-03</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-04</span>
 
 ::::{div}
 :class: roadmap-hero
@@ -15,8 +15,8 @@ The direction
 :::{div}
 :class: roadmap-statement
 
-The same lines that process one spectrum will process a whole spectroscopic-imaging dataset —
-and the result can answer for every step that produced it.
+Metadata neatly tucked away, the same lines that process a single FID process an N-D volume of
+them.
 :::
 
 :::{div}
@@ -178,7 +178,8 @@ decided in writing before its code is written.
 02 · The lineage record <span class="roadmap-status roadmap-status--decided">decided 2026-08-02</span>
 
 Processing history becomes one `xmr_history` record — what each operation actually applied, in
-order. Physics attrs stay flat and typed.
+order, so the result can answer for every step that produced it. Physics attrs stay flat and
+typed.
 
 <span class="roadmap-progress">[explored](#attrs-nb) ✓ → decided ✓ → <strong>next: solution spec</strong> → implementation</span>
 [#64](https://github.com/andrewendlinger/xmris/issues/64)


### PR DESCRIPTION
Closes #116.

## The driving question

A reader lands on the docs and asks: *where is this going, and can I depend on it?* The tracker
answers neither — 44 open issues carry no ordering a stranger can read. This PR is the answer: a
roadmap page that owns the **argument and the ordering**, with GitHub milestones (applied after
this page is approved) owning the item lists, so the two cannot disagree about whose job is what.

## The shape

Five bands descending in confidence off one decaying rail — Shipped · In motion (v0.7) · the
decision board (v0.8) · Committed, but not built (v0.8/v0.9) · Horizon — built with `{div}` +
`custom.css` only (the visual design was reviewed separately as the #116 draft).

## The decision board

The near horizon is a board of argued decisions, each decided **in writing before its code is
written**, ordered by irreversibility × how soon it blocks:

- **02 (lineage record) and 02b (physical constants) are decided**, and each card carries its
  paper trail: a frozen exploration notebook under `docs/decisions/` plus a progress line
  (explored ✓ → decided ✓ → next: solution spec → implementation).
- **Three former cards were retired as non-decisions** — fit schema (→ #133/#28), preprocessing
  middle (→ #132, now a v0.9 card), auto-convert default (→ #131, resolved wording fix in v0.7).
- **The license card is gone because the decision shipped** — BSD-3-Clause, #130.

## The release line

- **v0.7 — the tag that makes `main` installable.** Gated on #122; the changelog (#10) starts
  here.
- **v0.8 — the architecture settles.** The decision board resolves, and it is named publicly as
  the last release allowed to move the ground under a user.
- **v0.9 — ready for a stranger.** Onboarding, the schema (#28), the preprocessing middle
  (#132), with the **JOSS submission as the exit criterion**.
- **Horizon.** 1.0 as stated criteria (deliberately no milestone), MRSI as the confirmed
  destination, explicit non-goals.

The landscape section closes the page: the tracker split table (a dated snapshot pointing at the
live milestones), the board's dependency spine as a mermaid graph, and the standing rule that
when page and tracker disagree, the tracker is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)## The fold-in (2026-08-04)

The tracker now carries everything the co-design sessions produced, so this page needs no local
state to be picked up cold:

- **Resolutions recorded on GitHub**: decision 02 on #64 (the `xmr_history` record, with the 02b
  amendment), decision 02b on #21 (re-scoped and retitled to the `xmr_acquisition` container
  coordinate), with re-scope notes on #22/#23 and settled inputs posted to #28.
- **Every open decision issue got its audit delta** — evidence, entanglements, option space —
  as a comment: #124 (both halves), #125, #62, #65, #66, #133, #67.
- **Every decision card now links an issue**: 13 → #133, 14 → #67, 15 → #136 (the MRI non-goal,
  newly filed).
- **Milestones v0.7 / v0.8 / v0.9 exist** and own release membership (26 issues assigned; the
  Horizon is deliberately unmilestoned). The band version chips on the page link them.
- The decision notebooks' footers point at the board and the tracker instead of untracked
  session scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)