### PR TITLE
chore(ci): gate ruff format and stop the formatter at the docs door

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -25,6 +25,39 @@ jobs:
       - name: Check docs style
         run: python3 .claude/skills/docs-page/check_docs.py
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    # Both halves of ruff, once. `ruff check` used to be the first step of `test`,
+    # which meant it ran per matrix leg, a formatting nit stopped the maths from
+    # ever running, and the failure reported itself as a test failure. Same
+    # reasoning as the docs job above: a lint failure should read as a lint failure.
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      # Format before lint: the mechanical failure is the cheaper one to fix, so
+      # it should be the one you see first. `uv run lint` runs these same two.
+      - name: Format (ruff)
+        run: uv run ruff format --check .
+
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
   bare-install:
     name: bare install
     runs-on: ubuntu-latest
@@ -80,9 +113,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
-
-      - name: Lint (ruff)
-        run: uv run ruff check .
 
       - name: Run Tests
         run: uv run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Package manager is `uv` — never use pip. Add deps with `uv add <pkg>`; sync wi
 
 - Tests: `uv run test` (regenerates notebook tests from MyST, then runs pytest). Regenerate notebooks only: `uv run test-gen`.
 - Architecture tests only, fast iteration: `uv run pytest tests/test_core.py -n0 --no-cov` (pytest `addopts` otherwise forces `-n auto --nbmake --cov`). Single test: append `::TestClass::test_name`.
-- Lint: `uv run ruff check .` (`--fix` to auto-fix). Format: `uv run ruff format .`.
+- Lint + format check, exactly as the `Lint` CI job runs them: `uv run lint`. Individually: `uv run ruff check .` (`--fix` to auto-fix), `uv run ruff format .`. Ruff excludes `*.md` — it formats Python inside Markdown code blocks and would flatten the hand-set docs snippets, so `ruff format .` is safe to run tree-wide.
 - Type-check: `uv run mypy src/xmris` — run it and fix clear type errors before finishing. It is not in CI and not configured, so xarray typing can be noisy; fix real issues, don't chase false positives.
 - Docs API stubs: `uv run docs-api`. Check a page renders: `myst build --html` from `docs/` — one-shot, ~10 s warm, exit 0 (add `--execute` to run notebooks too).
 - `uv run docs` and `uv run docs-notebooks` **launch a blocking preview server** (`myst start --execute`) and never exit. They are for a human reading the site — never put them in a verification step. In general, check what a `uv run <name>` alias does in `src/xmris/_scripts.py`; the inline comments in `pyproject.toml` describe intent, not blocking behaviour.
@@ -56,5 +56,5 @@ Ruff: line length 100, NumPy docstring convention. Public functions need fully-t
 
 ## Commits & releases
 
-- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `add:`). Branch, then PR — `main` takes no direct pushes and requires five checks green (`Docs style`, `build`, `bare install`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
+- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `add:`). Branch, then PR — `main` takes no direct pushes and requires six checks green (`Docs style`, `Lint`, `build`, `bare install`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
 - Release (see `/release`): never bump version until CI is green. Releases go through a `release/vX.Y.Z` branch (full test matrix), then the bump lands on `main` via a PR — and only *then* is `vX.Y.Z` tagged on the merged commit, which triggers the PyPI publish. Tagging before the merge would leave the tag outside `main`'s history. Bump with `uv version --bump patch|minor`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,11 @@ short page with a live checklist.
 git clone https://github.com/andrewendlinger/xmris
 cd xmris
 uv sync --all-extras --dev   # uv replaces pip/virtualenv — see the setup guide
+uv run lint                  # check formatting, then lint — what the Lint check runs
 uv run test                  # regenerate the notebook tests and run the full suite
 ```
+
+Run both before you push: together they reproduce four of the six checks that gate a merge.
 
 The package manager is [`uv`](https://docs.astral.sh/uv/); please never use `pip`. The [environment
 setup guide](https://andrewendlinger.github.io/xmris/setup) covers the full toolchain (`uv`, `ruff`,

--- a/docs/contribute/publishing.md
+++ b/docs/contribute/publishing.md
@@ -16,7 +16,7 @@ _Note_: [Workflow diagram](#release-diagram) at the end of the page.
 (release-daily)=
 ## ① Daily Development
 
-Work on a branch and land it through a pull request — `main` takes no direct pushes, and five checks
+Work on a branch and land it through a pull request — `main` takes no direct pushes, and six checks
 gate every merge. That path has its own page: [Open a pull request](#contribute-pr).
 
 - **Do not** bump the version.
@@ -123,7 +123,7 @@ pull-request lifecycle: [How the documentation reaches the web](#contribute-pr-d
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart TD
     subgraph dev ["① Daily development"]
-        A["Branch + pull request"] -->|"five checks"| B["Fast CI: Py 3.10 & 3.13"]
+        A["Branch + pull request"] -->|"six checks"| B["Fast CI: Py 3.10 & 3.13"]
         B -->|"merge"| MAIN["main"]
     end
 

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -13,7 +13,7 @@ kernelspec:
 # Open a pull request
 
 Your change is written and green locally. This page covers everything between that and it being on
-`main`: how to name the commit, what the five checks that gate the merge actually measure, where to
+`main`: how to name the commit, what the six checks that gate the merge actually measure, where to
 read your change rendered as a website before anyone reviews it, and who merges. It applies to every
 kind of change — a processing method, a widget, a docs page, a diary entry.
 
@@ -51,22 +51,30 @@ command above fills in. Nothing downstream cares which route you took.
 Every push to the branch re-runs the checks below and refreshes your preview.
 
 (contribute-pr-checks)=
-## 3. Five checks gate the merge
+## 3. Six checks gate the merge
 
-All five must pass before the merge button works. Each one is reproducible locally with a single
+All six must pass before the merge button works. Each one is reproducible locally with a single
 command — run it there first, since a local failure costs seconds and a CI failure costs minutes:
 
 | Check | What it measures | Reproduce locally |
 |---|---|---|
 | **`Docs style`** | The docs rules `myst build` stays silent about: a header with no explicit target, a dead `.ipynb` link, a drifted kernel label, a page missing from the TOC | `uv run python .claude/skills/docs-page/check_docs.py` |
+| **`Lint`** | Both halves of ruff: that every Python file is formatted, and that it is free of lint errors | `uv run lint` |
 | **`build`** | Executes **every** notebook and explainer in the documentation, then fails on any mystmd error — a broken cross-reference, an unresolvable DOI, a directive that did not render | `cd docs && uv run myst build --html --execute --strict` |
 | **`bare install`** | Installs **only** `[project].dependencies` into a clean venv — the set a real user receives — then imports xmris and runs the processing chain | `uv venv /tmp/bare && uv pip install --python /tmp/bare/bin/python . && /tmp/bare/bin/python .github/scripts/bare_install_smoke.py` |
-| **`test (3.10)`** and **`test (3.13)`** | Lint, then the full suite — including the tutorials, which *are* the maths tests — on both ends of the supported Python range | `uv run ruff check .` then `uv run test` |
+| **`test (3.10)`** and **`test (3.13)`** | The full suite — including the tutorials, which *are* the maths tests — on both ends of the supported Python range | `uv run test` |
 
 Three things worth knowing about that table. The `build` check is why a notebook that hangs can never
 reach `main`: it runs under a 20-minute ceiling, so a stuck kernel fails visibly instead of burning
 six hours. And `--strict` is load-bearing — without it mystmd reports its errors and *still* exits 0,
 which is how a dead link once survived on the site for months.
+
+`Lint` is the newest, and it stops somewhere deliberate. ruff formats Python inside Markdown code
+blocks as readily as inside `.py` files, which would put every snippet on this site in its hands —
+and it flattens them: the leading-dot `.xmr` chains collapse onto one line, the aligned comment
+gutters lose their gutter. Since every page here is executed as a test, correctness is gated
+already; what is left is layout, and layout is an authoring decision. So `pyproject.toml` excludes
+`*.md` from ruff entirely, and `uv run ruff format .` is safe to run over the whole tree.
 
 `bare install` is the odd one out, and deliberately so: every other job installs with `uv sync
 --all-extras --dev`, which means the dependency set an actual `pip install xmris` produces is
@@ -114,7 +122,7 @@ contributor's first pull request should not open with a red X they have no way t
 (contribute-pr-green)=
 ## 5. Drive it green, then hand off
 
-Push fixes until all five checks pass. You do **not** need to keep the branch up to date with `main`
+Push fixes until all six checks pass. You do **not** need to keep the branch up to date with `main`
 — the checks are not configured strictly, so an unrelated merge landing meanwhile will not force you
 to rebase. Rebase only for a real conflict:
 

--- a/docs/contribute/setup.md
+++ b/docs/contribute/setup.md
@@ -19,14 +19,17 @@ We use modern, Rust-based tooling to keep the development environment blistering
 
 `ruff` is our single source of truth for code style, replacing `black`, `flake8`, and `isort` with a single tool that runs in milliseconds.
 
+* **Check both halves:** Run `uv run lint` — this is exactly what the `Lint` check on your pull request runs, so a green run here means a green check there.
 * **Format code:** Run `uv run ruff format .`
 * **Lint code:** Run `uv run ruff check .`
 * **Auto-fix issues:** Run `uv run ruff check . --fix` (This automatically fixes safe issues like unused imports or variables).
 
+`ruff format .` is safe to run over the whole repository: `pyproject.toml` excludes `*.md`, because ruff formats Python inside Markdown code blocks too and would flatten the hand-set snippets in the documentation. Prose layout is an authoring decision — see [the checks that gate a merge](#contribute-pr-checks).
+
 (setup-vscode)=
 ### 3. VS Code Configuration
 
-To ensure a seamless, "it-just-works" experience, we use the official **Ruff extension**. This configuration enables "Format on Save" and organizes imports automatically using the project's specific `ruff` rules.
+To ensure a seamless, "it-just-works" experience, we use the official **Ruff extension**.
 
 **Required Extensions:**
 
@@ -34,14 +37,24 @@ To ensure a seamless, "it-just-works" experience, we use the official **Ruff ext
 * [Ruff (Astral Software)](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
 
 **Settings (`.vscode/settings.json`):**
-Create or update your workspace `.vscode/settings.json` with the exact configuration below. This tells the editor to use the `uv`-created environment and delegates all formatting and linting directly to `ruff`:
+The repository already ships one, and it is deliberately short — only the two things that are *properties of this project* rather than of you:
 
 ```json
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.interpreter.infoVisibility": "always",
-  "python.analysis.typeCheckingMode": "basic",
 
+  "[python]": {
+    "editor.rulers": [100]
+  }
+}
+```
+
+The interpreter path points at the `.venv` that `uv sync` created; the ruler matches `line-length = 100` from `pyproject.toml`, so your editor draws the margin ruff actually enforces.
+
+Format-on-save is **not** set here, and that is on purpose: whether your editor reformats as you type is a personal preference, so it belongs in your own user settings rather than in everyone's checkout. If you want it, add this to your **user** `settings.json` once and every Python project benefits:
+
+```json
+{
   "[python]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "charliermarsh.ruff",
@@ -53,8 +66,8 @@ Create or update your workspace `.vscode/settings.json` with the exact configura
 
   "ruff.nativeServer": "on"
 }
