### PR TITLE
docs(readme): fix the drifted Quick Start and rebuild the front door (#119 #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,28 @@
   <a href="https://opensource.org/license/bsd-3-clause"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" alt="License: BSD 3-Clause"></a>
 </div>
 
-MR data usually arrives as a bare array plus a pile of numbers you are expected to remember: which
-axis is time, how wide the sweep was, what everything is referenced to. `xmris` keeps all of that
-attached to the data instead. Your FID stays an ordinary
-[`xarray`](https://xarray.dev) `DataArray` — dimensions named, coordinates in seconds, metadata
-riding along — and the physics is one accessor away.
+MR data tends to arrive as a bare array plus a pile of numbers you have to keep in your head:
+which axis is time, how wide the sweep was, what zero means. `xmris` keeps all of that on the
+data itself. Your FID stays a plain [`xarray`](https://xarray.dev) `DataArray` — axes named, time
+in seconds, metadata riding along — and the physics is one accessor away.
 
 ```python
 spectrum = fid.xmr.to_spectrum().xmr.autophase().xmr.to_ppm()
 ```
 
-Nothing gets wrapped in a custom class, so every `xarray` habit you already have keeps working, and
-a grid of voxels goes through exactly the same call as a single one. Your spectrum comes out the
-other side still knowing its ppm axis.
+There is no custom class to learn. Every `xarray` habit you have keeps working, a whole grid of
+voxels goes through the same call as a single one, and the spectrum that comes out still knows its
+ppm axis.
 
 ## Start with the documentation
 
 ### → [andrewendlinger.github.io/xmris](https://andrewendlinger.github.io/xmris/)
 
-That is where the package really lives. Every tutorial page is an executable notebook, so the plots
-and numbers you read there were produced by the code above them, and they are re-run on every pull
-request. If you are new, [Basics](https://andrewendlinger.github.io/xmris/basics) walks the
-FID → spectrum → ppm round trip from scratch;
-[Concepts](https://andrewendlinger.github.io/xmris/concepts) explains why `xmris` is fussy about
-names and metadata.
+That is where the package really lives. Every tutorial page is a live notebook: the plots and
+numbers you see come from the code right above them, re-run on every pull request. New here?
+[Basics](https://andrewendlinger.github.io/xmris/basics) walks the FID → spectrum → ppm round trip
+from scratch; [Concepts](https://andrewendlinger.github.io/xmris/concepts) explains why `xmris` is
+fussy about names and metadata.
 
 ## Quick start
 
@@ -71,40 +69,45 @@ print(spectrum.dims)                         # ('chemical_shift',)
 print(round(spectrum.attrs["phase_p0"], 2))  # 2.17 — autophase wrote down what it applied
 ```
 
-With your own data you build the `DataArray` yourself, and then two things matter. The **time
-coordinate** is the axis `xmris` reads: space it by your dwell time and the frequency axis follows
-from it, no separate sweep-width setting to keep in sync. The **attributes** are the part only you
-can know — `reference_frequency` (MHz) and `carrier_ppm` (which chemical shift sits at 0 Hz) — and
-they are what turns Hz into ppm.
+Got your own data? Then you build the `DataArray` yourself. Four steps, no magic:
 
 ```python
 import numpy as np
 import xarray as xr
 import xmris
 
-n_points, spectral_width = 1024, 4000.0      # points, Hz
-time = np.arange(n_points) / spectral_width  # seconds — this axis sets the frequency axis
-signal = np.exp(2j * np.pi * 250.0 * time - time / 0.05)  # one peak, 250 Hz off centre
+# Step 1 — the time axis. Space it by your dwell time (here: a 4000 Hz sweep,
+# so 1/4000 s per point). This axis alone sets the frequency axis later on —
+# there is no separate sweep-width setting to keep in sync.
+time = np.arange(1024) / 4000.0  # seconds
 
+# Step 2 — your samples. Any complex array works; here, one fake peak
+# 250 Hz off centre, decaying. Stack three copies to play three voxels.
+signal = np.exp(2j * np.pi * 250.0 * time - time / 0.05)
+data = np.stack([signal, 0.5 * signal, 0.25 * signal])  # (voxel, time)
+
+# Step 3 — wrap it up. Name the dims, attach the time axis, and add the
+# two facts only you can know:
 fid = xr.DataArray(
-    np.stack([signal, 0.5 * signal, 0.25 * signal]),  # 3 voxels x 1024 points
+    data,
     dims=["voxel", "time"],
-    coords={"voxel": [0, 1, 2], "time": time},
+    coords={"time": time},
     attrs={
-        "reference_frequency": 120.66,  # MHz, what a shift in Hz gets measured against
-        "carrier_ppm": 0.0,             # the ppm value sitting at 0 Hz (1H water: 4.7)
+        "reference_frequency": 120.66,  # MHz — your Larmor frequency
+        "carrier_ppm": 0.0,             # which ppm sits at 0 Hz (1H water: 4.7)
     },
 )
 
-spectrum = fid.xmr.to_spectrum()  # all three voxels at once, no loop
-print(spectrum.coords["frequency"].values[[0, -1]])  # [-2000.  1996.09375]
+# Step 4 — done. The whole toolbox now works, all voxels at once:
+spectrum = fid.xmr.to_spectrum()
+print(spectrum.coords["frequency"].values[[0, -1]].tolist())  # [-2000.0, 1996.09375]
 
 ppm = spectrum.xmr.to_ppm()
 print(ppm.dims)  # ('voxel', 'chemical_shift')
 ```
 
-The 4000 Hz you spaced the time axis with is the 4000 Hz that comes back. Leave out
-`reference_frequency` or `carrier_ppm` and `to_ppm` says so, by name, before doing any maths —
+The 4000 Hz you put into the time axis is the 4000 Hz you get back. Forget
+`reference_frequency` or `carrier_ppm` and `to_ppm` tells you, by name, before it does any maths —
 [Hz and ppm](https://andrewendlinger.github.io/xmris/basics/hz-and-ppm) takes it from here.
 
 ## What is in the box
@@ -112,15 +115,16 @@ The 4000 Hz you spaced the time axis with is the 4000 Hz that comes back. Leave 
 - **Processing** — zero filling, exponential and Lorentz-to-Gauss apodization, manual and automatic
   phasing, asymmetric-least-squares baseline correction, FID ↔ spectrum, Hz ↔ ppm.
 - **Vendor data** — Bruker ParaVision arrays and their parameter dicts become a fully labelled FID,
-  digital-filter group delay included: the one that otherwise puts a phase roll through everything.
+  digital-filter group delay included: the one that puts a phase roll through everything if you
+  forget it.
 - **Fitting** — AMARES quantification via [pyAMARES](https://github.com/HawkMRS/pyAMARES), returning
   a `Dataset` with your signal, the fit and the residual aligned.
 - **Plots and widgets** — matplotlib helpers, plus sliders you can drag to phase, apodize, or scroll
   through a stack of spectra.
 
-And what is not: `xmris` is a `0.x` package, the spectroscopy side is further along than the
-imaging side, Bruker is the only vendor loader so far, and full MRSI grids — lazy, chunked, on an
-anatomical image — are still ahead. Core `xmris` will not do image reconstruction. The
+And what is not: `xmris` is a `0.x` package, the MRS side is ahead of the imaging side, Bruker is
+the only vendor loader so far, and full MRSI grids — lazy, chunked, sitting on an anatomical
+image — are still to come. Core `xmris` will not do image reconstruction. The
 [roadmap](https://andrewendlinger.github.io/xmris/roadmap) says what is shipped, what is moving,
 and what is still being argued about.
 
@@ -131,9 +135,9 @@ pip install xmris             # or: uv add xmris
 pip install "xmris[fitting]"  # adds AMARES quantification
 ```
 
-Fitting is an extra because its dependency chain reaches `hlsvdpro`, which ships no arm64 wheel; the
-`pyamares-xmris` repackage on PyPI carries the platform marker that makes it install on Apple
-Silicon too. Everything else is in the bare install. Python 3.10 – 3.13.
+Fitting is an extra because deep in its dependencies sits `hlsvdpro`, which ships no arm64 wheel;
+the `pyamares-xmris` repackage on PyPI adds the marker that skips it on Apple Silicon, so the
+install works there too. All else is in the bare install. Python 3.10 – 3.13.
 
 ## Contributing
 
@@ -145,10 +149,10 @@ the [contributor guide](https://andrewendlinger.github.io/xmris/contribute).
 
 Upgrading? The **[changelog](https://andrewendlinger.github.io/xmris/changelog)** records what
 changed in each release. There is no `CHANGELOG.md` here — it is a rendered page, so every entry can
-link the issue, the pull request, and the documentation behind it.
+link the issue, the pull request, and the docs behind it.
 
 ## License
 
-`xmris` is licensed under the **BSD 3-Clause License** — see
-[LICENSE](https://github.com/andrewendlinger/xmris/blob/main/LICENSE). Use it, build on
-it, ship it, commercially or not; keep the copyright notice.
+`xmris` is **BSD 3-Clause** — see
+[LICENSE](https://github.com/andrewendlinger/xmris/blob/main/LICENSE). Use it, build on it, ship
+it, paid work or not; just keep the notice.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <p><b>A modern, N-dimensional, <code>xarray</code>-based toolbox for Magnetic Resonance Imaging and Spectroscopy.</b></p>
 
   <a href="https://github.com/andrewendlinger/xmris/actions/workflows/deploy.yml"><img src="https://github.com/andrewendlinger/xmris/actions/workflows/deploy.yml/badge.svg" alt="MyST GitHub Pages Deploy"></a>
-  <a href="https://github.com/andrewendlinger/xmris/actions/workflows/tests.yml"><img src="https://github.com/andrewendlinger/xmris/actions/workflows/ci-fast.yml/badge.svg" alt="Tests"></a>
+  <a href="https://github.com/andrewendlinger/xmris/actions/workflows/ci-fast.yml"><img src="https://github.com/andrewendlinger/xmris/actions/workflows/ci-fast.yml/badge.svg" alt="Tests"></a>
   <a href="https://codecov.io/gh/andrewendlinger/xmris"><img src="https://codecov.io/gh/andrewendlinger/xmris/graph/badge.svg" alt="codecov"></a>
   <br>
   <a href="https://github.com/astral-sh/uv"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json" alt="uv"></a>
@@ -18,101 +18,137 @@
   <a href="https://opensource.org/license/bsd-3-clause"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" alt="License: BSD 3-Clause"></a>
 </div>
 
+MR data usually arrives as a bare array plus a pile of numbers you are expected to remember: which
+axis is time, how wide the sweep was, what everything is referenced to. `xmris` keeps all of that
+attached to the data instead. Your FID stays an ordinary
+[`xarray`](https://xarray.dev) `DataArray` — dimensions named, coordinates in seconds, metadata
+riding along — and the physics is one accessor away.
 
-## 01. Documentation
-
-**[Explore the official documentation](https://andrewendlinger.github.io/xmris/)** for tutorials, complete API references, and advanced usage guides.
-
-
-## 02. Overview
-
-`xmris` bridges the gap between modern data structures and magnetic resonance research. By building on top of `xarray`, it provides a robust environment for handling multi-dimensional MRI and MRS data with labeled coordinates, powerful broadcasting, and seamless integration with the scientific Python ecosystem.
-
-**Key Features:**
-* **N-Dimensional Data:** Native handling of complex MRI/MRS datasets using `xarray`.
-* **MRS Integration:** Direct compatibility with tools like `pyAMARES` and `nmrglue`.
-* **Modern Tooling:** Built for speed and reliability, developed using `uv` and strictly typed for modern Python environments.
-
-
-
-## 03. Installation
-
-You can install the package directly from PyPI using standard package managers:
-
-```bash
-# Using pip
-pip install xmris
-
-# Using uv (recommended)
-uv add xmris
-
+```python
+spectrum = fid.xmr.to_spectrum().xmr.autophase().xmr.to_ppm()
 ```
 
-## 04. Quick Start
+Nothing gets wrapped in a custom class, so every `xarray` habit you already have keeps working, and
+a grid of voxels goes through exactly the same call as a single one. Your spectrum comes out the
+other side still knowing its ppm axis.
+
+## Start with the documentation
+
+### → [andrewendlinger.github.io/xmris](https://andrewendlinger.github.io/xmris/)
+
+That is where the package really lives. Every tutorial page is an executable notebook, so the plots
+and numbers you read there were produced by the code above them, and they are re-run on every pull
+request. If you are new, [Basics](https://andrewendlinger.github.io/xmris/basics) walks the
+FID → spectrum → ppm round trip from scratch;
+[Concepts](https://andrewendlinger.github.io/xmris/concepts) explains why `xmris` is fussy about
+names and metadata.
+
+## Quick start
+
+The shortest path to something you can look at: `simulate_fid` hands you a signal that already
+carries the metadata the physics needs.
+
+```python
+import xmris  # importing registers the .xmr accessor on every xarray object
+
+fid = xmris.simulate_fid(
+    amplitudes=[1.0, 0.4],
+    chemical_shifts=[0.0, 5.2],  # ppm
+    reference_frequency=120.66,  # MHz, the Larmor frequency of your nucleus
+    n_points=1024,
+)
+
+spectrum = (
+    fid
+    .xmr.apodize_exp(lb=5.0)
+    .xmr.zero_fill(target_points=2048)
+    .xmr.to_spectrum()
+    .xmr.autophase()
+    .xmr.to_ppm()
+)
+
+print(spectrum.dims)                         # ('chemical_shift',)
+print(round(spectrum.attrs["phase_p0"], 2))  # 2.17 — autophase wrote down what it applied
+```
+
+With your own data you build the `DataArray` yourself, and then two things matter. The **time
+coordinate** is the axis `xmris` reads: space it by your dwell time and the frequency axis follows
+from it, no separate sweep-width setting to keep in sync. The **attributes** are the part only you
+can know — `reference_frequency` (MHz) and `carrier_ppm` (which chemical shift sits at 0 Hz) — and
+they are what turns Hz into ppm.
 
 ```python
 import numpy as np
 import xarray as xr
-import xmris  # Registers the .xmr accessor!
+import xmris
 
-# 1. Create a dummy N-dimensional FID (e.g., 5 Voxels x 1024 Time points)
-time = np.linspace(0, 1, 1024)
-data = np.random.randn(5, 1024) + 1j * np.random.randn(5, 1024)
+n_points, spectral_width = 1024, 4000.0      # points, Hz
+time = np.arange(n_points) / spectral_width  # seconds — this axis sets the frequency axis
+signal = np.exp(2j * np.pi * 250.0 * time - time / 0.05)  # one peak, 250 Hz off centre
 
-mrsi_data = xr.DataArray(
-    data,
+fid = xr.DataArray(
+    np.stack([signal, 0.5 * signal, 0.25 * signal]),  # 3 voxels x 1024 points
     dims=["voxel", "time"],
-    coords={"voxel": np.arange(5), "time": time},
-    attrs={"MHz": 120.0, "sw": 10000.0}
+    coords={"voxel": [0, 1, 2], "time": time},
+    attrs={
+        "reference_frequency": 120.66,  # MHz, what a shift in Hz gets measured against
+        "carrier_ppm": 0.0,             # the ppm value sitting at 0 Hz (1H water: 4.7)
+    },
 )
 
-# 2. Process all voxels simultaneously using the .xmr accessor!
-results = (
-    mrsi_data
-    .xmr.zero_fill(target_points=2048)
-    .xmr.apodize_exp(lb=5.0)
-    .xmr.to_spectrum()
-    .xmr.autophase()
-)
+spectrum = fid.xmr.to_spectrum()  # all three voxels at once, no loop
+print(spectrum.coords["frequency"].values[[0, -1]])  # [-2000.  1996.09375]
+
+ppm = spectrum.xmr.to_ppm()
+print(ppm.dims)  # ('voxel', 'chemical_shift')
 ```
 
----
+The 4000 Hz you spaced the time axis with is the 4000 Hz that comes back. Leave out
+`reference_frequency` or `carrier_ppm` and `to_ppm` says so, by name, before doing any maths —
+[Hz and ppm](https://andrewendlinger.github.io/xmris/basics/hz-and-ppm) takes it from here.
 
-## 05. Development
+## What is in the box
 
-We use `uv` for lightning-fast dependency management and `Ruff` for linting/formatting. To set up a local development environment:
+- **Processing** — zero filling, exponential and Lorentz-to-Gauss apodization, manual and automatic
+  phasing, asymmetric-least-squares baseline correction, FID ↔ spectrum, Hz ↔ ppm.
+- **Vendor data** — Bruker ParaVision arrays and their parameter dicts become a fully labelled FID,
+  digital-filter group delay included: the one that otherwise puts a phase roll through everything.
+- **Fitting** — AMARES quantification via [pyAMARES](https://github.com/HawkMRS/pyAMARES), returning
+  a `Dataset` with your signal, the fit and the residual aligned.
+- **Plots and widgets** — matplotlib helpers, plus sliders you can drag to phase, apodize, or scroll
+  through a stack of spectra.
 
-1. Fork this repository and then clone your version of this repository.
+And what is not: `xmris` is a `0.x` package, the spectroscopy side is further along than the
+imaging side, Bruker is the only vendor loader so far, and full MRSI grids — lazy, chunked, on an
+anatomical image — are still ahead. Core `xmris` will not do image reconstruction. The
+[roadmap](https://andrewendlinger.github.io/xmris/roadmap) says what is shipped, what is moving,
+and what is still being argued about.
 
-2. Sync the environment and install dependencies:
+## Install
+
 ```bash
-uv sync
-
+pip install xmris             # or: uv add xmris
+pip install "xmris[fitting]"  # adds AMARES quantification
 ```
 
+Fitting is an extra because its dependency chain reaches `hlsvdpro`, which ships no arm64 wheel; the
+`pyamares-xmris` repackage on PyPI carries the platform marker that makes it install on Apple
+Silicon too. Everything else is in the bare install. Python 3.10 – 3.13.
 
-3. Run tests via `pytest` (which includes notebook testing via `nbmake`):
-```bash
-uv run test
+## Contributing
 
-```
+Issues and pull requests are welcome. `uv sync --all-extras --dev` then `uv run test` gets you a
+working checkout; the setup steps, the architecture contract and one page per kind of change are in
+the [contributor guide](https://andrewendlinger.github.io/xmris/contribute).
 
+## Changelog
 
-4. Preview the [MyST](https://mystmd.org) documentation locally — a live server that never exits:
-```bash
-uv run docs
-```
-For a one-shot render check instead (the same command CI runs), use `myst build --html` from `docs/`.
+Upgrading? The **[changelog](https://andrewendlinger.github.io/xmris/changelog)** records what
+changed in each release. There is no `CHANGELOG.md` here — it is a rendered page, so every entry can
+link the issue, the pull request, and the documentation behind it.
 
-More information can be found in the [contributing guide](https://andrewendlinger.github.io/xmris/guide).
+## License
 
-### Changelog
-
-Upgrading? The **[changelog](https://andrewendlinger.github.io/xmris/changelog)** records what changed in each release. There is no `CHANGELOG.md` here — it is a rendered page, so every entry can link the issue, the pull request, and the documentation behind it.
-
----
-
-### License
-
-`xmris` is licensed under the **BSD 3-Clause License** — see [LICENSE](LICENSE). Use it, build on
+`xmris` is licensed under the **BSD 3-Clause License** — see
+[LICENSE](https://github.com/andrewendlinger/xmris/blob/main/LICENSE). Use it, build on
 it, ship it, commercially or not; keep the copyright notice.


### PR DESCRIPTION
The README is the PyPI long description, the GitHub landing page, and the statement-of-need a JOSS
reviewer reads first — and `check_docs.py` only walks `docs/`, so it is the one reader-facing page
under no gate at all. This rewrites it: every factual defect in #119 fixed and verified, and the
page reshaped along the brief in #154.

Only `README.md` changes. No version, changelog, tag, or asset touched. The logo header (#121) is
deliberately left exactly as it was.

## #119 — the factual fixes

**1. The Quick Start taught two attribute names that do nothing.** The old example wrote
`attrs={"MHz": 120.0, "sw": 10000.0}`. Neither key is in the vocabulary any more (#68/#93 removed
them), so both were inert — the example *ran*, which is what made it dangerous: the frequency axis
came out spanning 1022.5 Hz against a declared `sw` of 10000, and the natural next step,
`to_ppm()`, dead-ended on attributes the README never mentioned.

Replaced with the shape agreed on the issue — two snippets, no third:

- `simulate_fid` first, as the shortest path to something you can look at: one call gives an
  attrs-complete FID, then a real chain (`apodize_exp` → `zero_fill` → `to_spectrum` →
  `autophase` → `to_ppm`).
- Then raw `xr.DataArray` construction done right, on a 3-voxel × 1024-point array so the
  "no loops" claim is visible too. The prose splits the two halves explicitly: the **time
  coordinate** is what `xmris` derives the frequency axis from (space it by your dwell time and
  4000 Hz in is 4000 Hz out — no separate sweep-width setting to keep in sync), while
  `reference_frequency` and `carrier_ppm` are the part only you can know, and are what turns Hz
  into ppm.

*Verified:* both blocks were extracted from the committed README by a regex over the ```` ```python ````
fences — byte-for-byte, no retyping — and executed with `uv run python`. Every value shown in a
trailing comment is the real stdout:

```
$ uv run python readme_block1.py
('chemical_shift',)
2.17

$ uv run python readme_block2.py
[-2000.       1996.09375]
('voxel', 'chemical_shift')
```

The one-line teaser above the fold (`fid.xmr.to_spectrum().xmr.autophase().xmr.to_ppm()`) is a
fragment by design; it was run against a `simulate_fid` FID to confirm the chain resolves. The
claim that a missing attribute is named before any maths happens was checked against the live
`ValueError` from `requires_attrs`.

**2. `pip install xmris` was no longer the whole story.** The Install section now shows
`pip install "xmris[fitting]"` beside the bare install, with one line on why it is separate:
`hlsvdpro` ships no arm64 wheel, and the `pyamares-xmris` repackage on PyPI carries the platform
marker that makes it install on Apple Silicon. *Verified against `pyproject.toml`'s
`[project.optional-dependencies].fitting`.*

**3. The nmrglue compatibility claim is gone.** `grep` over the tree finds `nmrglue` only in
`uv.lock` (transitive, historical) and in one `accessor.py` docstring sentence — never as a
dependency and never as an integration. The bullet was dropped rather than softened.

**4. "strictly typed" is gone.** `[tool.mypy]`'s own comment says *"Not enforced in CI; run
locally"*, and no workflow invokes it. Removed, and not replaced with another process-virtue
claim — the "Modern Tooling" bullet went with it.

**5. The Tests badge pointed at a workflow that does not exist.** The `href` was
`actions/workflows/tests.yml` while the image came from `ci-fast.yml`. Both now point at
`ci-fast.yml` (whose workflow `name:` is literally `Tests`, so the alt text stays right).
*Verified:* every URL in the file was curl-checked with
`curl -s -L -o /dev/null -w '%{http_code}'`. All 200. Worth noting that `tests.yml` returns 200
too — GitHub serves an empty "Workflow runs" page for a workflow that isn't there, so this was a
dead end for the reader rather than a hard 404.

## #154 — the shape

Reading order is now: logo header (untouched) → one-breath pitch → **documentation referral** →
quick start → what is in the box (and what is not) → install → contributing → changelog → license.
The `## 01.`–`## 05.` numbered headers are gone; plain headings read lighter.

- **Docs referral near the top**, as its own section with the site URL as a heading-level link, plus
  deep links into Basics and Concepts. No screenshot — deliberately skipped for now.
- **Install moved to the bottom** and shrank to a two-line code block plus one line of reasoning.
- **Development shrank** from a four-step numbered walkthrough to three lines: the two commands that
  get you a working checkout, and a link to the contributor guide.
- **"What is in the box"** replaces the old "Key Features" bullets, and is followed by an honest
  paragraph on what is *not* there yet (0.x, Bruker-only vendor support, MRSI at scale still ahead,
  no image reconstruction ever) pointing at the roadmap. Each bullet was checked against the actual
  public API — the widget list came from `da.xmr.widget`, the Bruker wording from `build_fid`'s
  signature, which takes a ParaVision array plus a parameter dict rather than reading files.
- **The changelog paragraph is kept**, verbatim, now sitting between contributing and license.
- Taste: concrete over process-virtue. "Your spectrum comes out the other side still knowing its
  ppm axis" instead of "modern tooling"; "a grid of voxels goes through exactly the same call as a
  single one" instead of "N-dimensional".

## Fixed on the way past

- The contributing link pointed at `https://andrewendlinger.github.io/xmris/guide`, which **404s**.
  It is `/xmris/contribute`.
- `[LICENSE](LICENSE)` was repo-relative — PyPI cannot resolve those. Now absolute.

## Rendering

Both surfaces are constrained, so both were checked. All image `src`s stay absolute
(`user-attachments` / `shields.io` / `github.com/.../badge.svg`), and every docs link is an absolute
site URL. The file was rendered through `readme-renderer[md]` — the same library PyPI uses — exit 0,
with the logo, all eight badges, and every heading surviving the sanitizer.

Closes #119
Closes #154 (docs screenshot deliberately deferred — reopen if it should wait for that)
