### PR TITLE
docs: the roadmap's original hero returns, generalized past the paper

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 (roadmap)=
 # Where xmris is going
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-05</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-10</span>
 
 ::::{div}
 :class: roadmap-hero
@@ -9,27 +9,29 @@
 :::{div}
 :class: roadmap-kicker
 
-The direction
+The vision
 :::
 
 :::{div}
 :class: roadmap-statement
 
-The physics used to live in headers, protocols, and someone's memory. Here it lives in the
-array.
+xmris is finished when the three lines you write to process a single FID are the same three lines
+that process a whole volume — and when the object they hand back already carries everything you
+need.
 :::
 
 :::{div}
 :class: roadmap-tenets
 
-`xarray in, xarray out` `one FID or a volume, the same lines` `docs before code`
+`xarray in, xarray out` `docs before code` `the record travels with the data`
 :::
 ::::
 
 Three commitments shape everything below. Your data stays an `xarray.DataArray` — the physics
 comes to it, never your data into a framework, and the whole xarray ecosystem keeps working. The
-same pure lines process one FID or an N-D volume of them. And the docs come before the code:
-every page executes on every pull request.
+docs come before the code: every page executes on every pull request. And the record travels with
+the data — the reference frequency, the phase that was applied, the prior knowledge a fit was
+given, attached to the object you already hold.
 
 :::{note} How to read this page
 Five bands: from what already works, through the upcoming architecture decisions, to the near


### PR DESCRIPTION
The roadmap hero statement drafted on 2026-07-26 was hedged into a prediction, then rewritten twice more, and had drifted from what it originally promised. It comes back — with its one narrow phrase widened.

**Before**

> **The direction**
> The physics used to live in headers, protocols, and someone's memory. Here it lives in the array.
> `xarray in, xarray out` `one FID or a volume, the same lines` `docs before code`

**After**

> **The vision**
> xmris is finished when the three lines you write to process a single FID are the same three lines that process a whole volume — and when the object they hand back already carries everything you need.
> `xarray in, xarray out` `docs before code` `the record travels with the data`

The original ended `already carries everything a paper needs`. An object handing back what the *next step* wants is not a claim about publishing, so that becomes `everything you need`.

## Why four lines and not one

The hero is a four-part system — kicker → statement → tenets → gloss — and the current three parts were composed around the *current* statement. Dropping the original statement in alone would make the same claim three times over.

- **Kicker → `The vision`.** `The direction` arrived in the same commit that turned the aspiration into a prediction. With `xmris is finished when…` back, the label that fits it is back too.
- **Tenet chip swap.** `one FID or a volume, the same lines` goes — the restored statement makes that claim in full, so the chip and the gloss sentence beneath it were repeating it. `the record travels with the data` returns from the original tenets in its place, backing the statement's second half.
- **Third gloss sentence** follows the chip swap, keeping the paragraph a 1:1 reading of the three tenets. Its clause is lifted from the original page's own prose.

Deliberately **not** restored: the paragraph that originally followed the hero. It claims `fit_amares` is one-dimensional — the load-bearing correction #123 made.

## One promise knowingly re-made

`the record travels with the data` is a claim that was moved off the hero and onto decision card 02, because the attrs/lineage strategy is still open (#64, Commandment 3). It reads as an aspiration here rather than a description of today — the statement is explicitly future-tense — and card 02 still owns the mechanism. Easy to drop the chip if that reads as overclaiming.

## Scope

`docs/roadmap.md` only, hero block only. No headers move, so no MyST targets change and no deep link breaks. No pages consolidated. No diary entry: copy revision, no competing approaches, no conceptual surface.

## Verification

- `check_docs.py docs/roadmap.md` — 0 errors, 0 warnings
- `cd docs && uv run myst build --html` — exit 0, no errors or warnings; hero confirmed in the rendered `_build/html/roadmap/index.html`, not just in the source

The full `--execute --strict` build is left to the `build` check. Read the hero on the preview — the four parts have to land as one system.