-
-
 ```
+
+Nothing depends on you doing so — `uv run lint` and the `Lint` check catch the drift either way.
 
 > **Pro Tip:** By setting `"ruff.nativeServer": "on"`, you bypass the Python wrapper and leverage the ultra-fast Rust-based language server directly. This provides near-instant, real-time feedback and auto-formatting as you type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ docs-notebooks = "xmris._scripts:docs_notebooks"        # Serve tutorials — bl
 docs = "xmris._scripts:docs_all"                        # API refs, then serve site — blocking
 test-gen = "xmris._scripts:generate_test_notebooks"
 test = "xmris._scripts:run_tests"
+lint = "xmris._scripts:run_lint"                        # Format check, then lint — mirrors CI
 
 # ==============================================================================
 # 2. BUILD SYSTEM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,10 +126,25 @@ addopts = """
 """
 testpaths = ["tests"]
 
-# --- Ruff (Linter) ---
+# --- Ruff (Linter & Formatter) ---
+# Both halves are gated by the `Lint` job in .github/workflows/ci-fast.yml, and
+# reproduced locally by `uv run lint`.
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+
+# No target-version: ruff infers it from `requires-python` above, so the two can
+# never disagree. They used to -- this said py312 while the package supports 3.10,
+# which let the selected `UP` rules propose syntax the `test (3.10)` leg cannot run.
+
+# ruff 0.16 formats Python blocks inside Markdown, and the docs are the one place
+# where snippet layout *is* the argument: the leading-dot `.xmr` chains and the
+# column-aligned comment gutters are hand-set teaching material, and the formatter
+# flattens both onto one line. Those pages are executed as tests by nbmake, so
+# their correctness is already gated -- what is left is prose, and prose is ours.
+# force-exclude makes the rule hold when a single file is named explicitly too
+# (an editor formatting the open buffer), not just when ruff walks the tree.
+extend-exclude = ["*.md"]
+force-exclude = true
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "NPY", "D", "UP"] # Errors, Failures, Isort, NumPy, Docstrings, Upgrade
@@ -138,10 +153,10 @@ ignore = ["D100", "D104", "D401"]                  # Ignore missing docstring in
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.ruff.lint.per-file-ignores]
-# Ignore line length, unused imports, and import positions in notebooks/scripts
-"docs/**/*.py" = ["E501", "F401", "E402"]
-"docs/**/*.ipynb" = ["E501", "F401", "E402"]
+# No per-file-ignores. The docs used to carry E501/F401/E402 relief under
+# `docs/**/*.py` and `docs/**/*.ipynb`, but jupytext commits only `.md` (now
+# excluded above) and the notebooks it generates are gitignored -- which ruff
+# skips by default. Both patterns matched nothing, so the relief was fictional.
 
 # --- Jupytext ---
 # Tool for automatic two-way syncing between Jupyter Notebooks (.ipynb) and Markdown (.md).

--- a/src/xmris/_scripts.py
+++ b/src/xmris/_scripts.py
@@ -481,3 +481,30 @@ def run_tests() -> None:
     except subprocess.CalledProcessError as e:
         # Pass the exact exit code from pytest back to the terminal/CI
         sys.exit(e.returncode)
+
+
+def run_lint() -> None:
+    """
+    Check formatting and lint the tree, exactly as the CI ``Lint`` job does.
+
+    Formatting is checked before linting because the mechanical failure is the
+    cheaper one to fix. Neither step writes: a formatting failure is repaired
+    with ``uv run ruff format .``, a lint failure often with
+    ``uv run ruff check . --fix``.
+    """
+    print("🔎 Checking formatting...", flush=True)
+    try:
+        subprocess.run(["ruff", "format", "--check", "."], check=True)
+    except subprocess.CalledProcessError as e:
+        print("\n❌ Formatting drift. Fix it with: uv run ruff format .")
+        # Pass the exact exit code from ruff back to the terminal/CI
+        sys.exit(e.returncode)
+
+    print("\n🔎 Linting...", flush=True)
+    try:
+        subprocess.run(["ruff", "check", "."], check=True)
+    except subprocess.CalledProcessError as e:
+        print("\n❌ Lint errors. Auto-fix the safe ones with: uv run ruff check . --fix")
+        sys.exit(e.returncode)
+
+    print("\n✅ Format and lint clean!")

--- a/src/xmris/processing/fourier.py
+++ b/src/xmris/processing/fourier.py
@@ -161,14 +161,8 @@ def fft(
 
         # Smart mapping: If converting standard time, automatically apply
         # frequency metadata
-        term = (
-            COORDS.frequency
-            if (d == DIMS.time and o_dim in (None, DIMS.frequency))
-            else None
-        )
-        da_transformed = _convert_fft_coords(
-            da_transformed, dim=d, out_dim=o_dim, term=term
-        )
+        term = COORDS.frequency if (d == DIMS.time and o_dim in (None, DIMS.frequency)) else None
+        da_transformed = _convert_fft_coords(da_transformed, dim=d, out_dim=o_dim, term=term)
 
     return da_transformed
 
@@ -216,12 +210,8 @@ def ifft(
 
         # Smart mapping: If converting standard frequency, automatically apply
         # time metadata
-        term = (
-            COORDS.time if (d == DIMS.frequency and o_dim in (None, DIMS.time)) else None
-        )
-        da_transformed = _convert_fft_coords(
-            da_transformed, dim=d, out_dim=o_dim, term=term
-        )
+        term = COORDS.time if (d == DIMS.frequency and o_dim in (None, DIMS.time)) else None
+        da_transformed = _convert_fft_coords(da_transformed, dim=d, out_dim=o_dim, term=term)
 
     return da_transformed
 
@@ -257,11 +247,7 @@ def fftc(
     """
     new_dims = out_dim if out_dim is not None else dim
 
-    return (
-        ifftshift(da, dim=dim)
-        .pipe(fft, dim=dim, out_dim=out_dim)
-        .pipe(fftshift, dim=new_dims)
-    )
+    return ifftshift(da, dim=dim).pipe(fft, dim=dim, out_dim=out_dim).pipe(fftshift, dim=new_dims)
 
 
 def ifftc(
@@ -291,8 +277,4 @@ def ifftc(
     """
     new_dims = out_dim if out_dim is not None else dim
 
-    return (
-        ifftshift(da, dim=dim)
-        .pipe(ifft, dim=dim, out_dim=out_dim)
-        .pipe(fftshift, dim=new_dims)
-    )
+    return ifftshift(da, dim=dim).pipe(ifft, dim=dim, out_dim=out_dim).pipe(fftshift, dim=new_dims)

--- a/src/xmris/visualization/widget/_static_exporter.py
+++ b/src/xmris/visualization/widget/_static_exporter.py
@@ -74,10 +74,7 @@ def export_widget_static(
             return val
 
         if isinstance(val, dict):
-            return {
-                k: _compress_and_check(v, f"{name}.{k}", depth + 1)
-                for k, v in val.items()
-            }
+            return {k: _compress_and_check(v, f"{name}.{k}", depth + 1) for k, v in val.items()}
 
         if isinstance(val, (list, tuple, np.ndarray)):
             arr = np.asarray(val)
@@ -108,11 +105,7 @@ def export_widget_static(
                 elif isinstance(raw_val, dict):
                     print(f"  [Sync] {name:<15} : Dictionary")
                 else:
-                    val_str = (
-                        str(raw_val)[:30] + "..."
-                        if len(str(raw_val)) > 30
-                        else str(raw_val)
-                    )
+                    val_str = str(raw_val)[:30] + "..." if len(str(raw_val)) > 30 else str(raw_val)
                     print(f"  [Sync] {name:<15} : {type(raw_val).__name__} = {val_str}")
 
             payload[name] = _compress_and_check(raw_val, name)


### PR DESCRIPTION
Closes #151. Part of #67.

`docs/contribute/setup.md` calls ruff "our single source of truth for code style" and tells contributors to run both halves. CI enforced only one: `ci-fast.yml` ran `uv run ruff check .` as the first step of `test`, and `ruff format --check` appeared in no workflow at all. There is no pre-commit config either, so the formatter was documented as law and enforced by nobody — it held only for contributors whose editor happened to format on save. That was an omission, not a decision: the lint gate arrived in 1f3c6dd (#92) and the formatter half was never picked up.

Pointing the formatter at the tree found `11 files would be reformatted` — and two different problems.

## The `.py` half: real drift

`processing/fourier.py` and `visualization/widget/_static_exporter.py` were wrapped as if the limit were 88, while `pyproject.toml` sets `line-length = 100`. The formatter only un-wraps; nothing semantic moves. Committed separately (`fabd4b3a`) so the mechanical diff is reviewable on its own.

Neither file is quoted into the docs — the only `literalinclude`s of library source are `contract.md`'s `fid.py` / `referencing.py` and `pull_requests.md`'s `deploy.yml`, all three pinned by hidden `assert` cells. Ran those asserts directly; they still pass.

## The `.md` half: not drift, and the actual decision

The other nine files are Markdown. ruff 0.16 formats Python code blocks *inside* Markdown, which quietly put every snippet on the docs site under the formatter — and there it does not fix layout, it removes it:

```diff
--- docs/concepts/architecture.md
-spectrum = (
-    mrsi_fid
-    .xmr.apodize_exp(lb=5.0)
-    .xmr.to_spectrum()
-    .xmr.to_ppm()
-)
+spectrum = mrsi_fid.xmr.apodize_exp(lb=5.0).xmr.to_spectrum().xmr.to_ppm()

