### PR TITLE
docs: a changelog, and the skill that writes it

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: changelog
+description: Write or update an xmris changelog entry — the user-facing record of what shipped in a release, in docs/changelog.md. Use at release time (the `release` skill calls it while the full matrix runs), or standalone to correct, re-curate or top up an existing version section.
+---
+
+# Write an xmris changelog entry
+
+`docs/changelog.md` answers one question, for one reader: *I just ran `pip install -U xmris` — what
+is different?* Nothing else on the site answers it. The [dev diary](#diary-about) records **why** a
+decision was made, the [roadmap](#roadmap) records **what is next**, and neither is a substitute:
+both are about reasoning, and this page is about consequences.
+
+There is no generator. `git log` is raw material, not a draft — the squash-merge subject says what
+the *diff* did, and a changelog bullet has to say what the *user* got. Turning one into the other is
+the whole job, and it is why this is a skill rather than a tool.
+
+```{note}
+**The genre carve-out.** House style lives in `CLAUDE.md` § "Documentation style" and is not
+restated here — with one exception, and it is a big one: **a changelog is a reference genre, not a
+motivated narrative.** No driving question, no felt tension, no admonition palette, no `{dropdown}`.
+A reader scans it; they do not read it. This is the only page on the site that works this way, so
+do not carry the shape *out* of here — and `docs-page`'s templates do not apply *in* here.
+```
+
+## 1. Establish the range
+
+```bash
+git describe --tags --abbrev=0            # the last released tag, e.g. v0.6.1
+git log <tag>..HEAD --reverse --no-merges --pretty='%h %s'
+```
+
+Every line in that output is accounted for by the end — as a bullet, or as a deliberate drop
+(§3). That accounting is what replaces a generator's guarantee that nothing was silently missed.
+
+Adding to a section that already exists (a release that slipped, a correction after the fact)? Use
+the range since the last commit the section already covers, and merge into the existing groups
+rather than appending a second block.
+
+## 2. Harvest the trail
+
+Every bullet carries links, and most of them are mechanical. Collect them per commit:
+
+| Link | Where it comes from |
+|---|---|
+| **PR** | the `(#N)` suffix squash-merge leaves on the subject |
+| **Issue(s)** | `gh pr view <N> --json body` — PR bodies here name what they close. Some subjects carry them inline: `… (#67 #69 #70 #80 #81 #82) (#105)` is six issues and one PR |
+| **Docs page** | `git show --stat <sha>` → a new or substantially rewritten `docs/**/*.md`; read its page target from the file head (`grep -m1 -oE '^\([a-z0-9-]+\)=' <file>`) |
+| **Diary entry** | the same `--stat` → a touched `docs/diary/*.md`; use its `(diary-…)=` target |
+
+`gh pr view <N> --json body` is also how you write the *sentence* when the subject does not explain
+the user impact. PR bodies in this repo are long and explicit about consequences; the subject is a
+headline. Read the body for anything you cannot describe in user terms from the subject alone.
+
+## 3. Decide what earns a bullet
+
+The test is **user-visible consequence**, not commit type. A `chore:` that changes what
+`pip install xmris` pulls in earns a bullet; a `feat:` that only adds an internal helper does not.
+
+| Material | Treatment |
+|---|---|
+| `chore(deps)` / `chore(deps-dev)` | **collapse** — one **Maintenance** bullet naming the count, no per-bump links |
+| `ci:` / `chore:` with no user-visible effect | **drop** |
+| `refactor:` behind an unchanged public surface | **drop**, unless it changed a default, a domain contract, or an error |
+| `docs:` | a bullet only when it changes what a reader should read or do — and then the new page *is* the link |
+| version bumps, merge-back noise, reverted pairs | **drop** |
+
+Write the drops down as you go. If a line is neither a bullet nor a stated drop, the accounting in
+§1 has not been done.
+
+## 4. Write it
+
+Group under bold-run labels, in this order, omitting any that is empty:
+
+**Breaking** · **Added** · **Changed** · **Fixed** · **Documentation** · **Maintenance**
+
+`**Breaking**` leads whenever it applies — pre-1.0, it applies often, and it is the only group a
+reader must not scroll past.
+
+One bullet, one sentence, then the trail:
+
+```markdown
+- `da.xmr.fit_amares` fits AMARES in the time domain and returns a `Dataset` of fitted parameters
+  alongside the reconstructed signals. — [#80](…/issues/80) · [#105](…/pull/105) ·
+  [AMARES in depth](#pyamares) · [diary](#diary-amares-fitting)
+```
+
+- **Trail order is fixed: issues → PRs → docs page → diary.** Issues and PRs are bare `#N` — the
+  convention `roadmap.md` and the contract already use — with full `https://github.com/…` URLs, since
+  a reader may arrive from PyPI. Pages are linked by their **title**; a diary entry by the word
+  *diary*.
+- **Docs and diary links use MyST targets** (`[text](#pyamares)`), never URLs or file paths. Targets
+  resolve page-globally and the build reports every one it cannot find, so that half of the trail is
+  machine-checkable — a URL is checked by nothing. Read §6 for how, and for the trap: an unresolved
+  target is a **warning**, so the exit code will not tell you.
+- **Name the public symbol**, never the internal module: `da.xmr.autophase`, `simulate_fid`,
+  `set_options` — not `processing/phasing.py`. The reader has never seen `src/`.
+- Past tense or plain present, one sentence, no lead-in ("This release adds…"). Say what it does now.
+- Several PRs delivering one capability get **one** bullet with several PR links, not one bullet each.
+
+## 5. Section shape and targets
+
+```markdown
+(changelog-v0-7-0)=
+## v0.7.0 — unreleased
+```
+
+- **One H2 per version, newest first, exactly one `(target)=` per version.** Deliberately no H3s:
+  the group labels are bold runs, so a release has one anchor — the one anyone would deep-link — and
+  inserting a version churns no other anchor. Commandment 8 binds here like everywhere else.
+- The target is the version with dots as hyphens: `v0.7.0` → `(changelog-v0-7-0)=`.
+- Heading reads `## vX.Y.Z — unreleased` until the release, then `## vX.Y.Z — YYYY-MM-DD`. The
+  `release` skill checks that word is gone before it tags.
+- `## Earlier releases` stays pinned at the bottom.
+
+Read `templates/entry.md` for the shape to copy.
+
+## 6. Verify
+
+```bash
+python3 .claude/skills/docs-page/check_docs.py docs/changelog.md          # 0 errors
+cd docs && uv run myst build --html --strict 2>&1 | tee /tmp/build.log    # must exit 0
+grep "No target for internal reference" /tmp/build.log                    # must print nothing
+```
+
+`myst build` is one-shot (~10 s warm). **Never `uv run docs`** — it starts a blocking preview server
+and never exits. It also leaves the shell in `docs/`; use absolute paths afterwards.
+
+```{warning}
+**The grep is not optional.** A broken `#target` is reported as a *warning*, and `--strict` only
+promotes **errors** to a non-zero exit — so a changelog full of dead cross-links builds green. The
+exit code catches a malformed directive; only the grep catches a mistyped target.
+```
+
+That covers the docs and diary half of every trail. Issue and PR numbers no build can check:
+spot-check a few against `gh pr view <N> --json title`.
+
+Then read the rendered page. Every bullet has to make sense to someone who has never seen the diff —
+that is the only test that matters, and it is not automatable.
+
+## Checklist
+
+<!-- excerpt:start -->
+- [ ] Range established from the last tag; **every commit in it is a bullet or a stated drop**
+- [ ] Bullets describe user-visible consequence, naming the public symbol — never a module path
+- [ ] Trail on every bullet, in order: issues → PRs → docs page → diary, the last two as MyST targets
+- [ ] `chore(deps)` collapsed to one **Maintenance** bullet; `ci:`/internal `chore:`/`refactor:` dropped
+- [ ] Groups in order, `**Breaking**` first where it applies; one H2 and one `(changelog-vX-Y-Z)=` per version, newest first
+- [ ] `check_docs.py` clean, `myst build --strict` exits 0, **and** the build log is free of `No target for internal reference` — the exit code alone does not prove the targets resolve
+- [ ] Rendered page read start to finish; no bullet requires the diff to understand
+<!-- excerpt:end -->

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -112,6 +112,13 @@ One bullet, one sentence, then the trail:
   `release` skill checks that word is gone before it tags.
 - `## Earlier releases` stays pinned at the bottom.
 
+**Never explain the page on the page.** The intro is one line of signposting to the diary and the
+roadmap, and it is already written — do not extend it, and never describe the format ("every entry
+links the issue that…"), the audience ("for someone who just ran `pip install -U`") or the
+changelog's own history. The reader can see the format; they are here for the bullets. The same
+applies to the one-line summary under a version heading: it names what shipped, not what the
+changelog is.
+
 Read `templates/entry.md` for the shape to copy.
 
 ## 6. Verify

--- a/.claude/skills/changelog/templates/entry.md
+++ b/.claude/skills/changelog/templates/entry.md
@@ -1,0 +1,59 @@
+# Changelog section skeleton
+
+Copy the structure below into `docs/changelog.md`, **above** the existing version sections and
+below the page intro. Prose only — no jupytext frontmatter, no kernel (the page is genre `other`,
+like `roadmap.md`, so nothing executes it).
+
+One H2 and one `(target)=` per version. No H3s: the group labels are bold runs, so a release owns
+exactly one anchor and inserting a version churns no other.
+
+---
+
+````markdown
+(changelog-v<X>-<Y>-<Z>)=
+## v<X>.<Y>.<Z> — unreleased
+
+**Breaking**
+- <What no longer works, and the one line that fixes it. This group leads whenever it exists —
+  it is the only one a reader must not scroll past.> — [#<issue>](…) · [#<pr>](…)
+
+**Added**
+- `<public.symbol>` <does what, for whom>. — [#<issue>](https://github.com/andrewendlinger/xmris/issues/<issue>) · [#<pr>](https://github.com/andrewendlinger/xmris/pull/<pr>) · [<Page title>](#<page-target>) · [diary](#diary-<slug>)
+
+**Changed**
+- <A default, a domain contract, an error message — anything a working pipeline would notice.> — [#<pr>](…)
+
+**Fixed**
+- <The wrong behaviour, stated as what the user saw, not as the root cause.> — [#<issue>](…) · [#<pr>](…)
+
+**Documentation**
+- <The new or rewritten page, linked by its title.> — [#<pr>](…) · [<Page title>](#<page-target>)
+
+**Maintenance**
+- <N> dependency updates, and <the packaging or CI change a user would actually notice>. — [#<pr>](…)
+````
+
+---
+
+## The rules the skeleton encodes
+
+| | |
+|---|---|
+| **Group order** | Breaking · Added · Changed · Fixed · Documentation · Maintenance. Drop any that is empty. |
+| **Trail order** | issues → PRs → docs page → diary. Fixed, so a reader learns to skim it. |
+| **Issues and PRs** | bare `#N` with the full `https://github.com/andrewendlinger/xmris/...` URL — readers arrive from PyPI, where a relative link is dead. |
+| **Docs and diary** | MyST targets (`[The Two Domains](#domains)`), never URLs or file paths — `myst build --strict` then verifies them for you. |
+| **Sentence** | names the public symbol, describes the consequence, needs no diff to understand. |
+| **`unreleased`** | stays in the heading until the release; the `release` skill refuses to tag while it is there. Replace with `— YYYY-MM-DD`. |
+
+## The bottom of the page
+
+Pinned last, written once, never regenerated:
+
+````markdown
+(changelog-earlier)=
+## Earlier releases
+
+v0.1.0 – v0.6.1 predate this changelog. Their contents are the
+[tag list](https://github.com/andrewendlinger/xmris/tags) and the commits between them.
+````

--- a/.claude/skills/changelog/templates/entry.md
+++ b/.claude/skills/changelog/templates/entry.md
@@ -13,6 +13,9 @@ exactly one anchor and inserting a version churns no other.
 (changelog-v<X>-<Y>-<Z>)=
 ## v<X>.<Y>.<Z> — unreleased
 
+<Optional: one line naming what shipped, if the release has a shape worth stating.
+ What shipped — never what the changelog is, how it is formatted, or who it is for.>
+
 **Breaking**
 - <What no longer works, and the one line that fixes it. This group leads whenever it exists —
   it is the only one a reader must not scroll past.> — [#<issue>](…) · [#<pr>](…)

--- a/.claude/skills/dev-diary/SKILL.md
+++ b/.claude/skills/dev-diary/SKILL.md
@@ -19,7 +19,7 @@ entry is rewritten ground-up into the current story — `Last edited` updated, t
 appended — rather than a sibling entry spawned. A new dated entry is for a new decision; the
 reader should never have to join two articles to get one answer.
 
-The `Dev Diary` group also has **one evergreen page** — `docs/diary/about.md` ("A dev diary for
+The `Dev Diary` group also has **one evergreen page** — `docs/diary/index.md` ("A dev diary for
 xmris") — that tells readers *what the diary is*. It is **not** an entry: no `Last edited` line, no
 assumptions block, no reconciliation, and it stays pinned at the **top** of the group. This skill
 governs the dated entries **below** it; touch `about.md` only when the diary's own workflow changes.

--- a/.claude/skills/docs-page/SKILL.md
+++ b/.claude/skills/docs-page/SKILL.md
@@ -24,10 +24,12 @@ any of them can reach for live `code-cell`s, real output and plots. What separat
 template applies. It holds the devices mined from the pages that work, each pointing at its live
 example so you copy rather than reinvent.
 
-**Two paths never route here:**
+**Three paths never route here:**
 
 - `docs/diary/` belongs to the **`dev-diary`** skill. Hand off; do not write an entry from here.
   (`check_docs.py` still checks entries — the structural rules in §2 bind every page in the tree.)
+- `docs/changelog.md` belongs to the **`changelog`** skill. It is a reference genre — no motivated
+  narrative, no live cells — so none of the templates below apply to it.
 - `docs/api/` is **generated and gitignored**. `docs_api()` clears the directory before
   regenerating, so a hand edit there is destroyed with no git history to recover it. Fix the
   docstring in `src/` instead.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,7 +22,9 @@ Pushing branches and tags triggers CI and an irreversible PyPI publish. **Confir
 
 2. **Determine the target version.** Show the current version (`uv version`) and the target implied by `$ARGUMENTS` (e.g. `0.2.0`). Confirm with the user — but **do not bump yet**.
 
-3. **Run the full matrix.** Push an *unbumped* `release/vX.Y.Z` branch — this triggers the full Ubuntu/Windows/macOS × Py 3.10–3.13 matrix in `ci-publish.yml`. Wait for it and check results with `gh run watch` / `gh run list`. If a job fails, fix it on the release branch and push again until green. **Every leg blocks, macOS included** — it was `continue-on-error` only while official `pyamares` hard-required `hlsvdpro` (no arm64 wheel); the `fitting` extra now depends on `pyamares-xmris`, whose platform marker skips it, so the exemption was removed in #105.
+3. **Run the full matrix — and write the changelog while it runs.** Push an *unbumped* `release/vX.Y.Z` branch — this triggers the full Ubuntu/Windows/macOS × Py 3.10–3.13 matrix in `ci-publish.yml`. Wait for it and check results with `gh run watch` / `gh run list`. If a job fails, fix it on the release branch and push again until green. **Every leg blocks, macOS included** — it was `continue-on-error` only while official `pyamares` hard-required `hlsvdpro` (no arm64 wheel); the `fitting` extra now depends on `pyamares-xmris`, whose platform marker skips it, so the exemption was removed in #105.
+
+   The matrix takes ~15 minutes and nothing depends on it here. Spend them on the changelog: **invoke the `changelog` skill** for `vX.Y.Z`. Its section in `docs/changelog.md` rides the bump commit in step 4, so the entry and the version land together in one pull request.
 
 4. **Bump and merge.** Once the matrix is green, bump on the release branch and land it through a PR — `main` takes no direct pushes:
    ```
@@ -31,22 +33,29 @@ Pushing branches and tags triggers CI and an irreversible PyPI publish. **Confir
    git push origin release/vX.Y.Z
    gh pr create --base main --title "chore: bump version to X.Y.Z"
    ```
-   Drive its four checks green; the user merges it (squash). Expect **two** CI cycles here: pushing
-   the bump re-triggers the full matrix on `release/**` (harmless, and it does test the bumped tree),
-   while the PR's four fast checks are the actual merge gate — do not wait on the matrix to merge.
+   The changelog section from step 3 belongs in this commit. Drive the PR's six checks green; the user merges it (squash). Expect **two** CI cycles here: pushing the bump re-triggers the full matrix on `release/**` (harmless, and it does test the bumped tree), while the PR's six fast checks are the actual merge gate — do not wait on the matrix to merge.
 
 5. **Tag & publish.** Tag the *merged* commit on `main` — **never the release branch**. PRs are squash-merged, so a tag cut before the merge would sit on a commit that never enters `main`'s history, leaving `git describe` on `main` blind to the release:
    ```
    git checkout main && git pull
-   git log --oneline -1          # MUST be the bump commit -- see below
-   uv version                    # MUST print X.Y.Z
+   git log --oneline -1                          # MUST be the bump commit -- see below
+   uv version                                    # MUST print X.Y.Z
+   grep -n "^## vX.Y.Z" docs/changelog.md        # MUST exist, and MUST NOT say "unreleased"
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
+   The changelog grep is the guard against the one failure this workflow cannot undo cheaply: a tag pushed for a version the changelog never described. Catch it here, before the tag — `ci-publish.yml` deliberately knows nothing about the changelog, because a check that fires *after* the tag would leave you deleting and re-pushing one.
+
    Check that tip before tagging: anything merged into `main` between the bump and the tag ships in
    this release without ever having seen the pre-flight matrix. If something did land, decide
    deliberately — either ship it (the tag re-runs the full matrix anyway) or tag the bump commit
    explicitly by SHA.
-   The tag re-runs the full matrix and then triggers `uv build --no-sources` + `uv publish` to PyPI via OIDC. Watch the publish run to confirm success. Delete the release branch afterwards.
+   The tag re-runs the full matrix and then triggers `uv build --no-sources` + `uv publish` to PyPI via OIDC. Watch the publish run to confirm success.
 
-6. **Wrap up.** Confirm the new version is live on PyPI and `main` is in the expected state. Summarize what shipped.
+6. **Announce it on GitHub.** Once the publish run is green and the version is live on PyPI, create the GitHub Release — this is what fills a body that used to be left empty:
+   ```
+   gh release create vX.Y.Z --title vX.Y.Z --notes-file <notes.md>
+   ```
+   Write `notes.md` to the scratchpad from the `vX.Y.Z` section you produced in step 3, converting the MyST target links (`[The Two Domains](#domains)`) to full docs URLs — GitHub cannot resolve them. Nothing in CI does this: creating the release by hand keeps `contents: write` off the job that publishes to PyPI, and means the announcement only ever exists for a version that actually shipped.
+
+7. **Wrap up.** Confirm the new version is live on PyPI and `main` is in the expected state. Delete the release branch. Summarize what shipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ If a change picks between ≥2 viable approaches, adds conceptual surface (a new
 
 Pass 1 is the change's **master overview** and its review gate: the plan file is right for executing and too heavy for approving, so the entry is what gets read on the rendered site (`uv run docs`) before work starts. It never restates the plan's steps. The skill always asks before writing anything — never decide that autonomously — and after committing the draft the turn **ends** so the user can review the page; implementation waits for their go-ahead.
 
-The `Dev Diary` section opens with one evergreen intro (`docs/diary/about.md`, pinned first) that explains what the diary *is*; dated entries follow it chronologically and carry a muted `Last edited` line rather than a status banner.
+The `Dev Diary` section opens with one evergreen intro (`docs/diary/index.md`, pinned first) that explains what the diary *is*; dated entries follow it chronologically and carry a muted `Last edited` line rather than a status banner.
 
 ## Environment & commands
 
@@ -56,5 +56,6 @@ Ruff: line length 100, NumPy docstring convention. Public functions need fully-t
 
 ## Commits & releases
 
-- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `add:`). Branch, then PR — `main` takes no direct pushes and requires six checks green (`Docs style`, `Lint`, `build`, `bare install`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
+- Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `ci:`, `chore:`, optional `(scope)`, `!` for breaking). Branch, then PR — `main` takes no direct pushes and requires six checks green (`Docs style`, `Lint`, `build`, `bare install`, `test (3.10)`, `test (3.13)`). PRs are squash-merged, so the **PR title** is the commit subject on `main`. The user merges; see @docs/contribute/pull_requests.md.
+- **The changelog is written at release time, not per PR.** `docs/changelog.md` is the canonical home (there is no root `CHANGELOG.md` — PyPI reaches it through `[project.urls]`). The `changelog` skill curates it from `git log` and PR bodies while the release matrix runs; the `release` skill invokes it and refuses to tag while the top section still says `unreleased`. Nothing is generated and no CI job parses it.
 - Release (see `/release`): never bump version until CI is green. Releases go through a `release/vX.Y.Z` branch (full test matrix), then the bump lands on `main` via a PR — and only *then* is `vX.Y.Z` tagged on the merged commit, which triggers the PyPI publish. Tagging before the merge would leave the tag outside `main`'s history. Bump with `uv version --bump patch|minor`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 **[Explore the official documentation](https://andrewendlinger.github.io/xmris/)** for tutorials, complete API references, and advanced usage guides.
 
+Upgrading? The **[changelog](https://andrewendlinger.github.io/xmris/changelog)** records what changed in each release. There is no `CHANGELOG.md` here — it is a rendered page, so every entry can link the issue, the pull request, and the documentation behind it.
+
 
 
 ## 02. Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,18 +1,13 @@
 (changelog)=
 # Changelog
 
-What changed in each release of `xmris`, for someone who just ran `pip install -U xmris`. Every
-entry links the issue that motivated it, the pull request that shipped it, and — where one exists —
-the page that documents it or the [diary](#diary-about) entry that argued it.
-
-Two neighbours answer different questions: the [dev diary](#diary-about) records *why* a decision was
-made, and the [roadmap](#roadmap) records what is coming. This page records only consequences.
+The [dev diary](#diary-about) records *why*; the [roadmap](#roadmap) records what is next.
 
 (changelog-v0-7-0)=
 ## v0.7.0 — unreleased
 
-The first release with a changelog, and a large one: the fitting subsystem, the domain-contract
-engine, a hardened vocabulary, and a documentation site rebuilt around them.
+The fitting subsystem, the domain-contract engine, a hardened vocabulary, and a documentation site
+rebuilt around them.
 
 **Breaking**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,8 @@
 (changelog)=
 # Changelog
 
-The [dev diary](#diary-about) records *why*; the [roadmap](#roadmap) records what is next.
+What shipped in each release; *why* is in the [dev diary](#diary-about), what is next in the
+[roadmap](#roadmap).
 
 (changelog-v0-7-0)=
 ## v0.7.0 — unreleased

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,156 @@
+(changelog)=
+# Changelog
+
+What changed in each release of `xmris`, for someone who just ran `pip install -U xmris`. Every
+entry links the issue that motivated it, the pull request that shipped it, and — where one exists —
+the page that documents it or the [diary](#diary-about) entry that argued it.
+
+Two neighbours answer different questions: the [dev diary](#diary-about) records *why* a decision was
+made, and the [roadmap](#roadmap) records what is coming. This page records only consequences.
+
+(changelog-v0-7-0)=
+## v0.7.0 — unreleased
+
+The first release with a changelog, and a large one: the fitting subsystem, the domain-contract
+engine, a hardened vocabulary, and a documentation site rebuilt around them.
+
+**Breaking**
+
+- The controlled vocabulary is **canonical-only** — no aliases. Bruker multi-receiver data now loads
+  with the dimension `coil` (was `channels`), acquisition dimensions are singular (`average`,
+  `repetition`), vocabulary terms are frozen against mutation, and the legacy `bruker_group_delay`
+  attribute fallback is gone. Rename inbound dimensions with `obj.rename({...})` until
+  `da.xmr.map_vocab` lands. — [#65](https://github.com/andrewendlinger/xmris/issues/65) ·
+  [#96](https://github.com/andrewendlinger/xmris/pull/96) ·
+  [The controlled vocabulary](#vocabulary)
+
+**Added**
+
+- `da.xmr.fit_amares` fits AMARES in the time domain and returns a `Dataset` of fitted parameters
+  alongside the reconstructed signals. It meets data in either domain and returns it unchanged,
+  normalises away the magnitude scale trap that made Bruker-scale FIDs "converge" on their prior,
+  and writes `NaN` for a failed voxel rather than a spurious zero. `build_prior_knowledge` replaces
+  pyAMARES's positional CSV with a named-peak dict, and the optimizer itself lives behind the
+  optional `xmris[fitting]` extra, so a bare `import xmris` never pulls it in. —
+  [#67](https://github.com/andrewendlinger/xmris/issues/67)
+  [#69](https://github.com/andrewendlinger/xmris/issues/69)
+  [#70](https://github.com/andrewendlinger/xmris/issues/70)
+  [#80](https://github.com/andrewendlinger/xmris/issues/80)
+  [#81](https://github.com/andrewendlinger/xmris/issues/81)
+  [#82](https://github.com/andrewendlinger/xmris/issues/82) ·
+  [#105](https://github.com/andrewendlinger/xmris/pull/105) ·
+  [Quick start: fitting](#fitting-quickstart) · [AMARES in depth](#pyamares) ·
+  [diary](#diary-amares-fitting)
+- Every domain-sensitive transform now declares the domain it works in, via `@computes_in`
+  (domain-preserving) or `@ensures_domain` (funnelling), so passing a FID where a spectrum is wanted
+  converts instead of returning nonsense. — [#42](https://github.com/andrewendlinger/xmris/issues/42)
+  [#63](https://github.com/andrewendlinger/xmris/issues/63) ·
+  [#73](https://github.com/andrewendlinger/xmris/pull/73) ·
+  [#77](https://github.com/andrewendlinger/xmris/pull/77) ·
+  [#78](https://github.com/andrewendlinger/xmris/pull/78) ·
+  [The Two Domains](#domains) · [Domain contracts in action](#domain-contracts)
+- `xmris.set_options(auto_convert=False)` turns that automatic conversion into a loud error naming
+  the converter to call — strict mode for quantitative work. Global or a context manager, mirroring
+  `xr.set_options`. — [#63](https://github.com/andrewendlinger/xmris/issues/63) ·
+  [#79](https://github.com/andrewendlinger/xmris/pull/79) · [The Two Domains](#domains)
+- `da.xmr.baseline_als` corrects a spectral baseline by asymmetric least squares. —
+  [#43](https://github.com/andrewendlinger/xmris/issues/43) ·
+  [#44](https://github.com/andrewendlinger/xmris/pull/44) · [Baseline correction](#baseline)
+- `da.xmr.estimate_group_delay` measures a Bruker group delay from the data by minimising the
+  residual, instead of trusting the header value. —
+  [#85](https://github.com/andrewendlinger/xmris/issues/85) ·
+  [#89](https://github.com/andrewendlinger/xmris/pull/89) · [Bruker — group delay](#bruker-grpdly)
+- `da.xmr.widget.scroll_spectra` scrolls through a stack of spectra, and `da.xmr.widget.apodize`
+  tunes line broadening against a live plot. Both render in the built documentation, not only in a
+  running kernel. — [#16](https://github.com/andrewendlinger/xmris/issues/16) ·
+  [#37](https://github.com/andrewendlinger/xmris/pull/37) ·
+  [#38](https://github.com/andrewendlinger/xmris/pull/38) ·
+  [#40](https://github.com/andrewendlinger/xmris/pull/40) ·
+  [Interactive scrolling](#widget-scroller) · [Interactive apodization](#widget-apodization)
+
+**Changed**
+
+- `xmris` is released under **BSD-3-Clause**, replacing AGPL-3.0. —
+  [#130](https://github.com/andrewendlinger/xmris/pull/130)
+- `autophase` was rewritten for robustness, and `nmrglue` is no longer a dependency. —
+  [#30](https://github.com/andrewendlinger/xmris/issues/30) ·
+  [#36](https://github.com/andrewendlinger/xmris/pull/36) ·
+  [Automated phase correction](#autophase-intro)
+- Plotting is configured by objects rather than keyword soup — `WaterfallConfig`, `CarpetConfig`,
+  `PlotTrajectoryConfig`, `PlotQCGridConfig`, reached through `da.xmr.plot`. —
+  [#39](https://github.com/andrewendlinger/xmris/issues/39) ·
+  [#41](https://github.com/andrewendlinger/xmris/pull/41) ·
+  [Config-based plotting](#plot-basics) · [Waterfall plots](#waterfall) · [Carpet plots](#carpet)
+- `apodize_exp`, `apodize_lg` and `zero_fill` return the representation you handed them, while
+  `baseline_als` funnels into the spectral domain and stays there. —
+  [#63](https://github.com/andrewendlinger/xmris/issues/63) ·
+  [#78](https://github.com/andrewendlinger/xmris/pull/78) · [The Two Domains](#domains)
+
+**Fixed**
+
+- A bare `pip install xmris` was unimportable: matplotlib is imported by every `import xmris` but
+  arrived only transitively through pyAMARES, and vanished when pyAMARES moved to the `fitting`
+  extra. `requires-python` also read `<=3.13`, which PEP 440 resolves to `<= 3.13.0` — admitting no
+  3.13 patch release. Both are fixed, and CI now installs the way a user does. —
+  [#122](https://github.com/andrewendlinger/xmris/issues/122) ·
+  [#147](https://github.com/andrewendlinger/xmris/pull/147)
+- `fit_amares` reads the canonical `reference_frequency` attribute, so FIDs produced by
+  `simulate_fid` fit without a manual `mhz=`. —
+  [#68](https://github.com/andrewendlinger/xmris/issues/68) ·
+  [#93](https://github.com/andrewendlinger/xmris/pull/93)
+- Waterfall and carpet plots reject complex input instead of silently plotting its real part, and
+  keep the time axis's units. — [#83](https://github.com/andrewendlinger/xmris/issues/83) ·
+  [#94](https://github.com/andrewendlinger/xmris/pull/94)
+- `import xmris` no longer emits a `DeprecationWarning`. —
+  [#67](https://github.com/andrewendlinger/xmris/issues/67) ·
+  [#92](https://github.com/andrewendlinger/xmris/pull/92)
+
+**Documentation**
+
+- The site was rebuilt: one directory per chapter, hands-on tutorials split from concept explainers,
+  and a landing page per chapter. — [#126](https://github.com/andrewendlinger/xmris/issues/126)
+  [#137](https://github.com/andrewendlinger/xmris/issues/137) ·
+  [#139](https://github.com/andrewendlinger/xmris/pull/139)
+- The contributor documentation is new in full: [The Architecture Contract](#contract) — the eleven
+  rules every change to `src/xmris/` obeys — a page per kind of contribution, and
+  [the dev diary](#diary-about). —
+  [#72](https://github.com/andrewendlinger/xmris/issues/72) ·
+  [#103](https://github.com/andrewendlinger/xmris/pull/103) ·
+  [#114](https://github.com/andrewendlinger/xmris/pull/114) ·
+  [Contribute](#contribute-home) · [Open a pull request](#contribute-pr) ·
+  [diary](#diary-architecture-contract)
+- Two explainers for the design decisions users hit first: [The Two Domains](#domains) on why a
+  function cares whether it is handed a FID or a spectrum, and
+  [The controlled vocabulary](#vocabulary) on why the names are fixed. —
+  [#76](https://github.com/andrewendlinger/xmris/pull/76) ·
+  [#100](https://github.com/andrewendlinger/xmris/pull/100)
+- [The roadmap](#roadmap) says what is shipped, in motion, and still being argued about. —
+  [#116](https://github.com/andrewendlinger/xmris/issues/116) ·
+  [#123](https://github.com/andrewendlinger/xmris/pull/123) ·
+  [#145](https://github.com/andrewendlinger/xmris/pull/145)
+- Every pull request now publishes a fully executed preview of the site it would produce. —
+  [#112](https://github.com/andrewendlinger/xmris/pull/112) ·
+  [How the documentation reaches the web](#contribute-pr-deployment) · [diary](#diary-docs-previews)
+
+**Maintenance**
+
+- The documentation pages *are* the maths tests — every tutorial and explainer is executed by
+  `nbmake` on both ends of the supported Python range, and a whole-tree docs-style checker gates the
+  merge. — [#104](https://github.com/andrewendlinger/xmris/issues/104) ·
+  [#110](https://github.com/andrewendlinger/xmris/pull/110) ·
+  [diary](#diary-authoring-skills)
+- Seven dependency updates, now arriving weekly via Dependabot, plus CI hardening: the site is published from
+  workflow artifacts rather than a 103 MB committed branch, the Codecov uploader comes from PyPI so
+  an outage cannot block every merge, and `ruff format` is gated for the first time. —
+  [#115](https://github.com/andrewendlinger/xmris/issues/115)
+  [#141](https://github.com/andrewendlinger/xmris/issues/141)
+  [#151](https://github.com/andrewendlinger/xmris/issues/151) ·
+  [#142](https://github.com/andrewendlinger/xmris/pull/142) ·
+  [#146](https://github.com/andrewendlinger/xmris/pull/146) ·
+  [#152](https://github.com/andrewendlinger/xmris/pull/152)
+
+(changelog-earlier)=
+## Earlier releases
+
+v0.1.0 – v0.6.1 predate this changelog. Their contents are the
+[tag list](https://github.com/andrewendlinger/xmris/tags) and the commits between them.

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -35,8 +35,9 @@ flowchart LR
 :::{note}
 **For Claude Code users:** four of the skills under
 [`.claude/skills/`](https://github.com/andrewendlinger/xmris/tree/main/.claude/skills) fire on the
-matching change above; a fifth, user-triggered `release` skill drives [cutting a
-release](#contribute-release). None carries rules of its own — each routes to the one canonical doc
+matching change above; two more drive [cutting a release](#contribute-release) — the user-triggered
+`release` skill, and the `changelog` skill it invokes to write that release's
+[changelog](#changelog) entry. None carries rules of its own — each routes to the one canonical doc
 that owns it, obeying the same "one home per concept" rule these docs preach.
 :::
 
@@ -47,9 +48,10 @@ that owns it, obeying the same "one home per concept" rule these docs preach.
    confirm `uv run test` is green.
 2. **Make your change**, following the page for its kind above. A significant decision starts as a
    [dev-diary draft](#contribute-dev-diary) that gets reviewed before the code is written.
-3. [**Open a pull request**](#contribute-pr) against `main` — `main` takes no direct pushes. Four
-   checks gate the merge: the test suite on Python 3.10 and 3.13, the docs style checker, and an
-   executed build of this documentation, so a broken notebook fails your branch rather than `main`.
+3. [**Open a pull request**](#contribute-pr) against `main` — `main` takes no direct pushes. Six
+   checks gate the merge: the test suite on Python 3.10 and 3.13, ruff, the docs style checker, an
+   install of only what a real user receives, and an executed build of this documentation, so a
+   broken notebook fails your branch rather than `main`.
    That build also publishes your change as a **live preview site**, which is where anything
    reader-facing gets reviewed.
 4. **Drive it green, then hand off** — a maintainer reviews and merges. Cutting a release is a

--- a/docs/contribute/publishing.md
+++ b/docs/contribute/publishing.md
@@ -56,6 +56,36 @@ macOS legs used to be `continue-on-error`, because official `pyamares` hard-requ
 
 ---
 
+(release-changelog)=
+## ②b The Changelog
+
+The matrix in ② takes roughly fifteen minutes and nothing else depends on it. That is when the
+[changelog](#changelog) entry gets written, so it is ready to ride the bump commit in ③ — one pull
+request carries both the new version and the description of what is in it.
+
+There are no changelog fragments to collect and no generator to run. `git log` since the last tag is
+raw material, not a draft: a squash-merge subject says what the *diff* did, and an entry has to say
+what the *user* got. Every bullet carries its trail — the issue, the pull request, and the page or
+diary entry behind it — so a reader can always get from a one-line consequence back to the reasoning.
+
+```{note}
+**For Claude Code users:** the [`changelog` skill](https://github.com/andrewendlinger/xmris/blob/main/.claude/skills/changelog/SKILL.md)
+does this, and the `release` skill invokes it at this step. Its checklist:
+```
+
+```{literalinclude} ../../.claude/skills/changelog/SKILL.md
+:language: markdown
+:start-after: <!-- excerpt:start -->
+:end-before: <!-- excerpt:end -->
+```
+
+Two properties of the entry are load-bearing later. Its heading says `unreleased` until the release,
+and ③ refuses to tag while that word is there — the only guard against a tag whose version the
+changelog never described. And its cross-links are MyST targets rather than URLs, so the build
+reports any that no longer resolve.
+
+---
+
 (release-tag-publish)=
 ## ③ Bump, Merge, Then Tag
 
@@ -97,12 +127,23 @@ The `v*` tag triggers the `publish` job in `ci-publish.yml`. It uses `uv build -
 (release-cleanup)=
 ## ④ After the Release
 
-The merge in ③ already put the bump on `main`, so cleanup is only:
+The merge in ③ already put the bump on `main`, so what is left is:
 
-- delete the release branch (GitHub offers this on the merge, or `git push origin --delete release/v0.2.0`),
-- confirm the new version is live on PyPI.
+- confirm the new version is live on PyPI,
+- create the GitHub Release — `gh release create v0.2.0 --title v0.2.0 --notes-file …`, its body the
+  changelog section written in ②b, with the MyST target links rewritten as full documentation URLs
+  because GitHub cannot resolve them,
+- delete the release branch (GitHub offers this on the merge, or `git push origin --delete release/v0.2.0`).
 
 The `v*` tag stays as the permanent release marker.
+
+```{note}
+The GitHub Release is created by hand rather than by `ci-publish.yml`, deliberately. Automating it
+would mean granting `contents: write` to the one job that publishes to PyPI, and parsing
+`docs/changelog.md` inside the pipeline — where a failure lands *after* the tag is pushed, and
+recovery means deleting and re-pushing a tag. Doing it here costs one command and can only ever
+announce a version that actually shipped.
+```
 
 ---
 
@@ -135,12 +176,14 @@ flowchart TD
         E -->|"No"| F["Fix on the release branch"]
         F -->|"push fix"| D
         E -->|"Yes"| G
+        D -.->|"while it runs"| CL["②b Write the changelog entry"]
     end
 
     G -.-> H
+    CL -.-> H
 
     subgraph publish ["③ Bump, merge, then tag"]
-        H["Bump on the release branch"] --> I["PR into main, merge"]
+        H["Bump + changelog, one commit"] --> I["PR into main, merge"]
         I -->|"tag v* on main"| J["Publish job: uv build --no-sources"]
         J -->|"Trusted Publishing"| K[("PyPI")]
     end
@@ -148,7 +191,7 @@ flowchart TD
     K -.-> L
 
     subgraph after ["④ After the release"]
-        L["Delete the branch, verify on PyPI"]
+        L["GitHub Release from the entry, delete the branch, verify on PyPI"]
     end
 
     style dev fill:#f0f7ff,stroke:#4a90d9,stroke-width:2px,color:#1a1a1a

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -30,11 +30,15 @@ git checkout -b <type>/<short-slug>     # e.g. feat/apodize-gauss, docs/domains-
 The **pull request title** becomes the commit subject on `main`, because pull requests are
 squash-merged — so it is the title, not your individual commits, that has to read well in
 `git log`. Use a [Conventional Commit](https://www.conventionalcommits.org/) prefix: `feat:`,
-`fix:`, `docs:`, `chore:`, `ci:`, `add:`.
+`fix:`, `docs:`, `refactor:`, `test:`, `ci:`, `chore:`. A parenthesised scope is encouraged where
+it narrows usefully — `fix(packaging)`, `chore(ci)`, `feat(fitting)` — and a `!` before the colon
+marks a breaking change.
 
 The body is where you say what moved. If you consolidated documentation — thinned one page into
 another, gave a concept a new home — name the pages, because that is the part a reviewer cannot see
-from the diff alone.
+from the diff alone. Write it for someone who was not in the discussion: at release time the
+[changelog](#changelog) entry for your change is written from this body, not from the diff, and it
+carries your issue and pull-request numbers forward as its trail.
 
 (contribute-pr-open)=
 ## 2. Open it against `main`

--- a/docs/diary/index.md
+++ b/docs/diary/index.md
@@ -51,4 +51,8 @@ flowchart LR
 :::{seealso}
 Writing one yourself? [Write a dev-diary entry](#contribute-dev-diary) has the
 mechanics, straight from the skill that drives it.
+
+After *what changed in a release* rather than why a design is the way it is? That
+is the [changelog](#changelog) — one line per change, linking back to entries here
+where one exists.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,7 +146,10 @@ need — every chapter title is also a page that summarises what is under it.
 | [Contribute](#contribute-home) | Setup, the Architecture Contract, one page per kind of change | You are opening a pull request |
 | [Dev diary](#diary-about) | One entry per significant decision, told as a story | You found a design choice you cannot explain |
 | [Roadmap](#roadmap) | What is shipped, in motion, and still being argued about | You are wondering whether to wait for something |
-| [Changelog](#changelog) | What changed in each release, with the issue and pull request behind it | You just upgraded and something behaves differently |
 
 Every page in the first six chapters is an executable notebook: the plots and numbers you see were
 produced by the code above them, and they run on every pull request.
+
+Not a chapter, and not in the sidebar: the [changelog](#changelog) records what changed in each
+release, if you have just upgraded and something behaves differently. It lives under **Project** in
+the header.

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,6 +146,7 @@ need — every chapter title is also a page that summarises what is under it.
 | [Contribute](#contribute-home) | Setup, the Architecture Contract, one page per kind of change | You are opening a pull request |
 | [Dev diary](#diary-about) | One entry per significant decision, told as a story | You found a design choice you cannot explain |
 | [Roadmap](#roadmap) | What is shipped, in motion, and still being argued about | You are wondering whether to wait for something |
+| [Changelog](#changelog) | What changed in each release, with the issue and pull request behind it | You just upgraded and something behaves differently |
 
 Every page in the first six chapters is an executable notebook: the plots and numbers you see were
 produced by the code above them, and they run on every pull request.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -221,6 +221,13 @@ project:
     # Its decision notebooks are niche and reachable from the decision board on
     # the page itself, so they stay in the TOC (hidden entries are still built
     # and still resolve as link targets) but out of the sidebar.
+    #
+    # The changelog hides here for the same reason, and pairs: the roadmap is
+    # what is coming, the changelog what shipped. The sidebar is for what you
+    # browse, and nobody browses a changelog -- you arrive at it from the
+    # header's Project menu, from a link in the page you were already reading,
+    # or from PyPI. That makes the `nav` entry below load-bearing, not a
+    # convenience: it is the only navigational route to this page.
     - file: roadmap.md
       title: Roadmap
       children:
@@ -230,12 +237,9 @@ project:
         - file: decisions/decision_02b_physics_constants.md
           title: 02b · Constants — exploration
           hidden: true
-
-    # 11. Changelog -- the other bookend to the roadmap, and a plain article for
-    # the same reason: what shipped belongs next to what is coming, not inside a
-    # chapter. Written by the `changelog` skill at release time.
-    - file: changelog.md
-      title: Changelog
+        - file: changelog.md
+          title: Changelog
+          hidden: true
 
 site:
   template: book-theme

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -231,6 +231,12 @@ project:
           title: 02b · Constants — exploration
           hidden: true
 
+    # 11. Changelog -- the other bookend to the roadmap, and a plain article for
+    # the same reason: what shipped belongs next to what is coming, not inside a
+    # chapter. Written by the `changelog` skill at release time.
+    - file: changelog.md
+      title: Changelog
+
 site:
   template: book-theme
   title: xmris
@@ -273,6 +279,8 @@ site:
           url: /diary
         - title: Roadmap
           url: /roadmap
+        - title: Changelog
+          url: /changelog
 
   actions:
     - title: GitHub

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -137,7 +137,7 @@ This very page — the roadmap you are reading is being written and argued right
 ::::{div}
 :class: roadmap-item roadmap-item--minor
 
-A changelog begins — its first entry is this release
+[A changelog](#changelog) begins — its first entry is this release
 [#10](https://github.com/andrewendlinger/xmris/issues/10)
 ::::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ fitting = [
 [project.urls]
 Repository = "https://github.com/andrewendlinger/xmris"
 Documentation = "https://andrewendlinger.github.io/xmris/"
+# There is no root CHANGELOG.md by design -- the changelog is a rendered docs page
+# (xarray/pandas/numpy do the same). PyPI surfaces this key in the project sidebar,
+# which is how a packager still finds it.
+Changelog = "https://andrewendlinger.github.io/xmris/changelog"
 
 [project.scripts]
 docs-api = "xmris._scripts:docs_api"                    # Update API references


### PR DESCRIPTION
Closes #10, and ticks the "Changelog + conventional-commit standard" box in #67.

`docs/roadmap.md` has promised this publicly for a while — *"A changelog begins — its first entry is this release."* Today there is nothing: no `CHANGELOG.md`, no tooling, and of seven tags only two have a GitHub Release, both with **empty bodies**. Meanwhile v0.6.1 shipped in March and 64 commits have piled up behind it.

## The driving question

The gap was never information. PRs are squash-merged, so `git log main --oneline` is already one conventional-commit line per PR with its number attached, and the PR bodies here are essays. What was missing is that **nobody ever writes the user-facing sentence** — the one that says what someone who just ran `pip install -U xmris` actually got.

So this is a curation problem, not a generation problem, and the design follows from that.

## What lands

- **`docs/changelog.md`** — canonical, and the only home. No root `CHANGELOG.md`, following xarray/pandas/numpy: MyST targets render as literal junk text on GitHub, and the site is where this project's documentation lives. PyPI reaches it through a new `[project.urls] Changelog` key.
- **`.claude/skills/changelog/`** — SKILL.md plus a template, in the `dev-diary`/`docs-page` house shape. It converts `git log` into consequences, and harvests the trail each bullet carries — issue → PR → the page it produced → the diary entry that argued it — from the PR body and `git show --stat`.
- **The v0.7.0 section, already drafted.** Docs deploy per merge rather than per release, so an empty page would go live immediately; and drafting it now tests the skill against five months of real material rather than a toy. All 64 commits are accounted for as a bullet or a deliberate drop.
- **Release wiring**, in `.claude/skills/release/SKILL.md` only: step 3 invokes the skill during the ~15 minutes of matrix time nothing else depends on, step 5 greps for the version before tagging and refuses while the heading says `unreleased`, and step 6 finally creates a GitHub Release with a body in it.

**No workflow file is touched and no executable code is added.**

## Two mechanisms considered and dropped

<details>
<summary>A CI gate on PR titles</summary>

Justified only as what makes a *generated* changelog trustworthy. Nothing is generated — the curator reads PR bodies, not subjects. It would have cost a new workflow, a new script, a seventh required check, and a sweep of the "six checks" count across five files, a number that has already gone stale twice. #10's "standardize our commits" stays prose-enforced, where it already sits at ~93% adherence unaided.
</details>

<details>
<summary>Parsing the changelog inside <code>ci-publish.yml</code></summary>

It would fail *after* the tag is pushed, with recovery meaning delete-and-re-push a tag — fragility in the one irreversible path — and it wants `contents: write` on the job that publishes to PyPI. The step-5 grep is the same guard, before the irreversible step instead of inside it.
</details>

<details>
<summary>towncrier fragments, and release-please</summary>

Fragments (pytest, NumPy, scikit-learn, MNE) exist to solve a merge-conflict problem on a shared changelog file — one this repo does not have, so it would be a per-PR tax for nothing. release-please, which #10 originally named, does not just write a changelog: it owns versioning, and would replace the release flow deliberately built in #114.
</details>

## Also in passing

All in files this change already opens:

- Documented commit prefixes drop the non-standard `add:` (5 uses, all early history; `feat:` covers it) and gain `refactor:`/`test:`, scopes and `!` — used heavily, documented nowhere.
- `CLAUDE.md` and `dev-diary/SKILL.md` still named `docs/diary/about.md`, renamed to `index.md` in #139.
- `docs-page/SKILL.md` now routes `docs/changelog.md` away, as it already does `docs/diary/` — its templates are all motivated-narrative genres, and the changelog is deliberately a reference one. That carve-out is the one piece of new conceptual surface here.

## Verification

- `check_docs.py` — 0 errors, 16 warnings (the baseline)
- `myst build --html --strict` — exit 0, **zero warnings tree-wide**
- `uv run lint` — clean
- `uv run test` — 304 passed

Worth knowing, and now written into the skill: an unresolved `#target` is reported as a **warning**, so `--strict` still exits 0 on it. The check is a grep for `No target for internal reference`, not the exit code. Confirmed by deliberately breaking a target and watching the build stay green.

**Read it rendered** at `/pr-preview/pr-N/changelog` — that is the only test that matters here.