### PR TITLE
ci: publish the docs site from workflow artifacts, not a committed branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,63 +5,53 @@ on:
     branches: [main]
   # Build (execute) the docs on PRs too, so a docs-breaking or kernel-hanging
   # dependency is caught pre-merge instead of only surfacing after landing on
-  # main -- and publish the result as a preview the reviewer can read.
-  # `closed` is not optional: it is the event that removes a merged/abandoned
-  # PR's preview directory from the gh-pages branch.
+  # main -- and publish the result as a preview the reviewer can read. There is
+  # no `closed` action: a preview is not deleted, it simply stops being an input
+  # to the next deploy.
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, closed]
-  # External link rot is checked weekly, off the PR path: a dead third-party URL
-  # is no reason to redden a PR that never touched it.
+    types: [opened, synchronize, reopened]
+  # Weekly, off the PR path. Three jobs at once: external link rot is checked
+  # (a dead third-party URL is no reason to redden a PR that never touched it),
+  # main's artifact is refreshed so it can never expire, and the site is
+  # republished -- which sweeps the preview of any pull request closed while
+  # nothing else happened to deploy.
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
-# Supersede a stale build for the same PR (each one is ~4 min and ends in a
-# publish, so racing two of them wastes minutes and can land the older site).
-# Keyed per PR, falling back to the ref, so a main deploy is never cancelled by
-# PR activity.
+# Supersede a stale build for the same PR (each one is ~4 min, so racing two of
+# them wastes minutes and can publish the older site). Keyed per PR, falling
+# back to the ref, so a main deploy is never cancelled by PR activity.
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Minimal default token; only the build job elevates, and only far enough to
-# push the built site and comment the preview link.
+# Minimal default token; only `publish` elevates, and only far enough to deploy
+# the site and comment the preview link.
 permissions:
   contents: read
 
 jobs:
-  # Runs on PR + push. Executes every notebook via `myst build --execute`, which
-  # is the check that a docs dependency didn't break/hang the build, then
-  # publishes: main to the gh-pages root, a PR to its own subdirectory.
+  # Executes every notebook via `myst build --execute`, which is the check that
+  # a docs dependency didn't break/hang the build, then hands the result to
+  # `publish` as an artifact. Nothing here writes to a branch: built output is
+  # derived, never stored.
   build:
-    # Everything but the weekly link check. A manual run rebuilds and republishes
-    # the live site, which is the only way to recover from a bad deploy without
-    # pushing a commit to main.
-    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     # A healthy build is ~2 min. This bound is the key guard: it turns a hung
     # kernel into a fast, visible failure instead of a 6h burn at GitHub's ceiling.
     timeout-minutes: 20
-    permissions:
-      contents: write       # push the built site to the gh-pages branch
-      pull-requests: write  # comment the preview link
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
 
-      # The expensive steps are skipped on `closed` -- there is nothing to build,
-      # only a preview to remove. Guarding the STEPS rather than the job keeps
-      # this job reporting on every PR event, which matters because its name is a
-      # required status check.
       - name: Setup uv
-        if: github.event.action != 'closed'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Install system dependencies
-        if: github.event.action != 'closed'
         run: |
           sudo apt-get update
           sudo apt-get install -y libegl1
@@ -69,11 +59,9 @@ jobs:
       - name: Install dependencies
         # Syncing the WHOLE project ensures 'xmris' is installed in editable
         # mode so the notebooks can find it during execution.
-        if: github.event.action != 'closed'
         run: uv sync --all-extras
 
       - name: Build MyST Site
-        if: github.event.action != 'closed'
         env:
           # BASE_URL is baked into every asset path at build time, so a preview
           # has to be built for the subdirectory it will be served from --
@@ -84,42 +72,136 @@ jobs:
           cd docs
           uv run myst build --html --execute --strict
 