--- docs/concepts/domains.md
-fid.xmr.autophase()        # → phased spectrum, ready to inspect
-spec.xmr.autophase()       # → phased spectrum (already home — no transform)
+fid.xmr.autophase()  # → phased spectrum, ready to inspect
+spec.xmr.autophase()  # → phased spectrum (already home — no transform)
```

Those are the pages the docs style rules exist to protect: the leading-dot chain *is* the argument in the architecture tour, and the aligned gutter *is* what makes the domain comparison scannable. Every one of those pages is executed as a test by nbmake, so their correctness is already gated — what is left is prose.

So `*.md` is excluded from ruff, with `force-exclude` so the rule also holds when a single file is named explicitly (an editor formatting the open buffer), not only when ruff walks the tree. `uv run ruff format .` is now safe to run over the whole repository, which it was not before.

## The gate

A dedicated `Lint` job, with the lint step removed from `test`. Same reasoning as the `Docs style` job already sitting above it — *a lint failure should read as a lint failure*. In `test` the check ran once per matrix leg, and a formatting nit stopped the maths from ever running.

Plus `uv run lint`, because `uv run test` does **not** lint, so nothing locally reproduced the CI job it looks like. It runs format-check before lint (the mechanical failure is the cheaper one to fix) and names the fix rather than only the fault:

```
$ uv run lint
🔎 Checking formatting...
unformatted: File would be reformatted
 --> src/xmris/core/utils.py:128:12
