### PR TITLE
docs: dev-diary entries are suggested at the end, not a gate at the start

### DIFF
--- a/.claude/skills/dev-diary/SKILL.md
+++ b/.claude/skills/dev-diary/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: dev-diary
-description: Write and reconcile an xmris dev-diary entry — a short, rendered article recording why a change was made and how it actually went. Use at the START of any change that picks between viable approaches, adds conceptual surface (a rule, decorator, or namespace), or spans multiple PRs — the entry is the review gate the user reads before implementation begins; and again at the END to reconcile it into the story of how it is now.
+description: Write an xmris dev-diary entry — a short, rendered article recording why a significant repo or architectural decision was made. Suggest one when a change picks between viable approaches, adds conceptual surface (a rule, decorator, or namespace), or spans multiple PRs; if the user accepts, the entry is written once the work has landed — the story of how it is now and why.
 ---
 
 # Write an xmris dev-diary entry
 
-A diary entry is a **decision record told as a story**, written twice and rendered on the docs
-site. It is not a reference page and not a changelog. Its two passes serve two readers who never
-meet:
-
-| Pass | Written | Reader | Deliverable |
-|---|---|---|---|
-| **1** | first commit on the branch, straight from the approved plan | **the user, now** — reviewing on the rendered site *before implementation starts* | one screen: problem → decision → shape → what's assumed |
-| **2** | last commit on the branch | whoever asks *"why is it like this?"* later | the same entry, rewritten into how it is now and why |
+A diary entry is a **decision record told as a story**, rendered on the docs site. It is not a
+reference page, not a changelog — and not the plan retold: commits and the diff own the steps;
+the entry owns the why.
 
 **One entry per decision.** When a later change extends a decision an entry already tells, that
 entry is rewritten ground-up into the current story — `Last edited` updated, the new PR number
