### PR TITLE
ci: publish docs previews for fork pull requests, and select artifacts by provenance (#164)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,37 +5,38 @@ on:
     branches: [main]
   # Build (execute) the docs on PRs too, so a docs-breaking or kernel-hanging
   # dependency is caught pre-merge instead of only surfacing after landing on
-  # main -- and publish the result as a preview the reviewer can read. There is
-  # no `closed` action: a preview is not deleted, it simply stops being an input
-  # to the next deploy.
+  # main -- and hand the result to `publish.yml` as an artifact the reviewer can
+  # read as a website. There is no `closed` action here: a preview is not
+  # deleted, it simply stops being an input to the next deploy.
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-  # Weekly, off the PR path. Three jobs at once: external link rot is checked
-  # (a dead third-party URL is no reason to redden a PR that never touched it),
-  # main's artifact is refreshed so it can never expire, and the site is
-  # republished -- which sweeps the preview of any pull request closed while
-  # nothing else happened to deploy.
+  # Weekly, off the PR path: main's artifact is refreshed so it can never expire,
+  # and the deploy that chains off this run republishes the site -- which sweeps
+  # the preview of any pull request closed while nothing else happened to deploy.
+  # External link rot is checked separately, in links.yml.
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
 # Supersede a stale build for the same PR (each one is ~4 min, so racing two of
 # them wastes minutes and can publish the older site). Keyed per PR, falling
-# back to the ref, so a main deploy is never cancelled by PR activity.
+# back to the ref, so a main build is never cancelled by PR activity.
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Minimal default token; only `publish` elevates, and only far enough to deploy
-# the site and comment the preview link.
+# This workflow executes the notebooks of whatever branch it is given, forks
+# included, so it must never hold anything but a read-only token. Everything
+# privileged -- deploying the site, commenting the link -- lives in publish.yml,
+# which `workflow_run` runs from the default branch and out of a fork's reach.
 permissions:
   contents: read
 
 jobs:
   # Executes every notebook via `myst build --execute`, which is the check that
   # a docs dependency didn't break/hang the build, then hands the result to
-  # `publish` as an artifact. Nothing here writes to a branch: built output is
+  # publish.yml as an artifact. Nothing here writes to a branch: built output is
   # derived, never stored.
   build:
     runs-on: ubuntu-latest
@@ -73,16 +74,14 @@ jobs:
           uv run myst build --html --execute --strict
 
       - name: Upload the built site
-        # Fork PRs get a read-only token and never publish: their HTML would
-        # otherwise be served from our own origin on github.io. They still build
-        # above as a smoke test -- a contributor's first PR should not open with
-        # a red X it has no way to fix.
-        if: >-
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+        # Fork pull requests upload like any other. Note that a fork rewrites
+        # this file -- for a `pull_request` event GitHub runs the workflow from
+        # the merge commit -- so the name below is a hint, not a guarantee, and
+        # nothing here can be trusted downstream. publish.yml therefore selects
+        # artifacts by PROVENANCE (which repository and which commit produced
+        # them), never by name alone.
         uses: actions/upload-artifact@v7
         with:
-          # These two names are the contract with the publish job below.
           name: ${{ github.event_name == 'pull_request' && format('preview-pr-{0}', github.event.number) || 'site-main' }}
           path: docs/_build/html
           # Retention is the store now that git isn't. 90 days for the live
@@ -90,148 +89,3 @@ jobs:
           # preview, which is slack for a long-lived PR, not an archive.
           retention-days: ${{ github.event_name == 'pull_request' && 14 || 90 }}
           if-no-files-found: error
-
-  # Recomputes the published site from present state -- main's build plus one
-  # artifact per currently open pull request -- and deploys it whole. Because
-  # that is a pure function of what is open now, a closed PR's preview vanishes
-  # on the next deploy with no cleanup step to miss.
-  publish:
-    needs: build
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Deployments queue instead of racing. The per-PR group at the top of this
-    # file still cancels redundant BUILDS; only publishing is serialized, since
-    # two overlapping deploys can land the one assembled first.
-    concurrency:
-      group: pages-publish
-      cancel-in-progress: false
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      pages: write          # create the Pages deployment
-      id-token: write       # the OIDC token deploy-pages exchanges for it
-      actions: read         # list and download the build artifacts
-      contents: read
-      pull-requests: write  # the sticky preview comment
-    steps:
-      - name: Assemble the site from current state
-        env:
-          GH_TOKEN: ${{ github.token }}
-          # This job never checks the repository out -- it only moves artifacts
-          # around -- so `gh` has no git remote to infer the repository from and
-          # every subcommand but `gh api` dies with "not a git repository".
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # Newest non-expired artifact of a given name -> the run that produced
-          # it. `gh run download` wants a run id, and the artifacts API is the
-          # only place that mapping exists. Assembly uses nothing but `gh`: a
-          # third-party deploy action is one more dependency a JOSS reviewer
-          # cannot see the far side of.
-          newest_run() {
-            gh api "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$1&per_page=100" \
-              --jq '.artifacts | map(select(.expired | not)) | sort_by(.created_at)
-                    | reverse | .[0].workflow_run.id // empty'
-          }
-
-          main_run=$(newest_run site-main || true)
-          if [ -z "$main_run" ]; then
-            # Fail loud rather than rebuilding: a Pages deployment is atomic, so
-            # a failed publish leaves the previous site serving -- never an
-            # empty one -- and a silent rebuild would hide that the artifact
-            # chain broke.
-            echo "::error::No usable 'site-main' artifact. The live site is unchanged; recover with: gh workflow run deploy.yml"
-            exit 1
-          fi
-          mkdir -p _site
-          gh run download "$main_run" --name site-main --dir _site
-
-          # The previews are a pure function of what is open RIGHT NOW.
-          open_prs=$(gh pr list --state open --json number --jq '.[].number' || true)
-          for pr in $open_prs; do
-            preview_run=$(newest_run "preview-pr-$pr" || true)
-            if [ -z "$preview_run" ]; then
-              echo "PR #$pr: no preview artifact (fork, or its build is still running) -- skipped"
-              continue
-            fi
-            mkdir -p "_site/pr-preview/pr-$pr"
-            if ! gh run download "$preview_run" --name "preview-pr-$pr" \
-                 --dir "_site/pr-preview/pr-$pr"; then
-              echo "PR #$pr: preview download failed -- skipped"
-              rm -rf "_site/pr-preview/pr-$pr"
-            fi
-          done
-
-          # Log the payload every time, so "the deploy is getting heavy" is a
-          # series rather than a single sample. It scales with open PRs now:
-          # BASE_URL is baked in, so previews barely share bytes with the root.
-          {
-            echo "### Assembled site"
-            echo "- $(find _site -type f | wc -l | tr -d ' ') files, $(du -sh _site | cut -f1)"
-            echo "- previews: $(ls _site/pr-preview 2>/dev/null | tr '\n' ' ')"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload the Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
-
-      - name: Comment the preview link
-        # Sticky: one comment per PR, edited in place on every push. This is the
-        # one thing the retired pr-preview-action gave us for free.
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}  # no checkout here either
-          PR: ${{ github.event.number }}
-          SITE: ${{ steps.deployment.outputs.page_url }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          # Heredoc, not an inline multi-line string: YAML indentation would
-          # otherwise survive into the comment, where four leading spaces make
-          # Markdown render the paragraph as a code block.
-          body=$(cat <<EOF
-          📖 **Docs preview:** ${SITE%/}/pr-preview/pr-$PR/
-
-          Fully executed, from \`${SHA:0:7}\`. It leaves the site on the first deploy after this pull request closes — nothing to clean up.
-          EOF
-          )
-          gh pr comment "$PR" --edit-last --create-if-none --body "$body"
-
-  # Weekly (and on demand): the same build with external link checking. Kept out
-  # of `build` so it can never gate a PR, and skips --execute since links are
-  # read from the source, not from cell output.
-  links:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Check external links
-        # --strict is what makes this job able to fail: an unresolvable link is
-        # reported as an error ("Site has 1 error ... stopping build"), and myst
-        # exits 0 on errors without it.
-        run: |
-          uv run docs-api
-          cd docs
-          uv run myst build --html --check-links --strict

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,41 @@
+name: Link check
+
+# Weekly (and on demand): the docs build with external link checking, and
+# nothing else. It lives apart from `Documentation` because publishing chains
+# off that workflow's overall conclusion -- so a rotted third-party URL sharing
+# a run with the build would take the weekly republish, which is also the
+# preview sweep, down with it. A dead external link is no reason to stop
+# deploying, and no reason to redden a pull request that never touched it.
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check external links
+        # --strict is what makes this job able to fail: an unresolvable link is
+        # reported as an error ("Site has 1 error ... stopping build"), and myst
+        # exits 0 on errors without it. No --execute: links are read from the
+        # source, not from cell output.
+        run: |
+          uv run docs-api
+          cd docs
+          uv run myst build --html --check-links --strict

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,259 @@
+name: Publish docs site
+
+# The trusted half of the docs preview system. `Documentation` builds the site
+# on every pull request -- INCLUDING forks, whose notebooks it executes -- with
+# a read-only token and no secrets. This workflow does everything privileged:
+# assemble, deploy, comment.
+#
+# `workflow_run` is what makes that split safe. GitHub runs this file from the
+# DEFAULT BRANCH, in base-repository context, whatever branch or fork triggered
+# the build -- so a fork cannot reach the token that publishes the site by
+# editing a workflow, which is exactly what it CAN do to `deploy.yml`.
+on:
+  workflow_run:
+    workflows: [Documentation]
+    types: [completed]
+  # A closed pull request's preview stops being an input to the assembly, but
+  # only once something deploys -- otherwise it serves until the weekly run.
+  # Safe here despite the name: this workflow never checks anything out, so no
+  # fork code ever runs beside the write token.
+  pull_request_target:
+    types: [closed]
+  # Re-assemble and redeploy from existing artifacts, no 4-minute rebuild.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # A failed build has no artifact worth publishing, and the other two events
+    # carry no conclusion at all. The path check matters as much as the
+    # conclusion: a fork's merge commit may add its own workflow file, and one
+    # also called `Documentation` would otherwise fire this job on demand.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.path == '.github/workflows/deploy.yml')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Deployments queue instead of racing, since two overlapping deploys can land
+    # the one assembled first. Note that a PENDING run is cancelled when a newer
+    # one enters the group -- which is why the comment step below refreshes EVERY
+    # open preview rather than only the one that triggered this run.
+    concurrency:
+      group: pages-publish
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write          # create the Pages deployment
+      id-token: write       # the OIDC token deploy-pages exchanges for it
+      actions: read         # list and download the build artifacts
+      contents: read
+      pull-requests: write  # the sticky preview comments
+      statuses: write       # the "Docs preview" commit status
+    steps:
+      - name: Assemble the site from current state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # This job never checks the repository out -- it only moves artifacts
+          # around -- so `gh` has no git remote to infer the repository from and
+          # every subcommand but `gh api` dies with "not a git repository".
+          GH_REPO: ${{ github.repository }}
+          # Fork-influenced fields (head_branch, display_title, actor.login,
+          # commit messages) must NEVER be interpolated into a `run:` block: git
+          # permits `$`, backticks and parentheses in a branch name, and a fork
+          # names its own branch. Anything of that kind arrives through `env:`.
+          TRIGGER_PATH: ${{ github.event.workflow_run.path }}
+          EVENT: ${{ github.event_name }}
+          # A healthy preview is ~21 MB compressed / ~56 MB unpacked, and a build
+          # is ~1,550 files. Pages caps a published site at 1 GB and its deploy
+          # at ten minutes, and this site is the sum of every open pull request.
+          MAX_PREVIEW_MB: 150
+          MAX_TOTAL_MB: 800
+          MAX_FILES: 20000
+        run: |
+          set -euo pipefail
+
+          # Artifact NAMES are attacker-controlled. For a `pull_request` event
+          # GitHub runs the workflow file from the merge commit, which a fork
+          # writes -- so a fork can rename its own upload to `site-main` and, if
+          # we selected by name alone, take over the ROOT of the published site.
+          # Every lookup below therefore filters on PROVENANCE: which repository
+          # and which commit actually produced the artifact. Those fields come
+          # from the API, never from the artifact.
+          api_artifacts() {
+            gh api --paginate "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$1&per_page=100" \
+              --jq '.artifacts[] | select(.expired | not)'
+          }
+
+          # main's build: same repository AND branch main. The repository check is
+          # the load-bearing half, since a fork may call its own branch "main";
+          # the branch check excludes same-repo pull requests, which cannot.
+          main_run=$(api_artifacts site-main 2>/dev/null | jq -rs '
+            map(select(.workflow_run.head_repository_id == .workflow_run.repository_id
+                       and .workflow_run.head_branch == "main"))
+            | sort_by(.created_at) | reverse | .[0].workflow_run.id // empty' || true)
+
+          if [ -z "$main_run" ]; then
+            # Fail loud rather than rebuilding: a Pages deployment is atomic, so a
+            # failed publish leaves the previous site serving -- never an empty
+            # one -- and a silent rebuild would hide that the artifact chain broke.
+            echo "::error::No usable 'site-main' artifact. The live site is unchanged; recover with: gh workflow run deploy.yml"
+            exit 1
+          fi
+          mkdir -p _site
+          # Always --name. Downloading a whole run instead creates one directory
+          # per artifact name, and those names are attacker-controlled
+          # (CVE-2024-54132).
+          gh run download "$main_run" --name site-main --dir _site </dev/null
+
+          # The previews are a pure function of what is open RIGHT NOW. headRefOid
+          # pins each one to the commit its pull request actually points at.
+          gh pr list --state open --limit 200 --json number,headRefOid </dev/null \
+            | jq -r '.[] | [.number, .headRefOid] | @tsv' > open_prs.tsv
+
+          : > published.tsv
+          : > dropped.md
+
+          while IFS=$'\t' read -r pr head_sha; do
+            [ -n "$pr" ] || continue
+
+            # Provenance for a preview: the artifact's run head SHA must be this
+            # pull request's own head. A fork cannot satisfy that for someone
+            # else's pull request without its branch tip BEING that commit.
+            match=$(api_artifacts "preview-pr-$pr" 2>/dev/null | jq -rs --arg sha "$head_sha" '
+              map(select(.workflow_run.head_sha == $sha))
+              | sort_by(.created_at) | reverse | .[0]
+              | if . == null then empty else "\(.workflow_run.id)\t\(.size_in_bytes)" end' || true)
+
+            if [ -z "$match" ]; then
+              echo "PR #$pr: no preview artifact matching its head commit -- skipped"
+              continue
+            fi
+            preview_run=$(printf '%s' "$match" | cut -f1)
+            size_mb=$(( $(printf '%s' "$match" | cut -f2) / 1048576 ))
+
+            # Measured BEFORE the download: a zip bomb expanded first is a dead
+            # runner, not a skipped preview.
+            if [ "$size_mb" -gt "$MAX_PREVIEW_MB" ]; then
+              echo "::warning::PR #$pr: preview is ${size_mb} MB compressed, over the ${MAX_PREVIEW_MB} MB cap -- dropped"
+              echo "  - PR #$pr: over the ${MAX_PREVIEW_MB} MB per-preview cap (${size_mb} MB)" >> dropped.md
+              continue
+            fi
+
+            dir="_site/pr-preview/pr-$pr"
+            mkdir -p "$dir"
+            if ! gh run download "$preview_run" --name "preview-pr-$pr" --dir "$dir" </dev/null; then
+              echo "PR #$pr: preview download failed -- skipped"
+              rm -rf "$dir"
+              continue
+            fi
+
+            # A byte cap does not stop two million empty files, and the tar Pages
+            # builds from them would blow the ten-minute deployment timeout.
+            files=$(find "$dir" -type f | wc -l | tr -d ' ')
+            if [ "$files" -gt "$MAX_FILES" ]; then
+              echo "::warning::PR #$pr: preview has $files files, over the $MAX_FILES cap -- dropped"
+              echo "  - PR #$pr: over the $MAX_FILES file cap ($files files)" >> dropped.md
+              rm -rf "$dir"
+              continue
+            fi
+
+            printf '%s\t%s\t%s\n' "$pr" "$head_sha" "$(du -sm "$dir" | cut -f1)" >> published.tsv
+          done < open_prs.tsv
+
+          # Total budget: drop the largest previews until the site fits. site-main
+          # is never a candidate -- the root is not negotiable.
+          total_mb() { du -sm _site | cut -f1; }
+          while [ "$(total_mb)" -gt "$MAX_TOTAL_MB" ] && [ -s published.tsv ]; do
+            biggest=$(sort -t"$(printf '\t')" -k3 -n -r published.tsv | head -1)
+            pr=$(printf '%s' "$biggest" | cut -f1)
+            mb=$(printf '%s' "$biggest" | cut -f3)
+            echo "::warning::Site is $(total_mb) MB, over the ${MAX_TOTAL_MB} MB budget -- dropping PR #$pr's preview (${mb} MB)"
+            echo "  - PR #$pr: dropped to keep the site under ${MAX_TOTAL_MB} MB (${mb} MB)" >> dropped.md
+            rm -rf "_site/pr-preview/pr-$pr"
+            awk -F'\t' -v drop="$pr" '$1 != drop' published.tsv > published.tsv.new
+            mv published.tsv.new published.tsv
+          done
+
+          # Log the payload every time, so "the deploy is getting heavy" is a
+          # series rather than a single sample -- and so a drop is never silent.
+          {
+            echo "### Assembled site"
+            echo "- triggered by \`$EVENT\` (${TRIGGER_PATH:-n/a})"
+            echo "- $(find _site -type f | wc -l | tr -d ' ') files, $(total_mb) MB of a ${MAX_TOTAL_MB} MB budget"
+            echo "- previews: $(cut -f1 published.tsv | tr '\n' ' ')"
+            if [ -s dropped.md ]; then
+              echo "- **dropped:**"
+              cat dropped.md
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Comment the preview link on every published pull request
+        # Deliberately not "the pull request that triggered this run". A pending
+        # publish is cancelled when a newer one enters the concurrency group, so a
+        # per-trigger comment goes missing exactly when previews are busiest --
+        # which is the bug this workflow exists to fix. Refreshing every open
+        # preview instead is idempotent (`--edit-last` raises no notification) and
+        # self-healing: a cancelled run costs nothing, because the next one
+        # re-posts everything.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}  # no checkout here either
+          SITE: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          [ -s published.tsv ] || { echo "No previews published -- nothing to comment."; exit 0; }
+
+          while IFS=$'\t' read -r pr head_sha _; do
+            url="${SITE%/}/pr-preview/pr-$pr/"
+            # Heredoc, not an inline multi-line string: YAML indentation would
+            # otherwise survive into the comment, where four leading spaces make
+            # Markdown render the paragraph as a code block.
+            body=$(cat <<EOF
+          📖 **Docs preview:** $url
+
+          Fully executed, from \`${head_sha:0:7}\`. It leaves the site on the first deploy after this pull request closes — nothing to clean up.
+          EOF
+          )
+            gh pr comment "$pr" --edit-last --create-if-none --body "$body" </dev/null
+            # A workflow_run job does not appear in the pull request's check list.
+            # This status is how the link gets there -- it is not among the
+            # ruleset's required contexts, so it reports without gating.
+            gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+              -f state=success -f context='Docs preview' \
+              -f target_url="$url" -f description='Built and published' >/dev/null
+          done < published.tsv
+
+      - name: Report a failed publish on the pull requests it affects
+        # Without this a failure is invisible where it matters: `publish` is no
+        # longer a check on the pull request, and the failed-run notification goes
+        # to whoever triggered the build -- often an outside contributor who can
+        # do nothing about it.
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          [ -s open_prs.tsv ] || exit 0
+          while IFS=$'\t' read -r pr head_sha; do
+            [ -n "$head_sha" ] || continue
+            echo "PR #$pr: reporting the failed publish on ${head_sha:0:7}"
+            gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+              -f state=failure -f context='Docs preview' \
+              -f target_url="$RUN_URL" -f description='The publish workflow failed' >/dev/null || true
+          done < open_prs.tsv

--- a/docs/contribute/pull_requests.md
+++ b/docs/contribute/pull_requests.md
@@ -86,10 +86,11 @@ exercised nowhere else. That gap once shipped a release whose `import xmris` rai
 `ModuleNotFoundError` while all four other checks stayed green, so this job installs the way a user
 does and refuses to trust anything the dev environment happens to provide.
 
-Two further jobs report on the pull request without gating it. `publish` assembles and deploys the
-site — that is where your preview comes from — and `links` checks external URLs **weekly on a
-schedule** rather than on your branch, because a third-party URL rotting is not your fault and
-should not redden your pull request.
+Neither of the two remaining pieces gates anything, and neither is a job on this run. Publishing
+the site — where your preview comes from — is a **separate workflow** that starts when `build`
+succeeds, and reports back as a `Docs preview` status carrying the link. External links are checked
+**weekly on a schedule** rather than on your branch, because a third-party URL rotting is not your
+fault and should not redden your pull request.
 
 (contribute-pr-preview)=
 ## 4. Read your change on its own website
@@ -109,19 +110,26 @@ other page.
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart LR
-    P["Push to the PR"] --> B["Build: execute + strict"]
-    B --> U["Upload preview-pr-N"]
-    U --> A["Assemble: main + every open PR"]
-    A --> D["Deploy the whole site"]
-    D --> C["Bot comments the link"]
-    M["Merge or close"] --> X["Dropped from the next assembly"]
+    subgraph Y["Your branch · read-only token"]
+        P["Push to the PR"] --> B["Build: execute + strict"]
+        B --> U["Upload preview-pr-N"]
+    end
+    subgraph N["main's workflow · write token"]
+        A["Assemble: main + every open PR"] --> D["Deploy the whole site"]
+        D --> C["Comment the link"]
+    end
+    U -.-> A
+    M["Merge or close"] --> X["Absent from the deploy it triggers"]
 ```
 
-Two caveats. The link arrives a couple of minutes after the green `build` check, because the deploy
-runs after it — the comment is posted once the site is actually live, so the link never points at
-nothing. And a pull request from a **fork** gets no preview: its token is read-only by design, so
-the build still runs as a smoke test but cannot publish. That is not a failure — an external
-contributor's first pull request should not open with a red X they have no way to fix.
+Two caveats. The link arrives a couple of minutes after the green `build` check, because
+publishing is a second workflow that starts only once this one has finished — the comment is posted
+when the site is actually live, so the link never points at nothing. And if you are contributing
+**from a fork**, your first build waits for a maintainer to press *Approve*: GitHub does not run
+workflows from a new contributor unprompted, and this repository executes every notebook in your
+branch. Once approved you get the same preview, the same comment and the same status as anyone
+else — the dashed arrow above is the only place your branch and the published site meet, and only
+an artifact crosses it.
 
 (contribute-pr-green)=
 ## 5. Drive it green, then hand off
@@ -144,10 +152,19 @@ Cutting a release is a separate, maintainer-run workflow ([Publishing](#contribu
 Deployment is continuous and has nothing to do with releases, and the built site is never stored
 anywhere: each deploy reassembles it from scratch — `main`'s most recent build, plus one artifact
 per *currently open* pull request — and publishes that whole tree to GitHub Pages. Your preview is
-on the site because your pull request is open, and it leaves on the first deploy after it closes.
-Nothing removes it; it simply stops being an input. A weekly scheduled run performs the same
-assembly, which keeps `main`'s build fresh and sweeps the preview of a pull request that closed
-during a quiet week. ([The diary entry](#diary-docs-previews) tells why it works this way.)
+on the site because your pull request is open. Closing it triggers one more deploy, from which it
+is simply absent; nothing removes it, and there is no cleanup step to fail. A weekly scheduled run
+performs the same assembly, which keeps `main`'s build fresh.
+([The diary entry](#diary-docs-previews) tells why it works this way.)
+
+That assembly is a *second* workflow, and the split is the load-bearing part. `Documentation`
+builds your branch — executing every notebook in it — and holds nothing but a read-only token.
+`Publish docs site` picks up the artifact afterwards and does everything privileged. GitHub runs
+that second workflow from `main`'s copy of the file whatever branch triggered it, so the token that
+can write to the site is never in reach of the branch being tested. Which is also why the assembly
+picks artifacts by *provenance* — which repository and which commit produced them — rather than by
+name: on a pull request the workflow file itself comes from your branch, so the name it writes on
+an artifact is a hint, not a promise.
 
 The one subtlety worth internalising if you ever touch the workflow: mystmd bakes the site's base
 path into every asset link **at build time**, so a preview has to be built for the subdirectory it
@@ -160,11 +177,13 @@ will be served from. That is what this step does, quoted from the workflow itsel
 :caption: The build step — quoted from .github/workflows/deploy.yml at build time
 ```
 
-To rebuild and republish the site without merging anything — after a failed deploy, say — run the
-**Documentation** workflow manually from the Actions tab (`workflow_dispatch`). That is also the
-recovery when `publish` fails with `No usable 'site-main' artifact`: a Pages deployment is atomic,
-so the previous site keeps serving until a good one replaces it, and the failure is loud rather
-than destructive.
+Both workflows can be run by hand from the Actions tab (`workflow_dispatch`), and which one you
+want depends on what broke. **Publish docs site** re-assembles and redeploys from the artifacts
+that already exist — seconds, and the right lever when a deploy failed. **Documentation** rebuilds
+first and then chains into publishing, which is the slower recovery you need when the artifact
+itself is missing or stale — including the `No usable 'site-main' artifact` failure. Either way a
+Pages deployment is atomic, so the previous site keeps serving until a good one replaces it, and
+the failure is loud rather than destructive.
 
 ```{code-cell} python
 :tags: [remove-cell]
@@ -196,7 +215,7 @@ assert "uv run myst build --html --execute --strict" in text, "end-at anchor no 
 | `build` red, `Could not find DOI "…" from doi.org` | DOI metadata is resolved over the network unless it is frozen in `docs/myst.doi.bib` | `cd docs && uv run myst build --doi-bib`, then commit `myst.doi.bib` |
 | `build` red, `Site has N error(s), stopping build` | A cross-reference, directive or link mystmd could not resolve | Reproduce with the `build` command above; the error names the file and line |
 | `build` red only in CI, green locally | Stale `docs/_build` cache locally | `rm -rf docs/_build` and rebuild |
-| Preview link 404s | The `publish` job has not finished deploying yet, or the pull request is from a fork — forks never publish | Wait for `publish` to go green; for forks, ask a maintainer to read the branch locally |
+| Preview link 404s | The **Publish docs site** workflow has not finished deploying yet, or (on a fork) the build is still waiting for a maintainer to approve it | Wait for the `Docs preview` status to appear; check the Actions tab for a run needing approval |
 | Merge button blocked with everything green | The branch is out of date in a way GitHub cannot merge, or a check never reported | Check the merge box for which requirement is unmet; rebase only if there is a real conflict |
 
 :::{seealso}

--- a/docs/diary/2026-07-25-docs-previews.md
+++ b/docs/diary/2026-07-25-docs-previews.md
@@ -1,188 +1,146 @@
 (diary-docs-previews)=
 # Every pull request publishes the page it changes
 
-<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-10 · #112, #114, #142, #143, #144</span>
+<span style="color: gray; font-size: 0.9em;">Last edited: 2026-08-26 · #112, #114, #142, #143, #144, #171</span>
 
 A preview link was the one thing a pull request never handed you, and getting one turned out to be
-mostly a matter of not deleting a build CI already paid for: the reviewer's copy used to live two
-minutes on a runner and then vanish. Three weeks later the bill arrived. The branch carrying the
-site had reached 103 MB across 3,079 files, its history 674 MB of unique blobs that every clone
-paid for; GitHub's own build of that branch had crept from 28 s to 494 s and errored on three of
-its last ten runs; the live site was serving a layout two merges old; and the preview for a pull
-request merged four days earlier was still published. Four bugs, one cause — **the published site
-was versioned state**.
+mostly a matter of not deleting a build CI had already paid for. Two questions had to be answered
+before that was safe, and each was answered wrong the first time: **what the published site is made
+of**, and **who is allowed to write it**.
 
 :::{important}
-Built output is derived, never stored. Every deploy recomputes the whole site from `main`'s build
-plus one artifact per *currently open* pull request. `gh-pages` no longer exists.
+Built output is derived, never stored: every deploy recomputes the whole site from `main`'s build
+plus one artifact per *currently open* pull request. Who may publish it is decided in
+`publish.yml`, which GitHub runs from `main` whatever branch triggered it — never in the file the
+branch being tested can edit.
 :::
 
 (diary-docs-previews-derived)=
 ## Nothing to clean up, because nothing accumulates
 
-Write the published site as a function of what is open *right now* and the entire class of failures
-above stops being reachable:
+The first answer arrived as a bill: three weeks in, the branch carrying the site had reached 103 MB,
+its build had crept from 28 s to 494 s, the live site was serving a layout two merges old, and a
+preview whose pull request merged four days earlier was still published. Four bugs, one cause — the
+published site was **versioned state**. Write it instead as a function of what is open *right now*
+and that entire class of failure stops being reachable:
 
 ```{mermaid}
 %%{init: {'flowchart': {'htmlLabels': false}}}%%
 flowchart LR
-    E["Any deploy event"] --> Q["Ask GitHub what is open"]
-    Q --> M["main's build artifact"]
-    Q --> P["one artifact per open PR"]
-    M --> A["Assemble the site"]
-    P --> A
-    A --> D["Deploy it whole"]
+    subgraph B["The branch · read-only token"]
+        E["Build: execute + strict"] --> P["Upload preview-pr-N"]
+    end
+    subgraph M["main's workflow · write token"]
+        Q["Ask GitHub what is open"] --> A["Assemble: main's build<br>+ each open preview"]
+        A --> D["Deploy it whole"]
+    end
+    P -.->|"one artifact"| Q
 ```
 
-A closed pull request's preview is not removed; on the next deploy it is simply no longer an input.
-That one sentence covers the preview still live four days after its merge, the `.nojekyll` files
-stranded in closed pull requests' directories, and the branch that only ever grew — all three were
-incremental-cleanup bugs, and there is no increment left to clean.
+A closed pull request's preview is never removed; it simply stops being an input. That one sentence
+covers the stranded preview, the `.nojekyll` files orphaned in closed pull requests' directories,
+and the branch that only ever grew — all three were incremental-cleanup bugs, and there is no
+increment left to clean. The store is GitHub's artifact retention rather than git.
 
-It behaved exactly that way on the first day. `pr-preview/pr-139/`, published and stranded since a
-merge four days earlier, was simply absent from the first assembled deploy. `pr-preview/pr-143/`
-served for eleven minutes, its pull request merged, and the next unrelated deploy erased it. No
-cleanup step exists to have run.
+(diary-docs-previews-provenance)=
+## The name on an artifact is not a claim about who wrote it
 
-The store is GitHub's artifact retention rather than git: 90 days for `main`'s build, 14 for a
-preview, with the weekly link-check run extended to rebuild and republish. That keeps the live
-artifact under a week old and doubles as the sweep, bounding how long a closed pull request's
-preview can linger when nothing else happens to deploy. One build is a 21 MB zip — 1,548 files,
-56 MB unpacked — and assembly downloads it fresh every time.
+The second answer arrived as a contributor, and this page asserted the wrong one for a month. The
+first fork pull request (#164) got no preview, and the guard that arranged that was doing nothing of
+the sort. For a `pull_request` event GitHub runs the workflow file **from the merge commit** — for a
+fork, a commit the contributor controls. The guard lived in that file. So did the line naming the
+artifact. And assembly chose the site root by asking for the newest artifact called `site-main`.
+Each link is defensible alone; chained, they meant a fork could have published the **root** of the
+site, with nothing in the way but a run-approval prompt that stops appearing after a contributor's
+first merged pull request.
 
-:::{warning}
-Publishing runs on pull-request events, so a branch's workflow writes to the live deployment. That
-is not theoretical: the site was updated by pull request #143's own run, before #143 merged. It is
-safe only because the root always comes from `main`'s artifact, never from the branch being tested,
-so a broken branch can corrupt its own subdirectory and nothing else. The fork guard, meanwhile,
-stops being a token limitation and becomes a security boundary — a fork's HTML would otherwise be
-served from our origin on `github.io`. That one is still design rather than evidence; no fork pull
-request has arrived to exercise it.
-:::
+So the guard was deleted rather than fixed, and forks now publish like anyone else. What makes that
+safe is a rule that reads nothing the branch wrote — **provenance, not name**:
 
-(diary-docs-previews-baseurl)=
-## What survives the move, and what it costs
+| Admitted | Only when |
+|---|---|
+| `site-main` | its run's `head_repository_id` equals `repository_id`, and its branch is `main` |
+| `preview-pr-N` | its run's head SHA **is** pull request N's current head |
+| the trigger itself | the completed run was `.github/workflows/deploy.yml` |
 
-Two details of the build step are unchanged and still load-bearing. `BASE_URL` is baked into every
-asset path at build time, so a preview must be built for the subdirectory it will be served from;
-building for `/xmris` and serving from `/xmris/pr-preview/pr-N/` 404s every stylesheet. That is
-also why the site refuses to compress — only 183 of 1,269 files across two builds are
-byte-identical, so `plotly-5BWH43UK.js` at 4.77 MB is a fresh blob per preview.
-
-Deleting the branch stops that from *accumulating*; it does not shrink a single copy, and the
-assembled site now scales with the number of open pull requests instead. Per-copy weight is
-therefore the only thing left that grows a deploy — today ~12 MB of it is executed-notebook figure
-output, which the move to vector figures should largely dissolve.
-
-:::{dropdown} The `.nojekyll` trap, now historical
-A branch-served Pages site runs Jekyll, which silently drops every `_`-prefixed path — here
-`build/_assets`, `build/_shared` and `build/routes/_index-*`, which is all of the site's CSS and
-JS. Neither deploy action wrote a `.nojekyll`, so the build did — for the root only. Writing one
-into each preview directory looked harmless and was not: the removal deploys an *empty* folder, and
-the action adds `--exclude .nojekyll` to its delete-rsync whenever the source lacks one, so exactly
-that file outlived every closed pull request. A site served from a workflow artifact is published
-as-is, so both the file and its footgun are gone.
-:::
-
-(diary-docs-previews-layers)=
-## Three enforcement layers, and how the third one bit
-
-Docs rules have three enforcers, each because the one above it is blind to something:
-
-| Layer | Catches | Blind to |
-|---|---|---|
-| `check_docs.py` — the `Docs style` job | what the build never mentions: a missing target, a dead `.ipynb` link, a drifted kernel name | anything it has no rule for |
-| `myst build --strict` | what the build *reports* and then exits 0 on anyway | its own warnings — a missed `literalinclude` anchor still only warns |
-| the preview | whether the page actually reads right | nothing a human declines to look at |
-
-That middle row is narrower than it sounds: mystmd's `--strict` exits non-zero on **errors** only,
-never on warnings. So the quoted-source pins in [the Architecture Contract](#contract) stay
-load-bearing — a renamed decorator would still truncate a `literalinclude` with nothing but a
-warning to show for it.
-
-Turning that layer on had a consequence nobody predicted. The first strict build on CI went red on
-a *valid* DOI:
-
-```text
-⛔️ 03_plotting_1dfid.md:198 Could not find DOI "https://doi.org/10.1002/mrm.25568" from doi.org
-```
-
-mystmd resolves every `doi.org` link against the network at build time, so `--strict` had quietly
-made the documentation build — and the deploy behind it — depend on doi.org being reachable from a
-GitHub runner. The fix is to stop asking: `myst build --doi-bib` freezes that metadata into
-`docs/myst.doi.bib`, which only takes effect once *listed* in `myst.yml`'s `bibliography`, because
-declaring that key at all makes mystmd load only the files named there. A `check_docs.py` rule now
-errors on any `doi.org` link missing from the cache, so the next contributor to add one is told
-before CI is. The lesson generalises past DOIs: **a strict gate converts every latent network
-dependency in a build into a flaky failure**, and it fails on whichever pull request happens to be
-open at the time.
-
-(diary-docs-previews-gate)=
-## What the gate cost, and what it was worth
-
-A preview only helps if a red check can actually stop a merge, and none could: `main`'s ruleset
-contained a single `deletion` rule, so nothing — not the tests, not `Docs style` — was required. It
-now requires all four checks and a pull request, with zero approving reviews so a sole maintainer
-can still merge their own work.
-
-Requiring a pull request broke exactly one thing, and instructively: the release flow ended with
-`git merge release/vX.Y.Z` and `git push origin main`. Routing that through a pull request exposes a
-second problem, because this repository squash-merges — a tag cut on the release branch would sit
-on a commit that never enters `main`'s history. So the order flipped: bump, merge, *then* tag the
-merged commit ([Publishing](#release-tag-publish)). Publishing itself never moved; the `v*` tag
-still triggers the matrix and the PyPI job.
+Every field there comes from the API, never from the artifact. The middle row is what lets a fork
+publish at all: it cannot claim another pull request's directory without its branch tip *being* that
+commit, at which point it has claimed nothing.
 
 :::{warning}
-Changing where Pages gets its bytes is not self-starting, and the trap has now appeared twice in
-the same shape. Moving *onto* the branch: a branch-served site builds on the next push to that
-branch, and the last `gh-pages` push predated the flip, so the old artifact kept serving with
-`pages/builds/latest` returning 404 and no workflow run to look at —
-`gh api -X POST repos/OWNER/REPO/pages/builds` bootstraps it. Moving *off* it: the `github-pages`
-environment restricts which refs may deploy, so a pull request is rejected — `Branch
-"refs/pull/142/merge" is not allowed to deploy to github-pages` — before a byte moves. The rule that
-admits it must be spelled `refs/pull/*/merge`, and a plain `*` will not do: policies are matched
-against `GITHUB_REF` with `fnmatch` semantics, where a wildcard never crosses a `/`.
-:::
-
-:::{dropdown} Why not Cloudflare Pages or Netlify?
-Both hand out preview URLs with no workflow YAML at all. The price is a vendor account and an API
-token in the repository's secrets — for a package heading into JOSS review, one more dependency a
-reviewer cannot see the far side of. GitHub Pages already hosts the site; a preview should not add
-a second host. The same stance is why the assembly step uses nothing but `gh` and the two
-first-party Pages actions, rather than the third-party deploy actions it replaces.
-:::
-
-:::{dropdown} Why not just download the build artifact?
-That was the smallest possible change back when previews were added — delete one `if:` and the
-artifact survives. Artifacts are now the transport, but the conclusion is unchanged: a 52 MB zip
-you download, unpack and serve locally is not a link, and a review gate only works when reading the
-page is the path of least resistance.
+This buys containment, not innocence. A fork's preview is still contributor-written HTML served from
+`andrewendlinger.github.io`, an origin shared with every Pages site on the account — the trade every
+hosted preview service makes. It is bounded, not removed: a fork writes only under its own
+`pr-preview/pr-N/`, closing the pull request triggers the deploy that drops it, and the payload is
+capped per preview, by file count, and against Pages' 1 GB ceiling. GitHub's approval prompt is a
+**run** gate, not a review gate — it is granted before the content exists.
 :::
 
 (diary-docs-previews-changed)=
 ## What changed from the plan
 
-Three assumptions were wrong, and each cost a red run to discover:
-
-- **The `publish` job has no checkout, and that broke `gh`.** Moving artifacts needs no source, so
-  omitting `actions/checkout` looked like free economy. But `gh run download`, `gh pr list` and
-  `gh pr comment` all resolve the repository from a git remote, so the job died half a second in
-  with `failed to run git: fatal: not a git repository`. Only the `gh api` calls survived, because
-  they carry an explicit `repos/OWNER/REPO/...` path. `GH_REPO` in the step environment fixes it
-  and keeps the job checkout-free.
-- **Flipping the Pages source is housekeeping, not the switch.** The plan treated
-  `build_type=workflow` as the moment the site changes hands. It is not: an explicit workflow
-  deployment is served whatever the configured source says, so the assembled site — main's build,
-  previews and all — went live while the API still reported `build_type: legacy` and a `gh-pages`
-  source. The flip still matters, because a stray push to that branch would otherwise trigger a
-  legacy build over the top of it, and because the branch cannot be deleted while it is the
-  nominal source.
-- **The rejection came from the ref pattern, not the branch list.** See the warning above: a
-  wildcard cannot match a merge ref, which is not a fact any amount of local reasoning produces.
+- **This page called the fork guard a security boundary.** It was a token workaround wearing a
+  boundary's clothes, and it sat here unchallenged until the first fork pull request arrived to test
+  it. A guard that lives in a file the adversary edits is documentation, not enforcement.
+- **The publishing job has no checkout, and that broke `gh`.** Moving artifacts needs no source, so
+  omitting `actions/checkout` looked like free economy — but `gh run download`, `gh pr list` and
+  `gh pr comment` all resolve the repository from a git remote, and the job died half a second in
+  with `failed to run git: fatal: not a git repository`. Only `gh api` survived, because it carries
+  an explicit `repos/OWNER/REPO/...` path. `GH_REPO` in the step environment fixes it.
 
 What the plan got right is the part that mattered: the fail-loud path fired for real on the first
-pull request, before any `site-main` artifact existed, printing
-`No usable 'site-main' artifact. The live site is unchanged; recover with: gh workflow run
-deploy.yml` — and the previous site kept serving throughout, exactly as an atomic deployment
-should. `gh-pages` was deleted at tip `5ae31c42` once the assembled site was confirmed serving all
-72 routes.
+pull request, before any `site-main` artifact existed, printing `No usable 'site-main' artifact. The
+live site is unchanged; recover with: gh workflow run deploy.yml` — and the previous site kept
+serving throughout, exactly as an atomic deployment should.
+
+:::{dropdown} Why not `pull_request_target` for the build?
+It is the obvious way to hand a fork's build a write token, and the wrong one here: the build runs
+`myst build --execute`, which executes every notebook in the branch. `pull_request_target` would
+pair arbitrary contributor code with a token that can write to the repository. `workflow_run`
+inverts it — the untrusted half keeps a read-only token and passes an artifact across, and the
+privileged half never sees the branch at all.
+:::
+
+:::{dropdown} Why not Cloudflare Pages or Netlify?
+Both hand out preview URLs with no workflow YAML at all. The price is a vendor account and an API
+token in the repository's secrets — for a package heading into JOSS review, one more dependency a
+reviewer cannot see the far side of. GitHub Pages already hosts the site; a preview should not add a
+second host. The same stance is why assembly uses nothing but `gh`.
+:::
+
+:::{dropdown} Why not just download the build artifact?
+That was the smallest possible change back when previews were added — delete one `if:` and the
+artifact survives. Artifacts are now the transport, but the conclusion is unchanged: a 52 MB zip you
+download, unpack and serve locally is not a link, and a review gate only works when reading the page
+is the path of least resistance.
+:::
+
+:::{dropdown} How `--strict` broke the build on a valid DOI
+Docs rules have three enforcers, each because the one above it is blind to something:
+`check_docs.py` catches what the build never mentions (a missing target, a dead `.ipynb` link, a
+drifted kernel name); `myst build --strict` catches what the build reports and then exits 0 on
+anyway; the preview catches whether the page actually reads right. Turning the middle one on went
+red on a *valid* DOI — `Could not find DOI "https://doi.org/10.1002/mrm.25568" from doi.org` —
+because mystmd resolves every `doi.org` link over the network at build time. `myst build --doi-bib`
+freezes that metadata into `docs/myst.doi.bib`, which only takes effect once *listed* in
+`myst.yml`'s `bibliography`, since declaring that key makes mystmd load only the files named there.
+The lesson generalises past DOIs: **a strict gate converts every latent network dependency into a
+flaky failure**, on whichever pull request happens to be open at the time. Note `--strict` exits
+non-zero on **errors** only, never warnings — so the quoted-source pins in
+[the Architecture Contract](#contract) stay load-bearing.
+:::
+
+:::{dropdown} The `.nojekyll` trap, and the ref pattern, now historical
+A branch-served Pages site runs Jekyll, which silently drops every `_`-prefixed path — all of the
+site's CSS and JS. Neither deploy action wrote a `.nojekyll`, so the build did, for the root only.
+Writing one into each preview directory looked harmless and was not: the removal deploys an *empty*
+folder, and the action adds `--exclude .nojekyll` to its delete-rsync whenever the source lacks one,
+so exactly that file outlived every closed pull request. A site served from a workflow artifact is
+published as-is, so both the file and its footgun are gone.
+
+Separately, a pull request was once refused with `Branch "refs/pull/142/merge" is not allowed to
+deploy to github-pages`. The rule admitting it must be spelled `refs/pull/*/merge`, because policies
+are matched against `GITHUB_REF` with `fnmatch` semantics, where a wildcard never crosses a `/`.
+That entry is now removable: with publishing moved to `main`'s workflow, no deployment ever comes
+from a merge ref again.
+:::


### PR DESCRIPTION
#164 is our first outside pull request. Every required check went green and the contributor got no
preview and no comment — silently, because two `if:` guards in `deploy.yml` skip the artifact
upload and the whole `publish` job for a fork. The reason was real: a `pull_request` event from a
fork downgrades `GITHUB_TOKEN` to read-only whatever the `permissions:` block says, so `publish`
could only ever have gone red on a contributor's first pull request.

This splits the system in two along the trust boundary instead.

- **`Documentation`** builds the branch — executing its notebooks, forks included — and holds
  nothing but `contents: read`. The fork guard on the upload is gone; a fork's build now produces a
  `preview-pr-N` artifact like any other.
- **`Publish docs site`** is new, triggered by `workflow_run`, and does everything privileged:
  assemble, deploy, comment. GitHub runs a `workflow_run` workflow from the **default branch** in
  base-repository context, so the write token is never in reach of the branch being tested.

## It also closes a hole the old guard only appeared to cover

Worth reading before merging, because it is live on `main` today, not introduced here.

For a `pull_request` event GitHub runs the workflow file **from the merge commit**, which for a
fork is contributor-controlled. So the fork guard *and* the artifact name (`deploy.yml:86`) both
lived in a file a fork rewrites, while assembly selected artifacts by name alone (`newest_run()`,
`deploy.yml:136-140`). A fork pull request could therefore have published content as the **root**
of the site, not a subdirectory. The only thing in the way was the `first_time_contributors`
approval policy, which stops applying to a contributor after one merged pull request.

Assembly now filters on **provenance**, from the API rather than from the artifact:

- `site-main` must come from this repository (`head_repository_id == repository_id`) on `main`;
- a `preview-pr-N` must come from a run whose head SHA **is** that pull request's current head;
- the trigger must be `.github/workflows/deploy.yml`, so a fork cannot add a second workflow also
  named `Documentation` to fire the trusted job on demand.

The `deploy.yml` comment now says plainly that nothing in that file can be trusted downstream.

## Other changes

- **Comment and status go to every assembled preview**, not to the pull request that triggered the
  run. A *pending* publish is cancelled when a newer one enters the concurrency group, so a
  per-trigger comment would go missing exactly when previews are busiest. Refreshing all of them is
  idempotent (`--edit-last` raises no notification) and self-healing.
- **A `Docs preview` commit status** carries the link, since a `workflow_run` job does not appear
  in a pull request's check list. Posted on failure too — otherwise a broken publish is visible
  only in a run notification sent to whoever triggered the build, often an outside contributor who
  can do nothing about it. It is not among the ruleset's required contexts, so it reports without
  gating.
- **Closing a pull request now triggers a deploy** (`pull_request_target: [closed]`, no checkout),
  so its preview stops serving in seconds instead of lingering until the weekly run.
- **The payload is bounded.** Per-preview size is checked *before* download (a zip bomb expanded
  first is a dead runner), plus a file-count cap and a hard total budget against the 1 GB Pages
  ceiling — the assembled artifact already hit 106 MB compressed with three pull requests open.
  Every drop is logged to the step summary.
- **`links` moves to its own weekly workflow.** Publishing chains off the `Documentation` run's
  conclusion, so a rotted third-party URL sharing that run would have taken the weekly republish —
  which is also the preview sweep — down with it.

## Docs moved

`docs/contribute/pull_requests.md` §4 and *How the documentation reaches the web*: the flowchart
now shows the trust boundary, the "a fork gets no preview" caveat is replaced by what a fork
contributor actually sees, the recovery paragraph names both `workflow_dispatch` levers and which
one fits which failure, and the troubleshooting row is rewritten. The `literalinclude` of the build
step is unchanged and still resolves.

## Verified locally

`actionlint` clean across all four workflows; `bash -n` on every embedded script; the provenance
jq run against the live artifacts API (selects the right `site-main`, empty when the repository
check is inverted, matches #167's preview on its head SHA, no match for #164); the assemble script
dry-run end-to-end with stubbed downloads, including all three drop paths; the comment heredoc
rendered to confirm no leading whitespace. `check_docs.py` 0 errors; `myst build --html --strict`
exit 0.

**Cannot be verified before merge:** `workflow_run` listeners only run from the default branch.
The failure mode is benign — a Pages deployment is atomic and the assemble step fails loud, so a
broken publish leaves the previous site serving.

---

## After the merge (not part of this PR)

1. `gh workflow run deploy.yml` and confirm `Publish docs site` chains off it.
2. Close and reopen #164 — `reopened` is already a trigger and its merge commit is recomputed
   against the new `main`, so the contributor needs to do nothing.
3. **Actions → "Approve and run workflows from fork pull requests" → *Require approval for all
   outside collaborators*** (currently `first_time_contributors`). This is the gate that sits
   *before* a fork's notebooks execute on a runner — today ungated for anyone past their first
   merged pull request.
4. `github-pages` environment: remove `refs/pull/*/merge` from the branch policy once every open
   pull request has re-run. Publishing now only ever runs from `main`.


---

The diary entry [Every pull request publishes the page it changes](https://andrewendlinger.github.io/xmris/diary/2026-07-25-docs-previews)
is rewritten in this PR rather than given a sibling — the decision it owns has evolved, and it was
the page carrying the wrong claim about the fork guard.