-      - name: Disable Jekyll
-        # gh-pages is served from a BRANCH, which runs Jekyll -- and Jekyll drops
-        # every _-prefixed path, which here means build/_assets, build/_shared and
-        # build/routes/_index-*: the entire CSS and JS of the site. Neither deploy
-        # action below writes this file, so the build must.
-        #
-        # Root deploys only: Pages honours .nojekyll at the published root, so a
-        # copy inside pr-preview/pr-N/ does nothing -- and worse, it is stranded
-        # there forever, because the removal rsync adds `--exclude .nojekyll`
-        # whenever the (empty) source folder lacks one.
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: touch docs/_build/html/.nojekyll
+      - name: Upload the built site
+        # Fork PRs get a read-only token and never publish: their HTML would
+        # otherwise be served from our own origin on github.io. They still build
+        # above as a smoke test -- a contributor's first PR should not open with
+        # a red X it has no way to fix.
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@v7
+        with:
+          # These two names are the contract with the publish job below.
+          name: ${{ github.event_name == 'pull_request' && format('preview-pr-{0}', github.event.number) || 'site-main' }}
+          path: docs/_build/html
+          # Retention is the store now that git isn't. 90 days for the live
+          # site (the weekly run keeps it far younger than that); 14 for a
+          # preview, which is slack for a long-lived PR, not an archive.
+          retention-days: ${{ github.event_name == 'pull_request' && 14 || 90 }}
+          if-no-files-found: error
+
+  # Recomputes the published site from present state -- main's build plus one
+  # artifact per currently open pull request -- and deploys it whole. Because
+  # that is a pure function of what is open now, a closed PR's preview vanishes
+  # on the next deploy with no cleanup step to miss.
+  publish:
+    needs: build
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Deployments queue instead of racing. The per-PR group at the top of this
+    # file still cancels redundant BUILDS; only publishing is serialized, since
+    # two overlapping deploys can land the one assembled first.
+    concurrency:
+      group: pages-publish
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write          # create the Pages deployment
+      id-token: write       # the OIDC token deploy-pages exchanges for it
+      actions: read         # list and download the build artifacts
+      contents: read
+      pull-requests: write  # the sticky preview comment
+    steps:
+      - name: Assemble the site from current state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Newest non-expired artifact of a given name -> the run that produced
+          # it. `gh run download` wants a run id, and the artifacts API is the
+          # only place that mapping exists. Assembly uses nothing but `gh`: a
+          # third-party deploy action is one more dependency a JOSS reviewer
+          # cannot see the far side of.
+          newest_run() {
+            gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$1&per_page=100" \
+              --jq '.artifacts | map(select(.expired | not)) | sort_by(.created_at)
+                    | reverse | .[0].workflow_run.id // empty'
+          }
+
+          main_run=$(newest_run site-main || true)
+          if [ -z "$main_run" ]; then
+            # Fail loud rather than rebuilding: a Pages deployment is atomic, so
+            # a failed publish leaves the previous site serving -- never an
+            # empty one -- and a silent rebuild would hide that the artifact
+            # chain broke.
+            echo "::error::No usable 'site-main' artifact. The live site is unchanged; recover with: gh workflow run deploy.yml"
+            exit 1
+          fi
+          mkdir -p _site
+          gh run download "$main_run" --name site-main --dir _site
+
+          # The previews are a pure function of what is open RIGHT NOW.
+          open_prs=$(gh pr list --state open --json number --jq '.[].number' || true)
+          for pr in $open_prs; do
+            preview_run=$(newest_run "preview-pr-$pr" || true)
+            if [ -z "$preview_run" ]; then
+              echo "PR #$pr: no preview artifact (fork, or its build is still running) -- skipped"
+              continue
+            fi
+            mkdir -p "_site/pr-preview/pr-$pr"
+            if ! gh run download "$preview_run" --name "preview-pr-$pr" \
+                 --dir "_site/pr-preview/pr-$pr"; then
+              echo "PR #$pr: preview download failed -- skipped"
+              rm -rf "_site/pr-preview/pr-$pr"
+            fi
+          done
+
+          # Log the payload every time, so "the deploy is getting heavy" is a
+          # series rather than a single sample. It scales with open PRs now:
+          # BASE_URL is baked in, so previews barely share bytes with the root.
+          {
+            echo "### Assembled site"
+            echo "- $(find _site -type f | wc -l | tr -d ' ') files, $(du -sh _site | cut -f1)"
+            echo "- previews: $(ls _site/pr-preview 2>/dev/null | tr '\n' ' ')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: docs/_build/html
-          branch: gh-pages
-          clean-exclude: pr-preview/  # never wipe a live preview
-          force: false                # rebase instead of force-pushing, so a
-                                      # concurrent preview write is not clobbered
+        id: deployment
+        uses: actions/deploy-pages@v5
 
-      - name: Deploy PR preview
-        # Fork PRs get a read-only token, so they cannot publish. They still
-        # build above as a smoke test -- a contributor's first PR should not open
-        # with a red X it has no way to fix.
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: docs/_build/html
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          action: auto  # deploy on open/reopen/sync, remove on close
+      - name: Comment the preview link
+        # Sticky: one comment per PR, edited in place on every push. This is the
+        # one thing the retired pr-preview-action gave us for free.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.number }}
+          SITE: ${{ steps.deployment.outputs.page_url }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Heredoc, not an inline multi-line string: YAML indentation would
+          # otherwise survive into the comment, where four leading spaces make
+          # Markdown render the paragraph as a code block.
+          body=$(cat <<EOF
+          📖 **Docs preview:** ${SITE%/}/pr-preview/pr-$PR/
+
+          Fully executed, from \`${SHA:0:7}\`. It leaves the site on the first deploy after this pull request closes — nothing to clean up.
+          EOF
+          )
+          gh pr comment "$PR" --edit-last --create-if-none --body "$body"
 
   # Weekly (and on demand): the same build with external link checking. Kept out
   # of `build` so it can never gate a PR, and skips --execute since links are

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -67,8 +67,10 @@ reach `main`: it runs under a 20-minute ceiling, so a stuck kernel fails visibly
 six hours. And `--strict` is load-bearing — without it mystmd reports its errors and *still* exits 0,
 which is how a dead link once survived on the site for months.
 
-A fifth job, `links`, checks external URLs — but it runs **weekly on a schedule**, not on your pull
-request, because a third-party URL rotting is not your fault and should not redden your branch.
+Two further jobs report on the pull request without gating it. `publish` assembles and deploys the
+site — that is where your preview comes from — and `links` checks external URLs **weekly on a
+schedule** rather than on your branch, because a third-party URL rotting is not your fault and
+should not redden your pull request.
 
 (contribute-pr-preview)=
 ## 4. Read your change on its own website
@@ -89,18 +91,18 @@ implementation begins.
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart LR
     P["Push to the PR"] --> B["Build: execute + strict"]
-    B --> V["Publish to pr-preview/pr-N"]
-    V --> C["Bot comments the link"]
-    C --> M["Merge"]
-    M --> R["Site rebuilds from main"]
-    M --> X["Preview removed"]
+    B --> U["Upload preview-pr-N"]
+    U --> A["Assemble: main + every open PR"]
+    A --> D["Deploy the whole site"]
+    D --> C["Bot comments the link"]
+    M["Merge or close"] --> X["Dropped from the next assembly"]
 ```
 
-Two caveats. The link lags the green check by a minute or two, because GitHub then runs its own
-Pages deployment on top of ours. And a pull request from a **fork** gets no preview: its token is
-read-only by design, so the build still runs as a smoke test but cannot publish. That is not a
-failure — an external contributor's first pull request should not open with a red X they have no way
-to fix.
+Two caveats. The link arrives a couple of minutes after the green `build` check, because the deploy
+runs after it — the comment is posted once the site is actually live, so the link never points at
+nothing. And a pull request from a **fork** gets no preview: its token is read-only by design, so
+the build still runs as a smoke test but cannot publish. That is not a failure — an external
+contributor's first pull request should not open with a red X they have no way to fix.
 
 (contribute-pr-green)=
 ## 5. Drive it green, then hand off
@@ -120,10 +122,13 @@ Cutting a release is a separate, maintainer-run workflow ([Publishing](#contribu
 (contribute-pr-deployment)=
 ## How the documentation reaches the web
 
-Deployment is continuous and has nothing to do with releases: every merge to `main` rebuilds the
-site and publishes it to the `gh-pages` branch root, which GitHub Pages serves. Pull-request
-previews live on that same branch under `pr-preview/pr-N/`, which is why merging your pull request
-also deletes its preview.
+Deployment is continuous and has nothing to do with releases, and the built site is never stored
+anywhere: each deploy reassembles it from scratch — `main`'s most recent build, plus one artifact
+per *currently open* pull request — and publishes that whole tree to GitHub Pages. Your preview is
+on the site because your pull request is open, and it leaves on the first deploy after it closes.
+Nothing removes it; it simply stops being an input. A weekly scheduled run performs the same
+assembly, which keeps `main`'s build fresh and sweeps the preview of a pull request that closed
+during a quiet week. ([The diary entry](#diary-docs-previews) tells why it works this way.)
 
 The one subtlety worth internalising if you ever touch the workflow: mystmd bakes the site's base
 path into every asset link **at build time**, so a preview has to be built for the subdirectory it
@@ -137,7 +142,10 @@ will be served from. That is what this step does, quoted from the workflow itsel
 ```
 
 To rebuild and republish the site without merging anything — after a failed deploy, say — run the
-**Documentation** workflow manually from the Actions tab (`workflow_dispatch`).
+**Documentation** workflow manually from the Actions tab (`workflow_dispatch`). That is also the
+recovery when `publish` fails with `No usable 'site-main' artifact`: a Pages deployment is atomic,
+so the previous site keeps serving until a good one replaces it, and the failure is loud rather
+than destructive.
 
 ```{code-cell} python
 :tags: [remove-cell]
@@ -169,7 +177,7 @@ assert "uv run myst build --html --execute --strict" in text, "end-at anchor no 
 | `build` red, `Could not find DOI "…" from doi.org` | DOI metadata is resolved over the network unless it is frozen in `docs/myst.doi.bib` | `cd docs && uv run myst build --doi-bib`, then commit `myst.doi.bib` |
 | `build` red, `Site has N error(s), stopping build` | A cross-reference, directive or link mystmd could not resolve | Reproduce with the `build` command above; the error names the file and line |
 | `build` red only in CI, green locally | Stale `docs/_build` cache locally | `rm -rf docs/_build` and rebuild |
-| Preview link 404s | GitHub's own Pages deployment has not finished, or the pull request is from a fork | Wait a minute; for forks, ask a maintainer to read the branch locally |
+| Preview link 404s | The `publish` job has not finished deploying yet, or the pull request is from a fork — forks never publish | Wait for `publish` to go green; for forks, ask a maintainer to read the branch locally |
 | Merge button blocked with everything green | The branch is out of date in a way GitHub cannot merge, or a check never reported | Check the merge box for which requirement is unmet; rebase only if there is a real conflict |
 
 :::{seealso}

--- a/docs/diary/2026-07-25-docs-previews.md
+++ b/docs/diary/2026-07-25-docs-previews.md
@@ -129,9 +129,10 @@ the same shape. Moving *onto* the branch: a branch-served site builds on the nex
 branch, and the last `gh-pages` push predated the flip, so the old artifact kept serving with
 `pages/builds/latest` returning 404 and no workflow run to look at —
 `gh api -X POST repos/OWNER/REPO/pages/builds` bootstraps it. Moving *off* it: the `github-pages`
-environment still restricts deployments to `gh-pages` and `main`, so a pull request's deploy is
-rejected — "branch is not allowed to deploy" — before a byte moves, unless a wildcard policy is
-added first.
+environment restricts which refs may deploy, so a pull request is rejected — `Branch
+"refs/pull/142/merge" is not allowed to deploy to github-pages` — before a byte moves. The rule that
+admits it must be spelled `refs/pull/*/merge`, and a plain `*` will not do: policies are matched
+against `GITHUB_REF` with `fnmatch` semantics, where a wildcard never crosses a `/`.
 :::
 
 :::{dropdown} Why not Cloudflare Pages or Netlify?
@@ -150,9 +151,6 @@ page is the path of least resistance.
 :::
 
 :::{attention} Assumptions to verify
-- The wildcard deployment policy on the `github-pages` environment is what unblocks pull-request
-  deploys — without it the first preview fails on the branch policy, not on anything about
-  artifacts.
 - No rebuild fallback is needed when `main`'s artifact is missing: a Pages deployment is atomic, so
   failing loudly leaves the previous site serving rather than an empty one.
 - The weekly rebuild plus 90-day retention keeps that artifact warm enough that expiry is never

--- a/docs/diary/2026-07-25-docs-previews.md
+++ b/docs/diary/2026-07-25-docs-previews.md
@@ -1,62 +1,84 @@
 (diary-docs-previews)=
 # Every pull request publishes the page it changes
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-25 · #112, #114</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-10 · #112, #114</span>
 
-The [`dev-diary` workflow](#diary-about-how) stops the work until a draft entry has been read *on
-the rendered site* — and the only way to read it there was to start a blocking local server and wait
-for it to execute every notebook. Meanwhile CI already built the whole site on every pull request,
-executed every cell, and threw it away: the reviewer's copy lived two minutes on a runner. For a
-project whose docs are its tests and its review surface, the one thing a pull request should hand
-you was the one thing it never had — a link.
+A preview link was the one thing a pull request never handed you, and getting one turned out to be
+mostly a matter of not deleting a build CI already paid for: the reviewer's copy used to live two
+minutes on a runner and then vanish. Three weeks later the bill arrived. The branch carrying the
+site is 103 MB across 3,079 files, its history 674 MB of unique blobs that every clone pays;
+GitHub's own build of that branch has crept from 28 s to 494 s and errored on three of its last ten
+runs; the live site is serving a layout two merges old; and the preview for a pull request merged
+four days ago is still published. Four bugs, one cause — **the published site is versioned state**.
 
 :::{important}
-Every pull request publishes its own executed build to the `gh-pages` branch under
-`pr-preview/pr-N/`, and comments the link on the pull request.
+Built output is derived, never stored. Every deploy recomputes the whole site from `main`'s build
+plus one artifact per *currently open* pull request, and `gh-pages` goes away.
 :::
 
-(diary-docs-previews-shape)=
-## Two publishers, one branch
+(diary-docs-previews-derived)=
+## Nothing to clean up, because nothing accumulates
 
-The expensive half was already paid for, so this was mostly a matter of not deleting it. One branch
-carries both the live site and every preview: `main` publishes to the root
-(`JamesIves/github-pages-deploy-action` with `clean-exclude: pr-preview/`), a pull request to its own
-subdirectory (`rossjrw/pr-preview-action`), and closing it takes that subdirectory away.
+Write the published site as a function of what is open *right now* and the entire class of failures
+above stops being reachable:
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart LR
-    B["Executed build"] --> P{"Which event?"}
-    P -->|"push to main"| R["gh-pages root"]
-    P -->|"PR opened or updated"| V["gh-pages: pr-preview/pr-N"]
-    P -->|"PR closed"| X["preview removed"]
-    R --> S["the live site"]
-    V --> C["link commented on the PR"]
+    E["Any deploy event"] --> Q["Ask GitHub what is open"]
+    Q --> M["main's build artifact"]
+    Q --> P["one artifact per open PR"]
+    M --> A["Assemble the site"]
+    P --> A
+    A --> D["Deploy it whole"]
 ```
 
-A preview is not a lighter build: it is the same executed run the live site gets, so a notebook that
-hangs or dies there would have done the same on `main`. What makes that affordable is that the
-`.github/workflows/deploy.yml` build step is unchanged — only its destination is new. Two details in
-that step are load-bearing, and both were guesses in the draft that turned out to hold:
+A closed pull request's preview is not removed; on the next deploy it is simply no longer an input.
+That one sentence covers the preview still live four days after its merge, the `.nojekyll` files
+stranded in closed pull requests' directories, and the branch that only ever grew — all three were
+incremental-cleanup bugs, and there is no increment left to clean.
 
-`BASE_URL` is baked into every asset path at build time, so a preview must be built for the
-subdirectory it will be served from; building for `/xmris` and serving from
-`/xmris/pr-preview/pr-N/` 404s every stylesheet. And a branch-served Pages site runs Jekyll, which
-silently drops every `_`-prefixed path — here `build/_assets`, `build/_shared` and
-`build/routes/_index-*`, which is all of the site's CSS and JS. Neither deploy action writes a
-`.nojekyll`, so the build does.
+The store becomes GitHub's artifact retention rather than git: 90 days for `main`'s build, 14 for a
+preview, with the weekly link-check run extended to rebuild and republish. That keeps the live
+artifact under a week old and doubles as the sweep, bounding how long a closed pull request's
+preview can linger when nothing else happens to deploy.
 
 :::{warning}
-`.nojekyll` is honoured at the **published root only**. Writing one into each preview directory
-looked harmless and was not: the removal deploys an *empty* folder, and the action adds
-`--exclude .nojekyll` to its delete-rsync whenever the source folder lacks one — so exactly that file
-outlived every closed pull request. It is now written for root deploys only.
+Publishing now runs on pull-request events, so a branch's workflow writes to the live deployment.
+`main`'s content always comes from `main`'s own artifact, so a broken branch can corrupt only its
+own subdirectory — but the fork guard stops being a token limitation and becomes a security
+boundary: a fork's HTML would otherwise be served from our origin on `github.io`. It is still
+design rather than evidence; no fork pull request has arrived to exercise it.
+:::
+
+(diary-docs-previews-baseurl)=
+## What survives the move, and what it costs
+
+Two details of the build step are unchanged and still load-bearing. `BASE_URL` is baked into every
+asset path at build time, so a preview must be built for the subdirectory it will be served from;
+building for `/xmris` and serving from `/xmris/pr-preview/pr-N/` 404s every stylesheet. That is
+also why the site refuses to compress — only 183 of 1,269 files across two builds are
+byte-identical, so `plotly-5BWH43UK.js` at 4.77 MB is a fresh blob per preview.
+
+Deleting the branch stops that from *accumulating*; it does not shrink a single copy, and the
+assembled site now scales with the number of open pull requests instead. Per-copy weight is
+therefore the only thing left that grows a deploy — today ~12 MB of it is executed-notebook figure
+output, which the move to vector figures should largely dissolve.
+
+:::{dropdown} The `.nojekyll` trap, now historical
+A branch-served Pages site runs Jekyll, which silently drops every `_`-prefixed path — here
+`build/_assets`, `build/_shared` and `build/routes/_index-*`, which is all of the site's CSS and
+JS. Neither deploy action wrote a `.nojekyll`, so the build did — for the root only. Writing one
+into each preview directory looked harmless and was not: the removal deploys an *empty* folder, and
+the action adds `--exclude .nojekyll` to its delete-rsync whenever the source lacks one, so exactly
+that file outlived every closed pull request. A site served from a workflow artifact is published
+as-is, so both the file and its footgun are gone.
 :::
 
 (diary-docs-previews-layers)=
 ## Three enforcement layers, and how the third one bit
 
-Docs rules now have three enforcers, each because the one above it is blind to something:
+Docs rules have three enforcers, each because the one above it is blind to something:
 
 | Layer | Catches | Blind to |
 |---|---|---|
@@ -64,69 +86,78 @@ Docs rules now have three enforcers, each because the one above it is blind to s
 | `myst build --strict` | what the build *reports* and then exits 0 on anyway | its own warnings — a missed `literalinclude` anchor still only warns |
 | the preview | whether the page actually reads right | nothing a human declines to look at |
 
-That middle row is narrower than it sounds, and it matters: mystmd's `--strict` exits non-zero on
-**errors** only, never on warnings. So the quoted-source pins in
-[the Architecture Contract](#contract) stay load-bearing — a renamed decorator
-would still truncate a `literalinclude` with nothing but a warning to show for it.
+That middle row is narrower than it sounds: mystmd's `--strict` exits non-zero on **errors** only,
+never on warnings. So the quoted-source pins in [the Architecture Contract](#contract) stay
+load-bearing — a renamed decorator would still truncate a `literalinclude` with nothing but a
+warning to show for it.
 
-Turning that layer on also had a consequence nobody predicted. The first strict build on CI went red
-on a *valid* DOI:
+Turning that layer on had a consequence nobody predicted. The first strict build on CI went red on
+a *valid* DOI:
 
 ```text
 ⛔️ 03_plotting_1dfid.md:198 Could not find DOI "https://doi.org/10.1002/mrm.25568" from doi.org
 ```
 
-mystmd resolves every `doi.org` link against the network at build time. `--strict` had therefore
-quietly made the documentation build — and the deploy behind it — depend on doi.org being reachable
-from a GitHub runner. The fix is to stop asking: `myst build --doi-bib` freezes that metadata into
+mystmd resolves every `doi.org` link against the network at build time, so `--strict` had quietly
+made the documentation build — and the deploy behind it — depend on doi.org being reachable from a
+GitHub runner. The fix is to stop asking: `myst build --doi-bib` freezes that metadata into
 `docs/myst.doi.bib`, which only takes effect once *listed* in `myst.yml`'s `bibliography`, because
 declaring that key at all makes mystmd load only the files named there. A `check_docs.py` rule now
 errors on any `doi.org` link missing from the cache, so the next contributor to add one is told
-before CI is.
-
-The lesson generalises past DOIs: **a strict gate converts every latent network dependency in a build
-into a flaky failure**, and it fails on whichever pull request happens to be open at the time.
+before CI is. The lesson generalises past DOIs: **a strict gate converts every latent network
+dependency in a build into a flaky failure**, and it fails on whichever pull request happens to be
+open at the time.
 
 (diary-docs-previews-gate)=
 ## What the gate cost, and what it was worth
 
 A preview only helps if a red check can actually stop a merge, and none could: `main`'s ruleset
-contained a single `deletion` rule, so nothing — not the tests, not `Docs style` — was required.
-It now requires all four checks and a pull request, with zero approving reviews so a sole maintainer
+contained a single `deletion` rule, so nothing — not the tests, not `Docs style` — was required. It
+now requires all four checks and a pull request, with zero approving reviews so a sole maintainer
 can still merge their own work.
 
 Requiring a pull request broke exactly one thing, and instructively: the release flow ended with
-`git merge release/vX.Y.Z` and `git push origin main`. Routing that through a pull request instead
-exposes a second problem, because this repository squash-merges — a tag cut on the release branch
-would sit on a commit that never enters `main`'s history. So the order flipped: bump, merge, *then*
-tag the merged commit ([Publishing](#release-tag-publish)). Publishing itself never moved; the `v*`
-tag still triggers the matrix and the PyPI job.
+`git merge release/vX.Y.Z` and `git push origin main`. Routing that through a pull request exposes a
+second problem, because this repository squash-merges — a tag cut on the release branch would sit
+on a commit that never enters `main`'s history. So the order flipped: bump, merge, *then* tag the
+merged commit ([Publishing](#release-tag-publish)). Publishing itself never moved; the `v*` tag
+still triggers the matrix and the PyPI job.
+
+:::{warning}
+Changing where Pages gets its bytes is not self-starting, and the trap has now appeared twice in
+the same shape. Moving *onto* the branch: a branch-served site builds on the next push to that
+branch, and the last `gh-pages` push predated the flip, so the old artifact kept serving with
+`pages/builds/latest` returning 404 and no workflow run to look at —
+`gh api -X POST repos/OWNER/REPO/pages/builds` bootstraps it. Moving *off* it: the `github-pages`
+environment still restricts deployments to `gh-pages` and `main`, so a pull request's deploy is
+rejected — "branch is not allowed to deploy" — before a byte moves, unless a wildcard policy is
+added first.
+:::
 
 :::{dropdown} Why not Cloudflare Pages or Netlify?
 Both hand out preview URLs with no workflow YAML at all. The price is a vendor account and an API
 token in the repository's secrets — for a package heading into JOSS review, one more dependency a
-reviewer cannot see the far side of. GitHub Pages already hosts the site; a preview should not add a
-second host.
+reviewer cannot see the far side of. GitHub Pages already hosts the site; a preview should not add
+a second host. The same stance is why the assembly step uses nothing but `gh` and the two
+first-party Pages actions, rather than the third-party deploy actions it replaces.
 :::
 
 :::{dropdown} Why not just download the build artifact?
-It was the smallest possible change — delete one `if:` and the artifact survives. But a 52 MB zip you
-download, unpack and serve locally is not a link, and a review gate only works when reading the page
-is the path of least resistance.
+That was the smallest possible change back when previews were added — delete one `if:` and the
+artifact survives. Artifacts are now the transport, but the conclusion is unchanged: a 52 MB zip
+you download, unpack and serve locally is not a link, and a review gate only works when reading the
+page is the path of least resistance.
 :::
 
-(diary-docs-previews-changed)=
-## What changed from the plan
-
-Two of the draft's assumptions were wrong in ways worth keeping, because both would cost an hour to
-rediscover:
-
-- **The draft assumed the fork guard and the merge-time write race were the risks worth naming.**
-  Neither has bitten: the `closed` cleanup and the `main` deploy fired simultaneously on #112 and
-  `force: false` rebased cleanly, and no fork pull request has arrived yet to exercise the read-only
-  token path — that guard is still design, not evidence.
-- **Flipping the Pages source was assumed to be the last step; it is not self-starting.** A
-  branch-served site builds on the next *push* to that branch, and the last `gh-pages` push predated
-  the flip — so the old artifact kept serving, with `pages/builds/latest` returning 404 and no
-  workflow run to look at. `gh api -X POST repos/OWNER/REPO/pages/builds` bootstraps it. Anyone
-  repeating this migration will otherwise conclude the deploy silently failed.
+:::{attention} Assumptions to verify
+- The wildcard deployment policy on the `github-pages` environment is what unblocks pull-request
+  deploys — without it the first preview fails on the branch policy, not on anything about
+  artifacts.
+- No rebuild fallback is needed when `main`'s artifact is missing: a Pages deployment is atomic, so
+  failing loudly leaves the previous site serving rather than an empty one.
+- The weekly rebuild plus 90-day retention keeps that artifact warm enough that expiry is never
+  reached in practice.
+- The flip moves no URLs: every path, plus the search index, `objects.inv` and `sitemap.xml`,
+  answers identically before and after — and `gh` alone replaces both deploy actions, sticky
+  preview comment included.
+:::


### PR DESCRIPTION
Closes #141.

**The driving question:** why does every docs-deploy failure this repo has hit — the 103 MB branch, the 494 s builds, the site stuck two merges back, the preview still live four days after its merge — keep coming back in a different costume? Because the published site is *versioned state*. This makes it derived instead: every deploy recomputes the whole site from `main`'s build plus one artifact per currently open pull request.

The reasoning lives in the diary entry, rewritten in place as the branch's first commit — [Every pull request publishes the page it changes](https://andrewendlinger.github.io/xmris/diary/2026-07-25-docs-previews) (`docs/diary/2026-07-25-docs-previews.md`). It is not restated here.

### What moved

- `.github/workflows/deploy.yml` — `build` now uploads `site-main` (90 d) or `preview-pr-<N>` (14 d) instead of pushing to a branch; a new `publish` job assembles `_site/` with `gh` alone and deploys via `upload-pages-artifact` + `deploy-pages`. Gone: both third-party deploy actions, the `Disable Jekyll` step, the `closed` trigger. The weekly schedule now runs `build` + `publish` + `links`, which keeps `main`'s artifact warm and sweeps a preview whose PR closed on a quiet week. The fork guard survives, now as an explicit security boundary.
- `docs/contribute/pull_requests.md` — the preview-lifecycle diagram, the "How the documentation reaches the web" section, the `publish`/`links` non-gating note and the 404 troubleshooting row. The `literalinclude` and its hidden assert cell are untouched: both pinned strings (`- name: Build MyST Site`, `uv run myst build --html --execute --strict`) are verbatim in the new workflow.

`docs/contribute/index.md` and `publishing.md` describe the deploy without naming its mechanism, so both stay correct as written.

### ⚠️ `publish` is expected to fail on this PR

Two reasons, both by design, and neither a required check:

1. **No `site-main` artifact exists yet.** It cannot until the new workflow runs on `main`, so assembly stops at the fail-loud branch — which is how that path got verified early:
   `##[error]No usable 'site-main' artifact. The live site is unchanged; recover with: gh workflow run deploy.yml`
2. Pages is still `build_type: legacy`, so the deploy leg could not have succeeded either. It is untested until after the flip.

**Correction to the plan, found by running it.** The first attempt was rejected with `Branch "refs/pull/142/merge" is not allowed to deploy to github-pages` even though a `*` deployment-branch policy was in place. Environment policies match `GITHUB_REF` using `fnmatch`, where a wildcard never crosses a `/`, so `*` cannot match a merge ref. The rule has to be spelled `refs/pull/*/merge` — now added, and the `*` rule removed as useless. The environment therefore ends up *tighter* than the plan proposed: only `main` and PR merge refs may deploy. The diary entry carries this correction.

Migration order after merge: flip `build_type=workflow` → verify the URL surface → delete `gh-pages` and its dead branch policy → reconcile the diary entry (pass 2).

### Verification

- `uv run pytest tests/test_core.py -n0 --no-cov` — 270 passed
- `cd docs && uv run myst build --html` — exit 0, no mystmd warnings
- `check_docs.py` — 0 errors
- the hidden assert cell in `pull_requests.md`, executed from its own directory — passes
- every `run:` script parsed out of the workflow and checked with `bash -n`; the artifact lookup and `gh pr list` filters dry-run against this repo
