### PR TITLE
ci: install the Codecov CLI from PyPI, not the signed binary (#115)

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -66,3 +66,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
+          # Fetch the uploader from PyPI, not cli.codecov.io. `test` is a required
+          # check, so the binary path's GPG step -- which once hung 4.5 min on a
+          # keyserver fetch and then failed -- could block every merge in the repo
+          # over an outage in a service the PR never touched. PyPI is already a hard
+          # dependency of this job via `uv sync`. Deliberately not `skip_validation`:
+          # that disables the integrity check rather than moving it. See #115.
+          use_pypi: true


### PR DESCRIPTION
## Problem

`test (3.10)` / `test (3.13)` are **required checks** on `main` now (#112/#114). That makes
Codecov's CLI distribution a merge blocker for the whole repository: on #114 the uploader's
own GPG verification hung ~4.5 min on a keyserver fetch and then failed, reddening a job in
which not a single test failed. A plain re-run went green, so it was purely transient.

```
gpg: no valid OpenPGP data found.
==> Verifying GPG signature integrity
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

Same shape as the `doi.org` problem #114 fixed for the docs build: a third-party service
reddening pull requests that never touched it.

## Fix

`use_pypi: true` on the `codecov/codecov-action@v7` step. The GPG verification that failed
belongs to the **binary-download** path, so this failure mode disappears — while PyPI is
already a hard dependency of the job via `uv sync`, so it adds no new third party.

`fail_ci_if_error: true` **stays**. The existing comment says it is deliberate, and it is: a
genuinely broken upload (bad token, missing `coverage.xml`) must still fail the check. This
changes *where the CLI comes from*, not whether the upload is allowed to fail.

Deliberately **not** `skip_validation: true` — its own docs say "This is NOT recommended", and
fixing a flake by disabling a supply-chain check is a bad trade for a JOSS-facing package.
`use_pypi` makes it unnecessary.

## Verification

YAML parses and the step's inputs resolve as intended. The real proof is the next few CI runs
taking the PyPI path; there is no way to assert the absence of a transient outage locally.

Closes #115