### PR TITLE
fix(packaging): matplotlib is a core dependency, and CI installs the way a user does (#122)

### DIFF
--- a/.github/scripts/bare_install_smoke.py
+++ b/.github/scripts/bare_install_smoke.py
@@ -1,0 +1,125 @@
+"""Prove that a bare ``pip install xmris`` is importable and usable.
+
+Every other CI job installs with ``uv sync --all-extras --dev``, so the dependency
+set a real user receives is exercised nowhere. That is the hole #122 fell through:
+matplotlib is imported at module level by ``core/accessor.py`` -- the one module
+every ``import xmris`` loads -- but arrived only transitively via pyAMARES, and
+moving pyAMARES into the ``fitting`` extra took it away. ``import xmris`` raised
+``ModuleNotFoundError`` on a fresh install for an entire release while CI stayed green.
+
+Run this with an interpreter whose environment was built from ``[project]
+dependencies`` **alone** -- no extras, no dev group. It asserts three things:
+
+1. the declared ``requires-python`` actually admits the running interpreter;
+2. the documented processing chain runs, plotting included;
+3. the ``fitting`` extra is still genuinely optional, and absent means a *friendly*
+   error rather than a traceback.
+
+Exits non-zero with a diagnostic on the first failure.
+"""
+
+import importlib.metadata
+import sys
+
+import matplotlib
+
+# A CI runner is headless. Select a non-interactive backend before pyplot is
+# imported anywhere, so a missing display fails as a real bug and never as Tk.
+matplotlib.use("Agg")
+
+import xarray as xr  # noqa: E402  (must follow matplotlib.use)
+
+import xmris  # noqa: E402
+
+
+def check_requires_python() -> None:
+    """Assert the running interpreter satisfies the distribution's own metadata.
+
+    ``requires-python`` was once spelled ``<=3.13``, which PEP 440 reads as
+    ``<= 3.13.0`` -- excluding every 3.13 patch release from 3.13.1 on. Installing
+    from a local path does not enforce the marker, so CI never noticed; a user
+    running ``pip install xmris`` on any real 3.13 was refused before dependency
+    resolution even began. This catches that class of typo permanently.
+    """
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    declared = importlib.metadata.metadata("xmris")["Requires-Python"]
+    running = Version(".".join(str(n) for n in sys.version_info[:3]))
+    if running not in SpecifierSet(declared):
+        raise AssertionError(
+            f"Python {running} does not satisfy the declared Requires-Python "
+            f"({declared}), so `pip install xmris` would refuse this interpreter.\n"
+            f"To fix this, correct `requires-python` in pyproject.toml -- a highest "
+            f'supported minor of X.Y is spelled ">=...,<X.(Y+1)", never "<=X.Y".'
+        )
+    print(f"requires-python  OK  ({declared} admits {running})")
+
+
+def check_processing_chain() -> None:
+    """Run the chain the README and tutorials promise, plotting included."""
+    fid = xmris.simulate_fid(
+        amplitudes=[1.0, 0.6],
+        chemical_shifts=[0.0, 5.2],
+        reference_frequency=120.66,
+        n_points=1024,
+    )
+    spectrum = fid.xmr.apodize_exp(lb=5.0).xmr.to_spectrum().xmr.autophase().xmr.to_ppm()
+    assert spectrum.sizes, "the processed spectrum is empty"
+    print("processing chain OK  (simulate -> apodize -> spectrum -> autophase -> ppm)")
+
+    # matplotlib fails at *import*, but plotting is the reason it is a core dep --
+    # so exercise a real figure rather than trusting that the import alone suffices.
+    # simulate_fid is 1-D (#113), so stack by hand the way the tutorials do.
+    stack = xr.concat(
+        [
+            xmris.simulate_fid(
+                amplitudes=[amp],
+                chemical_shifts=[0.0],
+                reference_frequency=120.66,
+                n_points=256,
+            )
+            for amp in (1.0, 0.8, 0.6)
+        ],
+        dim="repetition",
+    )
+    ax = stack.xmr.to_spectrum().xmr.autophase().real.xmr.plot.waterfall()
+    assert ax is not None, "waterfall returned no Axes"
+    print("plotting         OK  (waterfall rendered on the Agg backend)")
+
+
+def check_fitting_is_optional() -> None:
+    """Assert the fitting extra is absent *and* fails helpfully when reached."""
+    assert "fit_amares" not in xmris.__all__, (
+        "fit_amares is in __all__ on a fitting-free install, so `from xmris import *` "
+        "would force the resolver and raise"
+    )
+    try:
+        xmris.fit_amares
+    except ImportError as exc:
+        assert "xmris[fitting]" in str(exc), (
+            f"fitting is missing, but the error does not point at the extra: {exc}"
+        )
+        print("fitting extra    OK  (absent, and the ImportError names xmris[fitting])")
+    else:
+        raise AssertionError(
+            "xmris.fit_amares resolved on a bare install -- pyAMARES leaked into the "
+            "core dependency set, which is what the fitting extra exists to prevent"
+        )
+
+
+def main() -> int:
+    """Run every check, reporting the first failure."""
+    for check in (check_requires_python, check_processing_chain, check_fitting_is_optional):
+        try:
+            check()
+        except Exception as exc:  # noqa: BLE001  (a smoke test reports, it does not handle)
+            sys.stdout.flush()  # keep the passing lines above the failure in CI logs
+            print(f"\nFAIL in {check.__name__}: {exc}", file=sys.stderr)
+            return 1
+    print("\nA bare `pip install xmris` is importable and usable.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -25,6 +25,38 @@ jobs:
       - name: Check docs style
         run: python3 .claude/skills/docs-page/check_docs.py
 
+  bare-install:
+    name: bare install
+    runs-on: ubuntu-latest
+    # Every other job installs with `uv sync --all-extras --dev`, so the dependency
+    # set a real user receives is exercised nowhere -- which is how #122 shipped a
+    # release whose `import xmris` raised ModuleNotFoundError while CI stayed green.
+    # One Python version is enough: this checks the dependency *set*, not the matrix.
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      # Deliberately no --all-extras and no --dev: installing *only*
+      # [project].dependencies into a clean venv is the entire point of the job.
+      - name: Install the way a user does
+        run: |
+          uv venv /tmp/bare --python 3.13
+          uv pip install --python /tmp/bare/bin/python .
+
+      - name: Import xmris and run the processing chain
+        run: /tmp/bare/bin/python .github/scripts/bare_install_smoke.py
+
   test:
     runs-on: ubuntu-latest
     # A healthy run is ~4 min; bound it so a hung kernel fails fast, not at GitHub's 6h ceiling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,5 +56,5 @@ Ruff: line length 100, NumPy docstring convention. Public functions need fully-t
 
 ## Commits & releases
 
-- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `add:`). Branch, then PR — `main` takes no direct pushes and requires four checks green (`Docs style`, `build`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
+- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `add:`). Branch, then PR — `main` takes no direct pushes and requires five checks green (`Docs style`, `build`, `bare install`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
 - Release (see `/release`): never bump version until CI is green. Releases go through a `release/vX.Y.Z` branch (full test matrix), then the bump lands on `main` via a PR — and only *then* is `vX.Y.Z` tagged on the merged commit, which triggers the PyPI publish. Tagging before the merge would leave the tag outside `main`'s history. Bump with `uv version --bump patch|minor`.

--- a/docs/contribute/publishing.md
+++ b/docs/contribute/publishing.md
@@ -16,7 +16,7 @@ _Note_: [Workflow diagram](#release-diagram) at the end of the page.
 (release-daily)=
 ## ① Daily Development
 
-Work on a branch and land it through a pull request — `main` takes no direct pushes, and four checks
+Work on a branch and land it through a pull request — `main` takes no direct pushes, and five checks
 gate every merge. That path has its own page: [Open a pull request](#contribute-pr).
 
 - **Do not** bump the version.
@@ -123,7 +123,7 @@ pull-request lifecycle: [How the documentation reaches the web](#contribute-pr-d
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart TD
     subgraph dev ["① Daily development"]
-        A["Branch + pull request"] -->|"four checks"| B["Fast CI: Py 3.10 & 3.13"]
+        A["Branch + pull request"] -->|"five checks"| B["Fast CI: Py 3.10 & 3.13"]
         B -->|"merge"| MAIN["main"]
     end
 

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -13,7 +13,7 @@ kernelspec:
 # Open a pull request
 
 Your change is written and green locally. This page covers everything between that and it being on
-`main`: how to name the commit, what the four checks that gate the merge actually measure, where to
+`main`: how to name the commit, what the five checks that gate the merge actually measure, where to
 read your change rendered as a website before anyone reviews it, and who merges. It applies to every
 kind of change — a processing method, a widget, a docs page, a diary entry.
 
@@ -51,21 +51,28 @@ command above fills in. Nothing downstream cares which route you took.
 Every push to the branch re-runs the checks below and refreshes your preview.
 
 (contribute-pr-checks)=
-## 3. Four checks gate the merge
+## 3. Five checks gate the merge
 
-All four must pass before the merge button works. Each one is reproducible locally with a single
+All five must pass before the merge button works. Each one is reproducible locally with a single
 command — run it there first, since a local failure costs seconds and a CI failure costs minutes:
 
 | Check | What it measures | Reproduce locally |
 |---|---|---|
 | **`Docs style`** | The docs rules `myst build` stays silent about: a header with no explicit target, a dead `.ipynb` link, a drifted kernel label, a page missing from the TOC | `uv run python .claude/skills/docs-page/check_docs.py` |
 | **`build`** | Executes **every** notebook and explainer in the documentation, then fails on any mystmd error — a broken cross-reference, an unresolvable DOI, a directive that did not render | `cd docs && uv run myst build --html --execute --strict` |
+| **`bare install`** | Installs **only** `[project].dependencies` into a clean venv — the set a real user receives — then imports xmris and runs the processing chain | `uv venv /tmp/bare && uv pip install --python /tmp/bare/bin/python . && /tmp/bare/bin/python .github/scripts/bare_install_smoke.py` |
 | **`test (3.10)`** and **`test (3.13)`** | Lint, then the full suite — including the tutorials, which *are* the maths tests — on both ends of the supported Python range | `uv run ruff check .` then `uv run test` |
 
-Two things worth knowing about that table. The `build` check is why a notebook that hangs can never
+Three things worth knowing about that table. The `build` check is why a notebook that hangs can never
 reach `main`: it runs under a 20-minute ceiling, so a stuck kernel fails visibly instead of burning
 six hours. And `--strict` is load-bearing — without it mystmd reports its errors and *still* exits 0,
 which is how a dead link once survived on the site for months.
+
+`bare install` is the odd one out, and deliberately so: every other job installs with `uv sync
+--all-extras --dev`, which means the dependency set an actual `pip install xmris` produces is
+exercised nowhere else. That gap once shipped a release whose `import xmris` raised
+`ModuleNotFoundError` while all four other checks stayed green, so this job installs the way a user
+does and refuses to trust anything the dev environment happens to provide.
 
 Two further jobs report on the pull request without gating it. `publish` assembles and deploys the
 site — that is where your preview comes from — and `links` checks external URLs **weekly on a
@@ -107,7 +114,7 @@ contributor's first pull request should not open with a red X they have no way t
 (contribute-pr-green)=
 ## 5. Drive it green, then hand off
 
-Push fixes until all four checks pass. You do **not** need to keep the branch up to date with `main`
+Push fixes until all five checks pass. You do **not** need to keep the branch up to date with `main`
 — the checks are not configured strictly, so an unrelated merge landing meanwhile will not force you
 to rebase. Rebase only for a real conflict:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,14 @@ name = "xmris"
 version = "0.6.1"
 description = "An xarray-based MRI and MRS toolbox"
 readme = "README.md"
-# The <=3.13 ceiling is a pyAMARES constraint (the `fitting` extra). It stays
+# The 3.13 ceiling is a pyAMARES constraint (the `fitting` extra). It stays
 # project-wide only because requires-python cannot be scoped to an optional
 # extra; core xmris itself has no such cap. Revisit once pyAMARES supports 3.14.
-requires-python = ">=3.10,<=3.13"
+# Spelled `<3.14`, NOT `<=3.13`: PEP 440 reads `<=3.13` as `<= 3.13.0`, which
+# excluded every 3.13 patch release from 3.13.1 on -- i.e. all of them, since
+# 3.13.0 shipped in Oct 2024. `<3.14` is what "3.13 is the highest supported
+# minor" actually means.
+requires-python = ">=3.10,<3.14"
 authors = [
     { name = "Andrecho", email = "37243793+andrewendlinger@users.noreply.github.com" }
 ]
@@ -30,7 +34,9 @@ classifiers = [
 
 dependencies = [
     "anywidget>=0.9.21",
+    "matplotlib>=3.5",  # core/accessor + every plot module import it at module level
     "numpy>=1.26.0",
+    "pandas>=2.1",      # core/accessor imports pandas directly
     "scipy>=1.11.0",    # core baseline/phasing/bruker import scipy directly
     "xarray<2025.11.0", # Pinned for compatibility
 ]
@@ -44,6 +50,7 @@ dependencies = [
 fitting = [
     "pyamares-xmris>=0.3.33",
     "joblib>=1.5.3", # parallel fit dispatch (fitting-only)
+    "tqdm>=4.60",    # fitting/amares imports it directly for the fit progress bar
     "numpy<2.0",
     "pandas<2.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <=3.13"
+requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
@@ -3503,7 +3503,10 @@ version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "xarray" },
@@ -3515,6 +3518,7 @@ fitting = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pyamares-xmris" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -3540,11 +3544,14 @@ dev = [
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.21" },
     { name = "joblib", marker = "extra == 'fitting'", specifier = ">=1.5.3" },
+    { name = "matplotlib", specifier = ">=3.5" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'fitting'", specifier = "<2.0" },
+    { name = "pandas", specifier = ">=2.1" },
     { name = "pandas", marker = "extra == 'fitting'", specifier = "<2.2" },
     { name = "pyamares-xmris", marker = "extra == 'fitting'", specifier = ">=0.3.33" },
     { name = "scipy", specifier = ">=1.11.0" },
+    { name = "tqdm", marker = "extra == 'fitting'", specifier = ">=4.60" },
     { name = "xarray", specifier = "<2025.11.0" },
 ]
 provides-extras = ["fitting"]


### PR DESCRIPTION
## The bug, reproduced

```console
$ uv venv /tmp/bare && uv pip install --python /tmp/bare/bin/python .
$ /tmp/bare/bin/python -c "import xmris"
  File ".../xmris/visualization/plot/plot_carpet.py", line 3, in <module>
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'
```

matplotlib is imported at module level by `src/xmris/core/accessor.py:14` — the one module every
`import xmris` loads — plus the four plot modules, but it was absent from `[project].dependencies`.
It used to arrive transitively because `pyamares` was a core dep and pyAMARES requires
`matplotlib>=3.1.3`; moving pyAMARES into the `fitting` extra (#105) took it away. #122 diagnosed
this exactly.

## A second defect in the same metadata, found while fixing the first

`requires-python` was spelled `>=3.10,<=3.13`. PEP 440 reads `<=3.13` as **`<= 3.13.0`**:

| Python | Admitted by `<=3.13`? |
|---|---|
| 3.13.0 | ✅ |
| 3.13.1 | ❌ |
| 3.13.11 (current) | ❌ |

3.13.0 shipped in October 2024, so in practice **every** real 3.13 user was refused — and this one
fails *harder* than the matplotlib bug: pip rejects the distribution on the Requires-Python marker
before dependency resolution even begins. Now `<3.14`, which is what "3.13 is the highest supported
minor" actually means. The intent is unchanged and the pyAMARES ceiling still holds.

It hid for the same reason: `uv sync` on the local workspace does not enforce the marker (it warns —
that warning is visible in the repro above and is what led me to it).

## Why CI never caught either

Every job installs with `uv sync --all-extras --dev`. matplotlib is in both the `dev` group *and*
the `fitting` extra, so every job has it. **The dependency set a real user receives is exercised
nowhere.** That hole is the actual bug; the missing dep is what fell through it.

## Fix

**1. Declare what the code imports** (`pyproject.toml`):

| Package | Imported at | Was supplied by | Now |
|---|---|---|---|
| `matplotlib` | `core/accessor.py:14` + 4 plot modules | **nothing** | core dep |
| `pandas` | `core/accessor.py:16` (eager) | `xarray → pandas>=2.1` | core dep |
| `tqdm` | `fitting/amares.py:26` | `pyamares-xmris → tqdm` | `fitting` extra |

pandas and tqdm are not broken today — they are the same undeclared-transitive shape, one upstream
dependency shuffle from becoming the next #122, and crucially the smoke job **cannot** catch them
because they resolve fine. Declaring them is the belt to the job's braces.

**2. A `bare install` CI job** that installs with no extras and no dev group, then runs
`.github/scripts/bare_install_smoke.py`. It asserts the interpreter satisfies the declared
`requires-python`, runs the documented chain (`simulate_fid → apodize_exp → to_spectrum →
autophase → to_ppm`), renders a waterfall on the Agg backend, and checks `fit_amares` is absent
**and** that reaching it raises the friendly `xmris[fitting]` `ImportError` rather than a traceback.

**3. Docs:** four checks → five, with a table row for `bare install` and a paragraph on why it is
the odd one out (`pull_requests.md`, `publishing.md`, `CLAUDE.md`).

## What this deliberately does *not* decide

The core/extra boundary is #124's question, and #124 already draws the line: adding matplotlib to
core was *"the right tactical call for v0.7; this issue is where the question gets decided
strategically."* This PR states what `accessor.py` already does — it does not build the `[plotting]`
extra, which would mean performing a v0.8 design decision inside a v0.7 breakage fix. If #124 moves
plotting behind an extra, this one-line dep moves with that refactor.

`IPython` is undeclared too (`widget/_static_exporter.py:8`), and I left it out on purpose: that
module is on no eager import path and the widgets are already lazily imported
(`core/accessor.py:179-180`), which makes it a genuine lazy pillar and therefore #124's. Posting it
there as evidence rather than fixing it here.

## Verification

Reproduced the failure on `main` first, then confirmed the fix end-to-end in a clean venv:

```
requires-python  OK  (>=3.10, <3.14 admits 3.13.11)
processing chain OK  (simulate -> apodize -> spectrum -> autophase -> ppm)
plotting         OK  (waterfall rendered on the Agg backend)
fitting extra    OK  (absent, and the ImportError names xmris[fitting])

A bare `pip install xmris` is importable and usable.
```

Also negative-tested the smoke script — uninstalling matplotlib from the clean venv makes it exit
non-zero, so the job genuinely catches the bug rather than merely passing.

`uv run pytest tests/test_core.py` 270 passed · `ruff check .` clean · `check_docs.py` 0 errors
(16 pre-existing warnings, unchanged, tracked in #111) · `uv.lock` regenerated, diff is only these deps.

## ⚠️ Needs a settings change after the first run

`bare install` must be added to `main`'s **required status checks** (Settings → Branches) once it has
reported once, or it will report without gating.

Closes #122