### PR TITLE
fix(ci): give the publish job an explicit repo context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,10 @@ jobs:
       - name: Assemble the site from current state
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job never checks the repository out -- it only moves artifacts
+          # around -- so `gh` has no git remote to infer the repository from and
+          # every subcommand but `gh api` dies with "not a git repository".
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
@@ -187,6 +191,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}  # no checkout here either
           PR: ${{ github.event.number }}
           SITE: ${{ steps.deployment.outputs.page_url }}
           SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Follow-up to #142, found by the first post-merge run on `main` ([31388028552](https://github.com/andrewendlinger/xmris/actions/runs/31388028552)).

`build` did its half correctly — `site-main` uploaded, 21 MB, expiring in 90 days — but `publish` died half a second in:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The publish job has no `actions/checkout` on purpose: it only moves artifacts, and cloning the source would be pure waste. But `gh run download`, `gh pr list` and `gh pr comment` all resolve the target repository from a git remote, so with no working copy they abort before doing anything. The `gh api` calls survived only because they carry an explicit `repos/$GITHUB_REPOSITORY/...` path.

Fix: set `GH_REPO` on both steps, which tells `gh` the repository directly and keeps the job checkout-free.

### Verified outside CI

Reproduced and fixed in a scratch directory that is not a git repository, using the exact failing commands:

- without `GH_REPO`: `gh pr list` → `failed to run git: fatal: not a git repository`
- with `GH_REPO`: `gh pr list` → `58`, and `gh run download <run> --name site-main` unpacks **1,548 files / 56 MB**
- the unpacked artifact is a correct site root: `index.html`, `objects.inv`, `sitemap.xml`, `myst.search.json`, the per-chapter directories from #139, and `/xmris/` baked into every asset href

`publish` will still fail on this PR, one step later than before and for the known reason — Pages is `build_type: legacy` until the flip, which happens once this is on `main`.