...
❌ Formatting drift. Fix it with: uv run ruff format .
```

## Two adjacent fixes in the ruff table

Both flagged separately because neither is formatting:

- **`target-version = "py312"` contradicted `requires-python = ">=3.10,<3.14"`.** The `UP` rules are selected, so ruff could propose syntax the `test (3.10)` leg cannot run. Deleted rather than corrected — ruff infers it from `requires-python`, so the two can never disagree again. `ruff check .` stays clean.
- **`[tool.ruff.lint.per-file-ignores]` was fictional.** It relieved `E501`/`F401`/`E402` for `docs/**/*.py` and `docs/**/*.ipynb`, but jupytext commits only `.md` and the notebooks it generates are gitignored — which ruff skips by default. Both patterns matched nothing, which is why `ruff check docs/` reports "No Python files found."

## Docs moved

The merge-gate count was stated in five places and all five went stale together: `pull_requests.md`'s intro, its section header, its table, its "drive it green" step, and `publishing.md` — including the label on its workflow mermaid. The table gains a `Lint` row and loses the lint half of the `test` row.

`setup.md` also stopped lying about `.vscode/settings.json`: it told contributors to create a file with `formatOnSave` and `codeActionsOnSave`, while the repo ships a deliberately short one that leaves those to user settings. It now describes the file that exists and offers the rest as an opt-in.

## ⚠️ One manual step after merge

`Lint` has to be added to the "Protect Main Branch" ruleset, which today requires exactly `Docs style`, `build`, `bare install`, `test (3.10)`, `test (3.13)`. Until then the job reports but does not gate. Doing it *before* the merge would block any branch predating the job — there are no other open PRs right now, so the window is clean.

## Verification

```
uv run lint                    exit 0 — 39 files formatted, all checks passed
                               exit 1 on injected drift, with the fix named
uv run ruff format --check README.md    skipped, not reformatted (force-exclude holds)
uv run test                    304 passed, 90% coverage
uv run mypy src/xmris          54 errors — identical count on origin/main, so none new
check_docs.py                  52 pages, 0 errors
myst build --html --strict     exit 0 (the new cross-reference from setup.md resolves)
```
