### PR TITLE
docs(contribute): give the changelog skill the page every other skill has

### DIFF
--- a/docs/contribute/changelog_entries.md
+++ b/docs/contribute/changelog_entries.md
@@ -1,0 +1,45 @@
+(contribute-changelog)=
+# Write a changelog entry
+
+The [changelog](#changelog) answers one question, for one reader: *I just ran
+`pip install -U xmris` — what is different?* Nothing else on the site answers it. The
+[dev diary](#diary-about) records **why** a decision was made and the [roadmap](#roadmap) records
+**what is next**; both are about reasoning, and this page is about consequences.
+
+It is written **at release time, not per pull request** — during the fifteen minutes the full
+matrix runs, so the entry rides the version bump into `main` in a single pull request
+([Publishing, step ②b](#release-changelog)).
+
+There is no generator and there are no fragment files to collect. `git log` since the last tag is
+raw material, not a draft: a squash-merge subject says what the *diff* did, and a bullet has to say
+what the *user* got. Turning one into the other is the whole job. What replaces a generator's
+guarantee that nothing was silently missed is an accounting rule — every commit in the range ends
+up either a bullet or a deliberate, stated drop — and what earns a bullet is **user-visible
+consequence, not commit type**. A `chore:` that changes what `pip install xmris` pulls in earns
+one; a `feat:` that only adds an internal helper does not.
+
+Every bullet then carries its trail, in a fixed order: issues → pull requests → the docs page it
+produced → the diary entry that argued it, so a reader can always get from a one-line consequence
+back to the reasoning. The last two are MyST targets rather than URLs, which makes that half of the
+trail machine-checkable — with one trap: an unresolved target is a *warning*, and `--strict` only
+promotes errors, so the build log has to be grepped rather than trusted to its exit code.
+
+:::{note}
+**The genre carve-out.** The changelog is the one page on this site that is a **reference genre**:
+no driving question, no felt tension, no admonitions, no dropdowns. A reader scans it; they do not
+read it. The [four house-style rules](#contribute-docs) bind everywhere else — so do not carry this
+shape out of `docs/changelog.md`, and do not carry theirs in.
+:::
+
+(contribute-changelog-skill)=
+## Working with Claude Code
+
+The **`changelog`** skill's checklist:
+
+```{literalinclude} ../../.claude/skills/changelog/SKILL.md
+:language: markdown
+:start-after: <!-- excerpt:start -->
+:end-before: <!-- excerpt:end -->
+:caption: Quote from the [changelog/SKILL.md](https://github.com/andrewendlinger/xmris/blob/main/.claude/skills/changelog/SKILL.md)
+:class: skill-quote
+```

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -14,6 +14,7 @@ change you are making**. Find your row and follow the page it points to:
 | An interactive widget — a UI over the maths | [Add a widget](#contribute-widget) | [The Architecture Contract](#contract) |
 | A docs page — tutorial, explainer, or guide | [Write a docs page](#contribute-docs) | Documentation style |
 | The record of a significant decision | [Write a dev-diary entry](#contribute-dev-diary) | [A dev diary for xmris](#diary-about) |
+| The record of what shipped in a release | [Write a changelog entry](#contribute-changelog) | [Publishing](#contribute-release) |
 
 Each of those pages carries a **live checklist**, rendered straight from the Claude Code skill that
 automates that kind of change — so whether you work by hand or with Claude, you follow the same,
@@ -26,19 +27,21 @@ flowchart LR
     C2["Widget"] --> W["xmr-widget"]
     C3["Docs page"] --> P["docs-page"]
     C4["Decision record"] --> V["dev-diary"]
+    C5["Release record"] --> L["changelog"]
     M --> A["Architecture Contract — the Commandments"]
     W --> A
     P --> H["Documentation style"]
     V --> H
+    L --> R["Publishing — the release workflow"]
 ```
 
 :::{note}
-**For Claude Code users:** four of the skills under
+**For Claude Code users:** five of the skills under
 [`.claude/skills/`](https://github.com/andrewendlinger/xmris/tree/main/.claude/skills) fire on the
-matching change above; two more drive [cutting a release](#contribute-release) — the user-triggered
-`release` skill, and the `changelog` skill it invokes to write that release's
-[changelog](#changelog) entry. None carries rules of its own — each routes to the one canonical doc
-that owns it, obeying the same "one home per concept" rule these docs preach.
+matching change above; the sixth, the user-triggered `release` skill, drives [cutting a
+release](#contribute-release) and invokes `changelog` along the way. None carries rules of its own
+— each routes to the one canonical doc that owns it, obeying the same "one home per concept" rule
+these docs preach.
 :::
 
 (contribute-home-first)=

--- a/docs/contribute/publishing.md
+++ b/docs/contribute/publishing.md
@@ -61,23 +61,13 @@ macOS legs used to be `continue-on-error`, because official `pyamares` hard-requ
 
 The matrix in ② takes roughly fifteen minutes and nothing else depends on it. That is when the
 [changelog](#changelog) entry gets written, so it is ready to ride the bump commit in ③ — one pull
-request carries both the new version and the description of what is in it.
+request carries both the new version and the description of what is in it. How an entry is curated,
+and why nothing generates it, is its own page: [Write a changelog entry](#contribute-changelog).
 
-There are no changelog fragments to collect and no generator to run. `git log` since the last tag is
-raw material, not a draft: a squash-merge subject says what the *diff* did, and an entry has to say
-what the *user* got. Every bullet carries its trail — the issue, the pull request, and the page or
-diary entry behind it — so a reader can always get from a one-line consequence back to the reasoning.
-
-```{note}
-**For Claude Code users:** the [`changelog` skill](https://github.com/andrewendlinger/xmris/blob/main/.claude/skills/changelog/SKILL.md)
-does this, and the `release` skill invokes it at this step. Its checklist:
-```
-
-```{literalinclude} ../../.claude/skills/changelog/SKILL.md
-:language: markdown
-:start-after: <!-- excerpt:start -->
-:end-before: <!-- excerpt:end -->
-```
+:::{note}
+**For Claude Code users:** step 3 of the `release` skill invokes the `changelog` skill here. That
+page carries its live checklist.
+:::
 
 Two properties of the entry are load-bearing later. Its heading says `unreleased` until the release,
 and ③ refuses to tag while that word is there — the only guard against a tag whose version the

--- a/docs/diary/2026-07-22-authoring-skills.md
+++ b/docs/diary/2026-07-22-authoring-skills.md
@@ -1,7 +1,7 @@
 (diary-authoring-skills)=
 # The skills remember the rules so you don't
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-25 · #103, #104, #114</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-15 · #103, #104, #114</span>
 
 Every change to xmris has to clear the same stack of contracts at once. A new function, for
 example, has to honour
@@ -42,10 +42,11 @@ the missing front door.
 The skills split along one seam. `xmr-method` and `xmr-widget` produce the **what** — the maths
 and the UI over it. A widget is never a home for new maths, so it hands any missing method back to
 `xmr-method` first. `docs-page` and `dev-diary` produce the **how-to-use** and the **why** — the
-tutorial a reader runs, and the decision log you are reading now. A fifth skill sits off this
-seam: `release`, the user-triggered **ship** step, routes to [Publishing](#contribute-release)
-exactly as the four route to their docs — that operational axis is why the group is **Workflows**,
-not just the authoring four.
+tutorial a reader runs, and the decision log you are reading now. `changelog` produces the **what
+shipped** — the one record a reader reaches from PyPI rather than from the sidebar. A sixth skill
+sits off this seam: `release`, the user-triggered **ship** step, routes to
+[Publishing](#contribute-release) exactly as the five route to their docs — that operational axis
+is why the group is **Workflows**, not just the authoring five.
 
 (diary-authoring-skills-diary)=
 ## The diary is the workflow's review gate

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -177,7 +177,7 @@ project:
 
     # 8. Contribute -- the router page, then the four steps of a contribution.
     # Step 3 nests, because it is the only one that is a choose-one rather than
-    # a do-this: four sibling workflows, each mirroring the Claude Code skill
+    # a do-this: five sibling workflows, each mirroring the Claude Code skill
     # that automates it.
     - title: Contribute
       children:
@@ -197,6 +197,8 @@ project:
               title: Write a docs page
             - file: contribute/dev_diary.md
               title: Write a dev-diary entry
+            - file: contribute/changelog_entries.md
+              title: Write a changelog entry
         - file: contribute/pull_requests.md
           title: 4. Open a pull request
         - file: contribute/publishing.md


### PR DESCRIPTION
The `changelog` skill shipped in #153 with docs — but as a section inside `publishing.md` rather
than a peer of the four per-skill pages, and its `literalinclude` was missing the `:caption:` and
`:class: skill-quote` that every other skill quote carries. The
[authoring-skills diary entry](https://andrewendlinger.github.io/xmris/diary/2026-07-22-authoring-skills)
promises that *"each skill is also surfaced by a matching page in Contribute that quotes its
checklist live from the `SKILL.md`"*. This makes that true again.

## What moved, and where

**New: `docs/contribute/changelog_entries.md`** — `(contribute-changelog)=`, sibling of
`methods.md` / `static_widgets.md` / `docs_pages.md` / `dev_diary.md`, same router shape: prose
that owns the reasoning, then the checklist quoted live from `SKILL.md`.

It becomes the home for what previously only existed inside `.claude/skills/changelog/SKILL.md`,
invisible to a contributor not using Claude Code:

- the one reader a changelog is written for, and that it is written **at release time, not per
  pull request**;
- why there is no generator and no fragment files, and the accounting rule that replaces one —
  every commit in the range is a bullet or a stated drop;
- the fixed trail (issues → PRs → docs page → diary) and why its last two links are MyST targets;
- **the genre carve-out** — the changelog is the single page on this site that is a reference
  genre rather than motivated narrative. Worth having stated somewhere a contributor will find it,
  so nobody "fixes" `docs/changelog.md` into a narrative.

That content had nowhere to live: `docs/changelog.md` is forbidden by its own skill from explaining
itself ("never explain the page on the page").

**Thinned: `publishing.md` § ②b** (~27 → ~14 lines). It keeps only what the *release workflow*
owns — why the entry is written while the matrix runs, and the two properties step ③ depends on
(the `unreleased` tag guard, MyST targets over URLs). The trail paragraph and the checklist
`literalinclude` moved to the new page; a pointer and a short "For Claude Code users" note replace
them.

**Reconciled in place: `docs/diary/2026-07-22-authoring-skills.md`.** Its "a fifth skill sits off
this seam" is now a sixth. Per `CLAUDE.md` this is an update to the entry that already owns the
decision, not a sibling entry — no new decision is being made here.

## Wiring

- `contribute/index.md`: a fifth row in the router table, a fifth branch in the mermaid map, and
  the "four of the skills … two more drive cutting a release" note corrected to five plus
  `release`.
- `docs/myst.yml`: fifth child under the TOC group `3. Workflow & skills` — mandatory, since
  `check_docs.py` errors on a `contribute/` page missing from the TOC, and an absent page is not
  built at all.

## Deliberately not done

**No checklist quote for the `release` skill.** It is the only skill with no
`<!-- excerpt:start -->` markers, and it already has its page — `publishing.md` *is* the release
workflow. Rendering its seven operational steps into the page that already narrates those same
seven steps is duplication, not the peer pattern.

## Verification

- `check_docs.py` over the whole tree: **0 errors** (16 warnings, all pre-existing on untouched
  pages).
- `myst build --html --strict`: **exit 0**, and `grep "No target for internal reference"` on the
  build log prints nothing — the exit code alone would not prove the cross-links resolve.
- The `literalinclude` renders with `skill-quote` and the complete checklist (first and last items
  both present in the built page JSON) — mystmd only *warns* on an unmatched sentinel.
- `uv run lint` clean. No test-suite impact: the page carries no kernelspec, so `test-gen` skips
  it.