@@ -20,12 +15,9 @@ appended — rather than a sibling entry spawned. A new dated entry is for a new
 reader should never have to join two articles to get one answer.
 
 The `Dev Diary` group also has **one evergreen page** — `docs/diary/index.md` ("A dev diary for
-xmris") — that tells readers *what the diary is*. It is **not** an entry: no `Last edited` line, no
-assumptions block, no reconciliation, and it stays pinned at the **top** of the group. This skill
-governs the dated entries **below** it; touch `about.md` only when the diary's own workflow changes.
-
-Pass 1 exists because the plan file is precise but heavy — right for executing, wrong for approving.
-**Never restate the plan's steps.** If the entry reads like a second plan, it has failed.
+xmris") — that tells readers *what the diary is*. It is **not** an entry: no `Last edited` line,
+and it stays pinned at the **top** of the group. This skill governs the dated entries **below**
+it; touch `index.md` only when the diary's own workflow changes.
 
 **House style lives in `CLAUDE.md` § "Documentation style"** and is not restated here — with one
 carve-out: *one home per concept* binds an entry at the **decision** level, not the concept level.
@@ -61,10 +53,15 @@ The ask is one question, two options: **write an entry / skip** (or **update `<e
 Name the concrete trigger in the question ("adds `@ensures_domain` — a new decorator contract"),
 never ask abstractly. If the user skips, drop it — do not re-ask later in the same change.
 
-## 2. Pass 1 — from the plan, as the branch's first commit
+Ask the moment the trigger is recognized — often during planning. An accepted entry is **noted,
+then written once the work has landed**; it is never a precondition for starting, and nothing
+waits on it.
+
+## 2. Write the entry — once the change is built
 
 Read `templates/entry.md` and follow its skeleton. File: `docs/diary/YYYY-MM-DD-<topic-slug>.md`.
-Commit as `docs: diary entry for <topic>`.
+Commit as `docs: diary entry for <topic>` — normally the last docs commit on the branch, written
+when the change is in its final shape.
 
 **Budget: one screen rendered.** ≤500 words of prose, at most one diagram and one table. The budget
 is the feature — it forces the entry up to the altitude where the decision is visible.
@@ -73,31 +70,32 @@ Open with the **driving question** the change answers, felt as a tension rather 
 cold "Why X?" heading. Write it in the PR body too. If you cannot name it, you have a topic, not an
 article.
 
-Mark everything the plan asserts but code has not yet demonstrated in **one consolidated, visible
-block** near the end:
+**Write against the code, not from memory.** The entry is written after the work lands precisely
+so it is born accurate. Writing docs from the design instead cost PR #90: `domains.md` was written
+mid-design (#76) and never brought back in line with the code, so it sat wrong on `main` across
+five merges until two code reviews caught it. Every category below is a real defect from that
+incident — verify each against `src/` before committing:
 
-```markdown
-:::{attention} Assumptions to verify
-- `zero_fill` is the only length-changing op that stays `@computes_in`.
-:::
-```
+- **Quoted error messages** — wording drifts. Grep the actual string in `src/` and paste it verbatim.
+- **Decision criteria in diagrams and tables** — walk every branch against real code (that draft
+  gated on "length-preserving?", which is false: `zero_fill` changes length and is still
+  `@computes_in`).
+- **Over-general guardrails** — scope each rule to the paths it actually covers.
+- **API surface and every snippet** — names, signatures, defaults, attr keys all drift.
+- **Adopted rejections** — if something the entry argues against got built, the rationale reads
+  backwards. Rewrite or delete it.
 
-It must *render* — HTML comments are invisible on the page the user actually reads, which is the
-only moment an assumption matters. Inline `:::{attention} Assumption` boxes only where one qualifies
-a single specific passage. A pass-1 entry with no assumptions marked usually means none were looked
-for.
+**Absorb rationale that only the plan held** — decision criteria, rejected options, constraints
+discovered on the way — into the main line or a dropdown. The plan file lives outside the repo and
+does not survive the merge, so the entry and the PR body are the only reasoning record. *Steps*
+stay unrestated: commits and the diff own those.
 
-**Then stop — the draft is the gate.** Commit, name the page, tell the user to run `uv run docs`,
-and **end the turn**. Implementation, verification, further commits — everything waits until the
-user responds; a bare "go" is approval. This binds in auto-accept mode too: the handoff is the
-last thing in the turn, with nothing queued behind it. Rolling past an unreviewed draft defeats
-the entry's purpose, which is catching a bad decision *before* it is built.
-
-```{note}
-**Pass-1 code is illustrative — do not chase executability.** The API does not exist yet; you are
-sketching the call site you *wish* existed, which is design work in its own right. Static
-` ```python ` blocks are correct there. What pass 2 owes you is **accuracy, not executability**.
-```
+A closing **`## What changed from the plan`** is *conditional*, not mandatory. Add it only when
+the divergence itself teaches — an instructive failure mode, or a prior state real enough that
+someone actually saw it (shipped code, a published page). Early in a package's life the
+abandoned state usually had no witnesses, and a delta against a plan nobody read confuses more
+than it helps — fold the lesson into the main argument instead. When the section does appear,
+every bullet states inline what was previously assumed, so it reads without the plan.
 
 ### Which MyST feature carries which load
 
@@ -106,17 +104,14 @@ sketching the call site you *wish* existed, which is design work in its own righ
 | When the entry was last touched | a muted `Last edited:` line — **required**, directly under the H1 |
 | The decision, in one sentence | `{important}` |
 | The shape: states, or a choice a contributor faces | `{mermaid}` |
-| The call site you wish existed (pass 1) | a static `python` block — a small user story |
+| The call site, as it now works — a small user story | a static `python` block |
 | A contract surface | markdown table |
 | Guardrail, one-way door, footgun | `{warning}` |
 | An approach *we* rejected | `:::{dropdown} Why not <X>?` |
 | An approach *the reader* would try | paired ❌ / ✅ blocks, on the main line |
-| Unproven claim (pass 1 only) | `:::{attention} Assumptions to verify` |
 
-There is no rendered "planned / built" banner. A cold re-invocation tells the passes apart
-structurally: an open `:::{attention} Assumptions` block means pass 1 is still outstanding; its
-absence means pass 2 has landed. The exact `Last edited` span — kept muted with an inline style,
-because MyST's `[text]{.class}` shorthand does **not** parse here — lives in `templates/entry.md`.
+The exact `Last edited` span — kept muted with an inline style, because MyST's `[text]{.class}`
+shorthand does **not** parse here — lives in `templates/entry.md`.
 
 Mermaid escaping rules live in `docs-page`'s `templates/patterns.md` — quote every label, `<br>`
 not `\n`, monospace `<span>` for code inside labels. Copy an existing diagram rather than
@@ -132,61 +127,14 @@ Split by **who** rejected it:
 - **The reader would naively try it** → stays on the main line as paired ❌ / ✅ blocks. That is
   `architecture.md`'s "Parameter Soup", and it is pedagogy, not an appendix.
 
-## 4. Pass 2 — reconcile into the story of how it is now
+## 4. When a decision spans PRs or evolves
 
-Re-read the entry **against the merged code**, not from memory. Commit as
-`docs: reconcile diary entry for <topic>`. Not re-asked — accepting pass 1 commits to it.
+The entry lands with the PR that **completes** the decision. When a later PR changes behavior an
+existing entry describes, that PR updates the entry in place — prose rewritten into the current
+story, the `Last edited` date refreshed, the new PR number appended — so the article never sits
+wrong on `main`.
 
-The deliverable is a coherent article about **how it is now and why** — not the draft plus
-patches, and not a delta log. The plan file lives outside the repo and does not survive the merge,
-so after this commit the entry and the PR body are the only reasoning record:
-
-1. Update the `Last edited` line to the reconcile date, appending the merged PR numbers.
-2. **Rewrite drifted prose in place** — real paths, real snippets, the argument as you would make
-   it *having now built it* — so the article never misleads.
-3. Empty and **delete** the assumptions block — each item folded into the story, whether it held
-   or broke.
-4. **Absorb rationale that only the plan held** — decision criteria, rejected options, constraints
-   discovered on the way — into the main line or a dropdown. *Steps* stay unrestated: commits and
-   the diff own those; the entry owns the why.
-5. A closing **`## What changed from the plan`** is *conditional*, not mandatory. Add it only when
-   the divergence itself teaches — an instructive failure mode, or a prior state real enough that
-   someone actually saw it (shipped code, a published page). Early in a package's life the
-   abandoned state usually had no witnesses, and a delta against a plan nobody read confuses more
-   than it helps — fold the lesson into the main argument instead. When the section does appear,
-   every bullet states inline what was previously assumed, so it reads without the plan.
-
-Skipping this pass cost PR #90: `domains.md` was written mid-design (#76) and never reconciled, so
-it sat wrong on `main` across five merges until two code reviews caught it. Every category below is
-a real defect from that incident:
-
-- **Quoted error messages** — wording drifts. Grep the actual string in `src/` and paste it verbatim.
-- **Decision criteria in diagrams and tables** — the draft gated on "length-preserving?", which is
-  false (`zero_fill` changes length and is still `@computes_in`). Walk every branch against real code.
-- **Over-general guardrails** — "explicit dims pass through" held only for `@computes_in`. Scope each
-  rule to the paths it actually covers.
-- **API surface and every snippet** — names, signatures, defaults, attr keys all drift.
-- **Adopted rejections** — if something the entry argued against got built, the rationale now reads
-  backwards. Rewrite or delete it.
-
-```bash
-git grep -nF "{attention} Assumption" -- 'docs/diary/*.md'   # must be empty
-```
-
-Use `git grep` scoped to tracked files, **not** `grep -r docs/` — `docs/_build/` is ~9,800
-gitignored files that retain stale markers from earlier previews.
-
-## 5. Multi-PR chains
-
-The entry lives in the **first** PR and is reconciled in the **last** — so the first PR merges with
-pass 2 outstanding, by design. Each intermediate PR that changes described behavior carries its own
-reconcile hunk; batching them to the end is exactly the #76→#90 failure. For a single-PR change the
-opposite holds: do not merge with pass 2 outstanding.
-
-**Invoked mid-work?** Do not rewrite history to fake a first commit. Commit the entry now, run
-pass 2 as usual, and note the mid-flight start in the PR body.
-
-## 6. Register and link
+## 5. Register and link
 
 - **TOC entry in `docs/myst.yml`** under the `Dev Diary` group: **append it at the bottom** of
   `children`, below the pinned `about.md` intro and any earlier entries (chronological, oldest
@@ -199,13 +147,11 @@ pass 2 as usual, and note the mid-flight start in the PR body.
 <!-- excerpt:start -->
 - [ ] Trigger named (decision-weight, not category) and the choice **put to the user** — including
       update-an-existing-entry when one already tells this decision's story
-- [ ] Entry is the branch's first commit (or mid-flight start noted in the PR body)
+- [ ] Written once the change has landed — never a gate on starting the work
 - [ ] One screen: ≤500 words, no restated plan steps, driving question named in the PR body
-- [ ] `Last edited` line present; assumptions in a **rendered** block; rejections in dropdowns
-- [ ] **Pass 1 ends the turn**: page named, `uv run docs` handoff given, implementation not started
-- [ ] Pass 2 committed last, rewritten into how it is now and read against the code — error
-      strings, diagram branches, guardrail scopes and snippets all verified against `src/`
-- [ ] `git grep -nF "{attention} Assumption" -- 'docs/diary/*.md'` is empty
+- [ ] `Last edited` line present with the PR numbers; rejections in dropdowns
+- [ ] Written against the code, not from memory — error strings, diagram branches, guardrail
+      scopes and snippets all verified against `src/`
 - [ ] `## What changed from the plan` only where the divergence teaches — each bullet readable
       without the plan
 - [ ] TOC entry appended at the bottom of the `Dev Diary` group (below the pinned intro)

--- a/.claude/skills/dev-diary/templates/entry.md
+++ b/.claude/skills/dev-diary/templates/entry.md
@@ -3,7 +3,7 @@
 Copy the structure below into `docs/diary/YYYY-MM-DD-<topic-slug>.md`. Prose only — no jupytext
 frontmatter, no kernel. Explicit MyST targets above every header (Commandment 8).
 
-Order is deliberate: the reader gets the story, then what is still uncertain. Sections that carry
+Order is deliberate: the reader gets the story, then the finer points. Sections that carry
 nothing for this change get dropped — an entry with an empty guardrail section is padding.
 
 ---
@@ -12,7 +12,7 @@ nothing for this change get dropped — an entry with an empty guardrail section
 (diary-<slug>)=
 # <Title — a claim or a question, not a topic label>
 
-<span style="color: gray; font-size: 0.9em;">Last edited: YYYY-MM-DD</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: YYYY-MM-DD · #NN</span>
 
 <One paragraph. The concrete problem, felt as a tension the reader already has. Not an
 abstraction, not a summary of the plan. This is the driving question in prose form.>
@@ -24,43 +24,24 @@ abstraction, not a summary of the plan. This is the driving question in prose fo
 (diary-<slug>-<section>)=
 ## <How it works — the shape, not the steps>
 
-<A mermaid diagram or a table wherever it beats prose. The plan file owns the implementation
-steps; repeating them here produces a second plan. Budget: one screen, ≤500 words of prose,
-at most one diagram and one table.>
+<A mermaid diagram or a table wherever it beats prose. Commits and the diff own the
+implementation steps; repeating them here produces a second plan. Budget: one screen, ≤500 words
+of prose, at most one diagram and one table — flex it only when the story truly needs the room.>
 
 ```python
-# Optional but encouraged: the call site you wish existed — a small user story, not a spec.
-# Pass-1 code is illustrative (the API may not exist yet); drop the block if it earns nothing.
+# Optional but encouraged: the call site as it now works — a small user story, not a spec.
+# Verify names, signatures and defaults against src/; drop the block if it earns nothing.
 spectrum = fid.xmr.to_spectrum().xmr.new_thing(...)
 ```
 
 :::{dropdown} Why not <the alternative we dropped>?
 <Two or three sentences. What it would have bought, what it cost, why the cost won.>
 :::
-
-:::{attention} Assumptions to verify
-- <Something the plan asserts that no code has demonstrated yet.>
-- <Be honest — an entry with none usually means none were looked for.>
-:::
 ````
 
----
-
-## Pass 2 — what changes
-
-The 500-word budget is a **pass-1** figure. Pass 2 legitimately exceeds it: the reconciled story
-is what the entry is for.
-
-- `Last edited` line → the reconcile date with the merged PR numbers appended
-  (`Last edited: 2026-01-15 · #101, #104`).
-- Drifted prose rewritten **in place** — the deliverable is the story of how it is now and why,
-  not the draft plus patches.
-- The `{attention}` block **deleted**: each item folded into the story, whether it held or broke.
-- Rationale only the plan held — decision criteria, rejected options, discovered constraints —
-  absorbed into the main line or a dropdown; the plan file does not survive the merge.
-- A closing section **only when the divergence itself teaches** (an instructive failure, or a
-  prior state someone actually saw — with no witnesses, fold the lesson into the main argument
-  instead):
+An optional closing section — **only when the divergence from the plan itself teaches** (an
+instructive failure, or a prior state someone actually saw; with no witnesses, fold the lesson
+into the main argument instead):
 
 ````markdown
 (diary-<slug>-changed)=

--- a/.claude/skills/docs-page/check_docs.py
+++ b/.claude/skills/docs-page/check_docs.py
@@ -30,9 +30,9 @@ from pathlib import Path
 # the mapping is spelled out rather than inferred -- a new chapter has to
 # declare which genre its pages are held to. Writing a diary entry belongs to
 # the `dev-diary` skill, but the structural rules bind it like any other page --
-# an entry missing from the TOC never renders, and the diary is a review gate
-# that only works if it does. Only api/ escapes: it is generated and gitignored,
-# so there is nothing to hand-fix.
+# an entry missing from the TOC never renders, and a decision record no one can
+# read keeps nothing. Only api/ escapes: it is generated and gitignored, so
+# there is nothing to hand-fix.
 GENRES = {
     "basics": "tutorial",
     "pipeline": "tutorial",

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ docs/**/**/**/*.ipynb
 # Local scratch notes
 TODO.md
 
+# plan-doc plan folders — the plan file lives outside the repo
+plans/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,11 @@ These four rules govern everything under `docs/` — explanation articles, tutor
 
 Reader-facing prose uses plain strings (`"time"`, `"frequency"`), per Commandment 4's library-internals-only rule. `ATTRS`/`DIMS`/`COORDS` appear only in passages explicitly addressed to contributors, or inside hidden test cells.
 
-## Significant changes get a diary entry
+## Significant decisions: offer a diary entry
 
-If a change picks between ≥2 viable approaches, adds conceptual surface (a new rule, decorator, or namespace — not a vocabulary term that follows an existing pattern), or spans multiple PRs, invoke the `dev-diary` skill — at the **start** (a one-screen article written from the approved plan, as the branch's first commit) and again at the **end** (rewritten into the story of how it is now; a "what changed from the plan" note only where the divergence teaches). When an existing entry already tells the decision's story, propose updating that entry instead of adding a sibling.
+If a change involves a significant repo or architectural decision — it picks between ≥2 viable approaches, adds conceptual surface (a new rule, decorator, or namespace — not a vocabulary term that follows an existing pattern), or spans multiple PRs — **offer** a dev-diary entry via the `dev-diary` skill: a one-screen article, written once the change has landed, telling how it is now and why. When an existing entry already tells the decision's story, propose updating that entry instead of adding a sibling.
 
-Pass 1 is the change's **master overview** and its review gate: the plan file is right for executing and too heavy for approving, so the entry is what gets read on the rendered site (`uv run docs`) before work starts. It never restates the plan's steps. The skill always asks before writing anything — never decide that autonomously — and after committing the draft the turn **ends** so the user can review the page; implementation waits for their go-ahead.
+The skill always asks before writing anything — never decide that autonomously; if the user declines, drop it. The entry never restates the plan's steps — commits and the diff own those — and it absorbs the rationale only the plan held, since the plan file does not survive the merge.
 
 The `Dev Diary` section opens with one evergreen intro (`docs/diary/index.md`, pinned first) that explains what the diary *is*; dated entries follow it chronologically and carry a muted `Last edited` line rather than a status banner.
 

--- a/docs/contribute/dev_diary.md
+++ b/docs/contribute/dev_diary.md
@@ -2,10 +2,9 @@
 # Write a dev-diary entry
 
 A [dev-diary entry](#diary-about) records *why* a significant change was made — the kind of decision
-someone will want explained when they ask "why is it like this?" a year from now. You write it
-twice: a short draft distilled from the approved plan — the thing actually reviewed *before* the
-work starts, and the work waits until it has been — and a final version reconciled once the change
-has landed, rewritten into the story of how it is now.
+someone will want explained when they ask "why is it like this?" a year from now. It is written
+once, when the change has landed — checked against the real code rather than drafted from a plan,
+so it tells the story of how it is now and why.
 
 Not every change earns one. Choosing between two viable approaches, adding conceptual surface (a
 rule, a decorator, a namespace), or a refactor that spans several PRs does; a bug fix, a routine
@@ -14,8 +13,8 @@ puts that call to you before writing anything — and when an existing entry alr
 decision's story, it proposes updating that entry instead of adding a sibling.
 
 Entries live under `docs/diary/`, below the pinned [intro](#diary-about), with the newest at the
-bottom. The mechanics — the two passes, the one-screen budget, and how open assumptions are marked
-so they *render* on the page you review — are exactly what the skill enforces:
+bottom. The mechanics — the one-screen budget, the `Last edited` line, and where an entry
+registers — are exactly what the skill enforces:
 
 (contribute-dev-diary-skill)=
 ## Working with Claude Code

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -49,8 +49,8 @@ these docs preach.
 
 1. [**Set up your environment**](#setup) — clone the repo, run `uv sync --all-extras --dev`, and
    confirm `uv run test` is green.
-2. **Make your change**, following the page for its kind above. A significant decision starts as a
-   [dev-diary draft](#contribute-dev-diary) that gets reviewed before the code is written.
+2. **Make your change**, following the page for its kind above. A significant decision is offered a
+   [dev-diary entry](#contribute-dev-diary), written once the change lands.
 3. [**Open a pull request**](#contribute-pr) against `main` — `main` takes no direct pushes. Six
    checks gate the merge: the test suite on Python 3.10 and 3.13, ruff, the docs style checker, an
    install of only what a real user receives, and an executed build of this documentation, so a

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -103,8 +103,8 @@ https://andrewendlinger.github.io/xmris/pr-preview/pr-123/
 That is your branch, built and **fully executed** — the same build the live site gets, not a lighter
 one. Plots are real plots, hidden asserts really ran. For anything reader-facing this is the review
 surface: prose, admonitions, mermaid diagrams and cell output only reveal what they actually look
-like once rendered. A [dev-diary](#contribute-dev-diary) draft is *reviewed* here before its
-implementation begins.
+like once rendered. A [dev-diary](#contribute-dev-diary) entry is reviewed here like any
+other page.
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%

--- a/docs/diary/2026-07-22-authoring-skills.md
+++ b/docs/diary/2026-07-22-authoring-skills.md
@@ -1,7 +1,7 @@
 (diary-authoring-skills)=
 # The skills remember the rules so you don't
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-21 · #103, #104, #114</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-21 · #103, #104, #114, #166</span>
 
 Every change to xmris has to clear the same stack of contracts at once. A new function, for
 example, has to honour

--- a/docs/diary/2026-07-22-authoring-skills.md
+++ b/docs/diary/2026-07-22-authoring-skills.md
@@ -1,7 +1,7 @@
 (diary-authoring-skills)=
 # The skills remember the rules so you don't
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-15 · #103, #104, #114</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-21 · #103, #104, #114</span>
 
 Every change to xmris has to clear the same stack of contracts at once. A new function, for
 example, has to honour
@@ -49,19 +49,18 @@ sits off this seam: `release`, the user-triggered **ship** step, routes to
 is why the group is **Workflows**, not just the authoring five.
 
 (diary-authoring-skills-diary)=
-## The diary is the workflow's review gate
+## The diary keeps the why
 
-The `dev-diary` skill is where this system meets how xmris is actually planned: docs first.
-Before any code, the approved plan is distilled into a one-screen draft entry, and the work
-**stops** until that draft has been read on the rendered site — a gate that can be rolled past in
-an auto-accepting session is no gate at all. One full cycle of using the skill taught three
-refinements, now law in it:
+The `dev-diary` skill is where this system meets how xmris is actually built. A significant repo
+or architectural decision — one where a defensible alternative lost — is offered a diary entry,
+and once the work has landed the decision is written up as a one-screen story, checked against
+the code as built. Cycles of using the skill taught three refinements, now law in it:
 
 - An entry is proposed for **decisions**, not categories — a new rule, decorator or namespace
   earns one; a vocabulary term that merely names what a new method did does not.
-- Reconciling means **rewriting the entry into how it is now and why**. The plan file does not
-  survive the merge, so the entry absorbs its rationale; a "what changed from the plan" section
-  appears only where the divergence itself teaches.
+- The entry is written **against the code, not from memory**. The plan file does not survive
+  the merge, so the entry absorbs its rationale; a "what changed from the plan" section appears
+  only where the divergence itself teaches.
 - **One entry per decision, rewritten in place as the decision evolves** — this very article
   absorbed its later turns rather than spawning sequels, and its *Last edited* line says the
   story is current.

--- a/docs/diary/2026-07-23-architecture-contract.md
+++ b/docs/diary/2026-07-23-architecture-contract.md
@@ -1,7 +1,7 @@
 (diary-architecture-contract)=
 # The Commandments now run against the code they govern
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-07-23 · #103</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-21 · #103, #166</span>
 
 The [architecture rules](#contract) are the standing law for everything under
 `src/xmris/` — and the law had quietly stopped describing the land. Commandment 3 bans descriptive
@@ -69,7 +69,7 @@ home everything was just pointed at, for the price of re-homing every rule anywa
 - **One Commandment 7 violation was left standing.** `build_fid`'s repetition coordinate still
   hand-builds its attrs dict: `COORDS` has no `repetition` term, and growing the vocabulary is a
   Commandment 4 event of its own — flagged as follow-up rather than smuggled in.
-- All four pass-1 assumptions held: `inspect.getsource` sees the decorators; the kernelspec'd page
+- All four assumptions marked in the draft held: `inspect.getsource` sees the decorators; the kernelspec'd page
   executes in the docs build while `test-gen` still walks exactly its 26 tutorial/explainer files;
   the pinned mystmd's anchor behavior is what the build showed; and the new `TestAccessorDefaults`
   row runs without importing pyAMARES.

--- a/docs/diary/index.md
+++ b/docs/diary/index.md
@@ -21,31 +21,22 @@ edited* line under each title tells you the story is current.
 (diary-about-how)=
 ## How an entry gets written
 
-The entries are a by-product of how xmris is actually built. A significant change usually starts as a planning session — nowadays often with e.g. Claude Code — that ends in a precise, ordered plan. That plan is exactly
-right for *doing* the work and sometimes not so good for *judging* it: twenty mechanical
-steps with the one real decision buried underneath them.
+The entries are a by-product of how xmris is actually built. A significant change usually starts
+as a planning session — nowadays often with e.g. Claude Code — that ends in a precise, ordered
+plan, reviewed in its own right (how, varies by contributor and tooling). That plan is exactly
+right for *doing* the work and not so good for *keeping*: twenty mechanical steps with the one
+real decision buried underneath them — and the plan file does not survive the merge.
 
-So before any code is written, the plan is distilled into a short **draft
-entry** — one screen: the tension, the decision, a diagram, and often a code snippet or two — a small user story sketching
-the call we wish existed. That draft is what gets reviewed — and the work stops
-until it has been.
-Writing it this early, forcing the argument onto a single page helps catching bad decision early.
-
-> It's almost like a docs-first approach.
-
-Then the work happens, and reality argues back. So once the change lands, the
-draft is **reconciled into the story you are reading**: corrections wherever
-the plan turned out wrong, the real file paths and code snippets dropped in so
-you can see how it works under the hood, and a straight account of why — having
-now built it — we think the call was right.
+So once the change lands, that decision is told here as a one-screen **story**: the tension, the
+decision, the real file paths and code snippets so you can see how it works under the hood —
+checked against the code as built, not drafted from the plan — and a straight account of why,
+having now built it, we think the call was right.
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart LR
-    P["Plan"] --> D["Draft the entry"]
-    D --> R["Review the shape"]
-    R --> B["Build it"]
-    B --> S["Reconcile into a story"]
+    P["Plan"] --> B["Build"]
+    B --> S["Tell the story"]
 ```
 
 :::{seealso}


### PR DESCRIPTION
## Why

Can a committed skill demand that all work stop for a diary draft — for every contributor who clones the repo? The dev-diary skill forced a two-pass workflow: a draft entry as the branch's first commit, then the turn ended and implementation waited for an explicit go. The plan-review role that gate served is covered by the planning tooling itself, and every contributor plans differently; a fresh contributor's first substantial PR should not be interrupted by a work pattern they never opted into.

## What changes

- **`.claude/skills/dev-diary/SKILL.md`** — the skill still fires on the same triggers (≥2 viable approaches, new conceptual surface, multi-PR chains) and still always asks first, but an accepted entry is now written **once, when the change has landed** — checked against the code as built, so it is born accurate (writing docs from the design is exactly what cost #90). The two-pass machinery, the assumptions-block lifecycle, and the end-the-turn gate are gone.
- **`templates/entry.md`** — assumptions seed and the second-pass section removed; the optional "What changed from the plan" closing kept.
- **`CLAUDE.md`** — the mandate becomes an offer.
- **Contributor mirrors** (`docs/contribute/dev_diary.md`, `index.md`, `pull_requests.md`, `docs/diary/index.md`) — no page still claims work stops for a draft; the literalinclude picks up the new checklist automatically.
- **`docs/diary/2026-07-22-authoring-skills.md`** — updated in place per the diary's own rewrite-in-place rule; its gate section now tells the current workflow ([The diary keeps the why](#diary-authoring-skills-diary)).
- **Gate-era wording sweep** — `check_docs.py`'s genre comment no longer calls the diary a review gate, and `docs/diary/2026-07-23-architecture-contract.md` drops the "pass-1" jargon no doc explains anymore (`Last edited` bumped on both touched entries).
- **`.gitignore`** — ignore `plans/`, the out-of-repo plan-doc working folders.

## Verification

- `check_docs.py`: 54 pages, 0 errors (16 pre-existing warnings on untouched files)
- `myst build --html` (strict, executed): exit 0
- `git grep` for gate language (`work stops`, `end the turn`, `pass 1/2`, `review gate`, `reconcile`, …) across CLAUDE.md, the skills, and docs: only historical/unrelated hits remain (roadmap-reconcile in publishing.md; the docs-previews entry's dropdown about PR previews being the review surface, which is still current)
- literalinclude excerpt markers intact in SKILL.md

https://claude.ai/code/session_01DbuVPoofxq4SYP4J11B7rP